### PR TITLE
expose topologyKey of pod anti-affinity rules as a variable

### DIFF
--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 4.1.11
+version: 4.1.12
 appVersion: 20.1.8
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -272,6 +272,7 @@ For details see the [`values.yaml`](values.yaml) file.
 | `statefulset.nodeAffinity`               | [Node affinity rules][2] of StatefulSet Pods                    | `{}`                                             |
 | `statefulset.podAffinity`                | [Inter-Pod affinity rules][1] of StatefulSet Pods               | `{}`                                             |
 | `statefulset.podAntiAffinity`            | [Anti-affinity rules][1] of StatefulSet Pods                    | auto                                             |
+| `statefulset.podAntiAffinity.topologyKey`| The topologyKey for auto [anti-affinity rules][1]               | `kubernetes.io/hostname`                         |
 | `statefulset.podAntiAffinity.type`       | Type of auto [anti-affinity rules][1]                           | `soft`                                           |
 | `statefulset.podAntiAffinity.weight`     | Weight for `soft` auto [anti-affinity rules][1]                 | `100`                                            |
 | `statefulset.nodeSelector`               | Node labels for StatefulSet Pods assignment                     | `{}`                                             |

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -102,7 +102,7 @@ spec:
         {{- if .Values.statefulset.podAntiAffinity.type }}
         {{- if eq .Values.statefulset.podAntiAffinity.type "hard" }}
           requiredDuringSchedulingIgnoredDuringExecution:
-            - topologyKey: kubernetes.io/hostname
+            - topologyKey: {{ .Values.statefulset.podAntiAffinity.topologyKey }}
               labelSelector:
                 matchLabels:
                   app.kubernetes.io/name: {{ template "cockroachdb.name" . }}
@@ -114,7 +114,7 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: {{ .Values.statefulset.podAntiAffinity.weight | int64 }}
               podAffinityTerm:
-                topologyKey: kubernetes.io/hostname
+                topologyKey: {{ .Values.statefulset.podAntiAffinity.topologyKey }}
                 labelSelector:
                   matchLabels:
                     app.kubernetes.io/name: {{ template "cockroachdb.name" . }}

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -176,6 +176,9 @@ statefulset:
   # You may either toggle options below for default anti-affinity rules,
   # or specify the whole set of anti-affinity rules instead of them.
   podAntiAffinity:
+    # The topologyKey to be used.
+    # Can be used to spread across different nodes, AZs, regions etc.
+    topologyKey: kubernetes.io/hostname
     # Type of anti-affinity rules: either `soft`, `hard` or empty value (which
     # disables anti-affinity rules).
     type: soft


### PR DESCRIPTION
very useful for small clusters, where number of replicas <= number of AZs