### PR TITLE
Adding cluster-name to init job

### DIFF
--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 4.0.4
+version: 4.0.5
 appVersion: 20.1.3
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -106,6 +106,9 @@ spec:
               {{- else }}
               --insecure
               {{- end }}
+              {{- with index .Values.conf "cluster-name" }}
+              --cluster-name={{.}}
+              {{- end }}
               --host={{ template "cockroachdb.fullname" . }}-0.{{ template "cockroachdb.fullname" . -}}
                      :{{ .Values.service.ports.grpc.internal.port | int64 }}
               2>&1);


### PR DESCRIPTION
I found that without `--cluster-name` the init job would hang indefinitely if the cluster name was set in `values.yaml`.