### PR TITLE
Automate the charts release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.DEFAULT_GOAL := all
+all: build
+
+.PHONY: build
+build:
+	build/make.sh
+
+.PHONY: lint
+lint:
+	build/lint.sh
+
+.PHONY: release
+release:
+	build/release.sh
+
+.PHONY: clean
+clean:
+	rm -r build/artifacts/

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,33 @@
+# Building, Testing and Releasing
+
+The scripts and docker images used for testing, building and deploying.
+
+Installing docker is a prerequisite. The instructions differ depending on the
+environment. Docker is comprised of two parts: the daemon server which runs on
+Linux and accepts commands, and the client which is a Go program capable of
+running on MacOS, all Unix variants and Windows.
+
+
+## Docker Installation
+
+Follow the [Docker install
+instructions](https://docs.docker.com/engine/installation/).
+
+
+## Available Images
+
+### Building
+
+The build image is a basic image containing Helm. To use it:
+
+```
+/.../helm-charts $ ./build/builder.sh helm package cockroachdb
+```
+
+
+## Upgrading / Extending the Builder Image
+
+- Edit `build/builder/Dockerfile` as desired
+- Run `build/builder.sh init` to test -- this will build the image locally. The result of `init` is a docker image version which you can subsequently stick into the `version` variable inside the `builder.sh` script for testing locally.
+- Once you are happy with the result, run `build/builder.sh push` which pushes your image towards Docker hub, so that it becomes available to others. The result is again a version number, which you then *must* copy back into `build/builder.sh`. Then commit the change to both Dockerfile and `build/builder.sh` and submit a PR.
+

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+image=cockroachdb/charts-builder
+version=20200702-210440
+
+function init() {
+  docker build --tag="${image}" "$(dirname "${0}")/builder"
+}
+
+if [ "${1-}" = "pull" ]; then
+  docker pull "${image}:${version}"
+  exit 0
+fi
+
+if [ "${1-}" = "init" ]; then
+  init
+  exit 0
+fi
+
+if [ "${1-}" = "push" ]; then
+  init
+  tag=$(date +%Y%m%d-%H%M%S)
+  docker tag "${image}" "${image}:${tag}"
+  docker push "${image}:${tag}"
+  echo "New image: ${image}:${tag}"
+  exit 0
+fi
+
+if [ "${1-}" = "version" ]; then
+  echo "${version}"
+  exit 0
+fi
+
+if [ -t 0 ]; then
+  tty=--tty
+fi
+
+# Absolute path to the toplevel helm-charts directory.
+helm_charts_toplevel=$(dirname "$(cd "$(dirname "${0}")"; pwd)")
+
+host_home=${helm_charts_toplevel}/build/builder_home
+mkdir -p "${host_home}"
+
+container_home=/charts/
+
+# Run our build container with a set of volumes mounted that will
+# allow the container to store persistent build data on the host
+# computer.
+vols="--volume=${helm_charts_toplevel}:${container_home}"
+
+# -i causes some commands (including `git diff`) to attempt to use
+# a pager, so we override $PAGER to disable.
+
+# shellcheck disable=SC2086
+docker run --init --privileged -i ${tty-} --rm \
+  ${vols} \
+  --workdir="${container_home}" \
+  --env="PAGER=cat" \
+  --env="TZ=America/New_York" \
+  "${image}:${version}" "$@"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -1,0 +1,15 @@
+FROM debian:10.4-slim
+
+RUN apt-get update && \
+        apt-get install --yes curl gnupg awscli
+
+# Install helm
+RUN curl https://helm.baltorepo.com/organization/signing.asc | apt-key add - && \
+        apt-get install apt-transport-https --yes && \
+        echo "deb https://baltocdn.com/helm/stable/debian/ all main" | tee /etc/apt/sources.list.d/helm-stable-debian.list && \
+        apt-get update && \
+        apt-get install --yes helm
+
+RUN mkdir -p /charts
+
+WORKDIR /charts/

--- a/build/make.sh
+++ b/build/make.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# Absolute path to the toplevel helm-charts directory.
+helm_charts_toplevel="$(dirname "$(cd "$(dirname "${0}")"; pwd)")/"
+relative_artifacts_dir="build/artifacts/"
+artifacts_dir="/charts/${relative_artifacts_dir}"
+builder="${helm_charts_toplevel}/build/builder.sh"
+charts_hostname="${CHARTS_HOSTNAME:-charts.cockroachdb.com}"
+
+mkdir -p "${helm_charts_toplevel}${relative_artifacts_dir}"
+
+# Grab the current index.yaml to merge into the new index.yaml.
+curl "https://s3.amazonaws.com/${charts_hostname}/index.yaml" > "${relative_artifacts_dir}/old-index.yaml"
+
+# Build the charts
+"${builder}" helm package cockroachdb --destination "${artifacts_dir}"
+"${builder}" helm repo index "${artifacts_dir}" --url "https://${charts_hostname}" --merge "${artifacts_dir}/old-index.yaml"

--- a/build/release.sh
+++ b/build/release.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+helm_charts_toplevel="$(dirname "$(cd "$(dirname "${0}")"; pwd)")/"
+builder="${helm_charts_toplevel}/build/builder.sh"
+charts_hostname="${CHARTS_HOSTNAME:-charts.cockroachdb.com}"
+
+if [ -n "${DISTRIBUTION_ID-}" ] ; then
+  distribution_id="${DISTRIBUTION_ID}"
+elif [ "${charts_hostname-}" = "charts.cockroachdb.com" ] ; then
+  distribution_id="E2PBFCZT8WAC7B"
+elif [ "${charts_hostname-}" = "charts-test.cockroachdb.com" ] ; then
+  distribution_id="E20WB6NQP118CN"
+fi
+
+# Push the new chart file and updated index.yaml file to S3
+"${builder}" env \
+    AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
+    AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+    aws s3 sync "build/artifacts/" "s3://${charts_hostname}" --exclude old-index.yaml
+
+# Invalidate any cached version of index.yaml (so this version is immediately available)
+if [ -n "${distribution_id}" ] ; then
+  "${builder}" env \
+    AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
+    AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+    aws cloudfront create-invalidation --distribution-id "${distribution_id}" --paths /index.yaml
+fi

--- a/build/teamcity-make-and-publish-charts-release.sh
+++ b/build/teamcity-make-and-publish-charts-release.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+remove_artifacts() {
+  make clean
+}
+trap remove_artifacts EXIT
+
+build/make.sh
+build/release.sh


### PR DESCRIPTION
Before: releasing was manual toil

Why: to make releasing repeatable, less error prone and easy

Now:

Adding files for building and publishing new charts. This supports the
"Make and Publish Charts Release" TeamCity build configuration.