### PR TITLE
Cert manager certificates

### DIFF
--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 5.0.0
+version: 5.1.0
 appVersion: 20.2.0
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -371,6 +371,10 @@ For details see the [`values.yaml`](values.yaml) file.
 | `tls.certs.clientRootSecret`                              | If certs are provided, secret name for client root cert         | `cockroachdb-root`                               |
 | `tls.certs.nodeSecret`                                    | If certs are provided, secret name for node cert                | `cockroachdb-node`                               |
 | `tls.certs.tlsSecret`                                     | Own certs are stored in TLS secret                              | `no`                                             |
+| `tls.certs.certManager`                                   | Provision certificates with cert-manager                        | `false`                                          |
+| `tls.certs.certManagerIssuer.group`                       | IssuerRef group to use when generating certificates             | `cert-manager.io`                                |
+| `tls.certs.certManagerIssuer.kind`                        | IssuerRef kind to use when generating certificates              | `Issuer`                                         |
+| `tls.certs.certManagerIssuer.name`                        | IssuerRef name to use when generating certificates              | `cockroachdb`                                    |
 | `tls.init.image.repository`                               | Image to use for requesting TLS certificates                    | `cockroachdb/cockroach-k8s-request-cert`         |
 | `tls.init.image.tag`                                      | Image tag to use for requesting TLS certificates                | `0.4`                                            |
 | `tls.init.image.pullPolicy`                               | Requesting TLS certificates container pull policy               | `IfNotPresent`                                   |

--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -54,40 +54,6 @@ Note that for a production cluster, you will likely want to override the followi
 For more information on overriding the `values.yaml` parameters, please see:
 > <https://www.cockroachlabs.com/docs/stable/orchestrate-cockroachdb-with-kubernetes.html#step-2-start-cockroachdb>
 
