### PR TITLE
Apply the same env of statefulset in job.init

### DIFF
--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -118,6 +118,10 @@ spec:
               [[ "$initOUT" == *"cluster has already been initialized"* ]] && exit 0;
               sleep 5;
               done
+          env:
+          {{- with .Values.statefulset.env }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- if .Values.tls.enabled }}
           volumeMounts:
             - name: client-certs


### PR DESCRIPTION
I needed to apply this COCKROACH_SKIP_KEY_PERMISSION_CHECK environment variable to both yaml.