### PR TITLE
Fix #24

### DIFF
--- a/cockroachdb/templates/networkpolicy.yaml
+++ b/cockroachdb/templates/networkpolicy.yaml
@@ -23,10 +23,9 @@ spec:
   ingress:
     - ports:
         - port: grpc
-    {{- with .Values.networkPolicy.ingress.grpc }}
       from:
         # Allow connections via custom rules.
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.networkPolicy.ingress.grpc | nindent 8 }}
         # Allow client connection via pre-considered label.
         - podSelector:
             matchLabels:
@@ -49,7 +48,6 @@ spec:
               {{- toYaml . | nindent 14 }}
             {{- end }}
       {{- end }}
-    {{- end }}
     # Allow connections to admin UI and for Prometheus.
     - ports:
         - port: http


### PR DESCRIPTION
The use of `{{- with ... }}` seems useless here, and it breaks everything else. I think(?) it doesn't cause an issue in the default configuration because `.Values.networkPolicy.ingress.grpc` is an empty array (and I guess that means it doesn't actually switch into that scope?).

Would be nice™ to add a test too (I made this PR from the GitHub web app).