-If you are running in secure mode (with configuration parameter `tls.enabled` set to `yes`/`true`) and `tls.certs.provided` set to `no`/`false`), then you will have to manually approve the cluster's security certificates as the pods are created. You can see the pending CSRs (certificate signing requests) by running `kubectl get csr`, and approve them by running `kubectl certificate approve <csr-name>`. You'll have to approve one certificate for each CockroachDB node (e.g., `default.node.my-release-cockroachdb-0` and one client certificate for the job that initializes the cluster (e.g., `default.node.root`).
-
-When `tls.certs.provided` is set to `yes`/`true`, this chart will use certificates created outside of Kubernetes. You may want to use this if you want to use a different certificate authority from the one being used by Kubernetes or if your Kubernetes cluster doesn't fully support certificate-signing requests. To use this, first set up your certificates and load them into your Kubernetes cluster as Secrets using the commands below:
-
-```
-mkdir certs
-mkdir my-safe-directory
-cockroach cert create-ca --certs-dir=certs --ca-key=my-safe-directory/ca.key
-cockroach cert create-client root --certs-dir=certs --ca-key=my-safe-directory/ca.key
-kubectl create secret generic cockroachdb-root --from-file=certs
-cockroach cert create-node --certs-dir=certs --ca-key=my-safe-directory/ca.key localhost 127.0.0.1 eerie-horse-cockroachdb-public eerie-horse-cockroachdb-public.default eerie-horse-cockroachdb-public.default.svc.cluster.local *.eerie-horse-cockroachdb *.eerie-horse-cockroachdb.default *.eerie-horse-cockroachdb.default.svc.cluster.local
-kubectl create secret generic cockroachdb-node --from-file=certs
-```
-
-Set `tls.certs.tlsSecret` to `yes/true` if you make use of [cert-manager][3] in your cluster.
-
-[cert-manager][3] stores generated certificates in dedicated TLS secrets. Thus, they are always named:
-
-* `ca.crt`
-* `tls.crt`
-* `tls.key`
-
-On the other hand, CockroachDB also demands dedicated certificate filenames:
-
-* `ca.crt`
-* `node.crt`
-* `node.key`
-* `client.root.crt`
-* `client.root.key`
-
-By activating `tls.certs.tlsSecret` we benefit from projected secrets and convert the TLS secret filenames to their according CockroachDB filenames.
-
-If you are running in secure mode, then you will have to manually approve the cluster's security certificates as the pods are created. You can see the pending CSRs (certificate signing requests) by running `kubectl get csr`, and approve them by running `kubectl certificate approve <csr-name>`. You'll have to approve one certificate for each CockroachDB node (e.g., `default.node.my-release-cockroachdb-0` and one client certificate for the job that initializes the cluster (e.g., `default.node.root`).
-
 Confirm that all pods are `Running` successfully and init has been completed:
 
 ```shell
@@ -113,6 +79,86 @@ NAME                                       CAPACITY   ACCESS MODES   RECLAIM POL
 pvc-64878ebf-f3f0-11e8-ab5b-42010a8e0035   100Gi      RWO            Delete           Bound     default/datadir-my-release-cockroachdb-0   standard                 51s
 pvc-64945b4f-f3f0-11e8-ab5b-42010a8e0035   100Gi      RWO            Delete           Bound     default/datadir-my-release-cockroachdb-1   standard                 51s
 pvc-649d920d-f3f0-11e8-ab5b-42010a8e0035   100Gi      RWO            Delete           Bound     default/datadir-my-release-cockroachdb-2   standard                 51s
+```
+
+### Running in secure mode
+
+In order to setup a secure cockroachdb cluster set `tls.enabled` to `yes`/`true`
+
+There are 3 ways to configure a secure cluster, with this chart. This all relates to how the certificates are issued:
+
+* Built-in CSR's in kubernetes (default)
+* Cert-manager
+* Manual
+
+#### Built-in
+
+This is the default behaviour, and requires no configuration beyond enabling tls.
+
+If you are running in this mode, you will have to manually approve the cluster's security certificates as the pods are created. You can see the pending CSRs (certificate signing requests) by running `kubectl get csr`, and approve them by running `kubectl certificate approve <csr-name>`. You'll have to approve one certificate for each CockroachDB node (e.g., `default.node.my-release-cockroachdb-0` and one client certificate for the job that initializes the cluster (e.g., `default.node.root`).
+
+#### Manual
+
+If you wish to supply the certificates to the nodes yourself set `tls.certs.provided` to `yes`/`true`. You may want to use this if you want to use a different certificate authority from the one being used by Kubernetes or if your Kubernetes cluster doesn't fully support certificate-signing requests. To use this, first set up your certificates and load them into your Kubernetes cluster as Secrets using the commands below:
+
+```shell
+$ mkdir certs
+$ mkdir my-safe-directory
+$ cockroach cert create-ca --certs-dir=certs --ca-key=my-safe-directory/ca.key
+$ cockroach cert create-client root --certs-dir=certs --ca-key=my-safe-directory/ca.key
+$ kubectl create secret generic cockroachdb-root --from-file=certs
+secret/cockroachdb-root created
+$ cockroach cert create-node --certs-dir=certs --ca-key=my-safe-directory/ca.key localhost 127.0.0.1 my-release-cockroachdb-public my-release-cockroachdb-public.my-namespace my-release-cockroachdb-public.my-namespace.svc.cluster.local *.my-release-cockroachdb *.my-release-cockroachdb.my-namespace *.my-release-cockroachdb.my-namespace.svc.cluster.local
+$ kubectl create secret generic cockroachdb-node --from-file=certs
+secret/cockroachdb-node created
+```
+
+> Note: The subject alternative names are based on a release called `my-release` in the `my-namespace` namespace. Make sure they match the services created with the release during `helm install`
+
+If your certificates are stored in tls secrets such as secrets generated by cert-manager, the secret will contain files named:
+
+* `ca.crt`
+* `tls.crt`
+* `tls.key`
+
+Cockroachdb, however, expects the files to be named like this:
+
+* `ca.crt`
+* `node.crt`
+* `node.key`
+* `client.root.crt`
+* `client.root.key`
+
+By enabling `tls.certs.tlsSecret` the tls secrets are projected on to the correct filenames, when they are mounted to the cockroachdb pods.
+
+#### Cert-manager
+
+If you wish to supply certificates with [cert-manager][3], set
+
+* `tls.certs.certManager` to `yes`/`true`
+* `tls.certs.certManagerIssuer` to an IssuerRef (as they appear in certificate resources) pointing to a clusterIssuer or issuer, you have set up in the cluster
+
+Example issuer:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cockroachdb-ca
+  namespace: cockroachdb
+data:
+  tls.crt: [BASE64 Encoded ca.crt]
+  tls.key: [BASE64 Encoded ca.key]
+type: kubernetes.io/tls
+---
+apiVersion: cert-manager.io/v1alpha3
+kind: Issuer
+metadata:
+  name: cockroachdb-cert-issuer
+  namespace: cockroachdb
+spec:
+  ca:
+    secretName: cockroachdb-ca
 ```
 
 ## Upgrading the cluster

--- a/cockroachdb/templates/certificate.client.yaml
+++ b/cockroachdb/templates/certificate.client.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.tls.enabled .Values.tls.certs.certManager }}
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: {{ template "cockroachdb.fullname" . }}-root-client
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    helm.sh/chart: {{ template "cockroachdb.chart" . }}
+    app.kubernetes.io/name: {{ template "cockroachdb.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  duration: 672h
+  renewBefore: 48h
+  usages:
+    - digital signature
+    - key encipherment
+    - client auth
+  keySize: 2048
+  keyAlgorithm: rsa
+  commonName: root
+  organization:
+    - Cockroach
+  secretName: {{ .Values.tls.certs.clientRootSecret }}
+  issuerRef: {{- toYaml .Values.tls.certs.certManagerIssuer | nindent 4 }}
+{{- end }}

--- a/cockroachdb/templates/certificate.node.yaml
+++ b/cockroachdb/templates/certificate.node.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.tls.enabled .Values.tls.certs.certManager }}
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: {{ template "cockroachdb.fullname" . }}-node
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    helm.sh/chart: {{ template "cockroachdb.chart" . }}
+    app.kubernetes.io/name: {{ template "cockroachdb.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  duration: 8760h
+  renewBefore: 168h
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth
+  keySize: 2048
+  keyAlgorithm: rsa
+  commonName: node
+  organization:
+    - Cockroach
+  dnsNames:
+    - "localhost"
+    - "127.0.0.1"
+    - {{ printf "%s-public" (include "cockroachdb.fullname" .) | quote }}
+    - {{ printf "%s-public.%s" (include "cockroachdb.fullname" .) .Release.Namespace | quote }}
+    - {{ printf "%s-public.%s.svc.%s" (include "cockroachdb.fullname" .) .Release.Namespace .Values.clusterDomain | quote }}
+    - {{ printf "*.%s" (include "cockroachdb.fullname" .) | quote }}
+    - {{ printf "*.%s.%s" (include "cockroachdb.fullname" .) .Release.Namespace | quote }}
+    - {{ printf "*.%s.%s.svc.%s" (include "cockroachdb.fullname" .) .Release.Namespace .Values.clusterDomain | quote }}
+  secretName: {{ .Values.tls.certs.nodeSecret }}
+  issuerRef: {{- toYaml .Values.tls.certs.certManagerIssuer | nindent 4 }}
+{{- end }}

--- a/cockroachdb/templates/clusterrole.yaml
+++ b/cockroachdb/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.tls.enabled (not .Values.tls.certs.provided) }}
+{{- if and .Values.tls.enabled (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager) }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/cockroachdb/templates/clusterrolebinding.yaml
+++ b/cockroachdb/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.tls.enabled (not .Values.tls.certs.provided) }}
+{{- if and .Values.tls.enabled (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager) }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -30,16 +30,16 @@ spec:
     spec:
       restartPolicy: OnFailure
       terminationGracePeriodSeconds: 0
-    {{- if or .Values.image.credentials (and .Values.tls.enabled .Values.tls.init.image.credentials (not .Values.tls.certs.provided)) }}
+    {{- if or .Values.image.credentials (and .Values.tls.enabled .Values.tls.init.image.credentials (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager)) }}
       imagePullSecrets:
       {{- if .Values.image.credentials }}
         - name: {{ template "cockroachdb.fullname" . }}.db.registry
       {{- end }}
-      {{- if and .Values.tls.enabled .Values.tls.init.image.credentials (not .Values.tls.certs.provided) }}
+      {{- if and .Values.tls.enabled .Values.tls.init.image.credentials (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager) }}
         - name: {{ template "cockroachdb.fullname" . }}.init-certs.registry
       {{- end }}
     {{- end }}
-    {{- if and .Values.tls.enabled (not .Values.tls.certs.provided)}}
+    {{- if and .Values.tls.enabled (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager) }}
       serviceAccountName: {{ template "cockroachdb.tls.serviceAccount.name" . }}
       initContainers:
         # The init-certs container sends a CSR (certificate signing request) to
@@ -129,8 +129,8 @@ spec:
     {{- if .Values.tls.enabled }}
       volumes:
         - name: client-certs
-          {{- if .Values.tls.certs.provided }}
-          {{- if .Values.tls.certs.tlsSecret }}
+          {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager }}
+          {{- if or .Values.tls.certs.tlsSecret .Values.tls.certs.certManager }}
           projected:
             sources:
             - secret:

--- a/cockroachdb/templates/role.yaml
+++ b/cockroachdb/templates/role.yaml
@@ -15,7 +15,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    {{- if .Values.tls.certs.provided }}
+    {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager }}
     verbs: ["get"]
     {{- else }}
     verbs: ["create", "get"]

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -41,18 +41,18 @@ spec:
       annotations: {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
-    {{- if or .Values.image.credentials (and .Values.tls.enabled .Values.tls.init.image.credentials (not .Values.tls.certs.provided)) }}
+    {{- if or .Values.image.credentials (and .Values.tls.enabled .Values.tls.init.image.credentials (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager)) }}
       imagePullSecrets:
       {{- if .Values.image.credentials }}
         - name: {{ template "cockroachdb.fullname" . }}.db.registry
       {{- end }}
-      {{- if and .Values.tls.enabled .Values.tls.init.image.credentials (not .Values.tls.certs.provided) }}
+      {{- if and .Values.tls.enabled .Values.tls.init.image.credentials (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager) }}
         - name: {{ template "cockroachdb.fullname" . }}.init-certs.registry
       {{- end }}
     {{- end }}
     {{- if .Values.tls.enabled }}
       serviceAccountName: {{ template "cockroachdb.tls.serviceAccount.name" . }}
-      {{- if not .Values.tls.certs.provided }}
+      {{- if and (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager) }}
       initContainers:
         # The init-certs container sends a CSR (certificate signing request) to
         # the Kubernetes cluster.
@@ -292,8 +292,8 @@ spec:
         {{- end }}
       {{- if .Values.tls.enabled }}
         - name: certs
-          {{- if .Values.tls.certs.provided }}
-          {{- if .Values.tls.certs.tlsSecret }}
+          {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager }}
+          {{- if or .Values.tls.certs.tlsSecret .Values.tls.certs.certManager }}
           projected:
             sources:
             - secret:

--- a/cockroachdb/templates/tests/client.yaml
+++ b/cockroachdb/templates/tests/client.yaml
@@ -15,10 +15,10 @@ spec:
   imagePullSecrets:
     - name: {{ template "cockroachdb.fullname" . }}.db.registry
 {{- end }}
-  {{- if .Values.tls.certs.provided }}
+  {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager }}
   volumes:
     - name: client-certs
-      {{- if .Values.tls.certs.tlsSecret }}
+      {{- if or .Values.tls.certs.tlsSecret .Values.tls.certs.certManager }}
       projected:
         sources:
         - secret:
@@ -43,7 +43,7 @@ spec:
     - name: client-test
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
       imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-      {{- if .Values.tls.certs.provided }}
+      {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager }}
       volumeMounts:
       - name: client-certs
         mountPath: /cockroach-certs
@@ -51,7 +51,7 @@ spec:
       command:
         - /cockroach/cockroach
         - sql
-        {{- if .Values.tls.certs.provided }}
+        {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager }}
         - --certs-dir
         - /cockroach-certs
         {{- else }}

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -361,6 +361,15 @@ tls:
     # Enable if the secret is a dedicated TLS.
     # TLS secrets are created by cert-mananger, for example.
     tlsSecret: false
+    # Use cert-manager to issue certificates for mTLS.
+    certManager: false
+    # Specify an Issuer or a ClusterIssuer to use, when issuing
+    # node and client certificates. The values correspond to the
+    # issuerRef specified in the certificate.
+    certManagerIssuer:
+      group: cert-manager.io
+      kind: Issuer
+      name: cockroachdb
 
   init:
     # Image to use for requesting TLS certificates.


### PR DESCRIPTION
Originally https://github.com/helm/charts/pull/22902

#### What this PR does / why we need it:

- Add cert-manager certificate resources to the helm chart, to avoid users having to manually match subject alternative names in certificate resources
- Update documentation on setting up secure clusters

#### Special notes for your reviewer:

- The implementation of this is made with maximum backwards compatibility in mind. I've tested that the new templates render to the same result as the old ones, when using the same values. The right thing to do here, seems to be to rework the template a bit, but it'll break backwards compatibility, and require a major version bump.
- The implementation only covers the certificates, but it could be easily expanded to include the certificate authority and the issuer, with inspiration from https://github.com/helm/charts/pull/22838 

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
