### PR TITLE
Add support for Pod Topology Spread Constraints

### DIFF
--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 4.1.12
+version: 4.1.13
 appVersion: 20.1.8
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -240,94 +240,99 @@ Note that there are some backward-incompatible changes to SQL features between v
 The following table lists the configurable parameters of the CockroachDB chart and their default values.
 For details see the [`values.yaml`](values.yaml) file.
 
-| Parameter                                | Description                                                     | Default                                          |
-| ---------                                | -----------                                                     | -------                                          |
-| `clusterDomain`                          | Cluster's default DNS domain                                    | `cluster.local`                                  |
-| `conf.attrs`                             | CockroachDB node attributes                                     | `[]`                                             |
-| `conf.cache`                             | Size of CockroachDB's in-memory cache                           | `25%`                                            |
-| `conf.cluster-name`                      | Name of CockroachDB cluster                                     | `""`                                             |
-| `conf.disable-cluster-name-verification` | Disable CockroachDB cluster name verification                   | `no`                                             |
-| `conf.join`                              | List of already-existing CockroachDB instances                  | `[]`                                             |
-| `conf.max-disk-temp-storage`             | Max storage capacity for temp data                              | `nil`                                              |
-| `conf.max-offset`                        | Max allowed clock offset for CockroachDB cluster                | `nil`                                          |
-| `conf.max-sql-memory`                    | Max memory to use processing SQL querie                         | `25%`                                            |
-| `conf.locality`                          | Locality attribute for this deployment                          | `""`                                             |
-| `conf.single-node`                       | Disable CockroachDB clustering (standalone mode)                | `no`                                             |
-| `conf.sql-audit-dir`                     | Directory for SQL audit log                                     | `""`                                             |
-| `conf.port`                              | CockroachDB primary serving port in Pods                        | `26257`                                          |
-| `conf.http-port`                         | CockroachDB HTTP port in Pods                                   | `8080`                                           |
-| `image.repository`                       | Container image name                                            | `cockroachdb/cockroach`                          |
-| `image.tag`                              | Container image tag                                             | `v20.1.8`                                        |
-| `image.pullPolicy`                       | Container pull policy                                           | `IfNotPresent`                                   |
-| `image.credentials`                      | `registry`, `user` and `pass` credentials to pull private image | `{}`                                             |
-| `statefulset.replicas`                   | StatefulSet replicas number                                     | `3`                                              |
-| `statefulset.updateStrategy`             | Update strategy for StatefulSet Pods                            | `{"type": "RollingUpdate"}`                      |
-| `statefulset.podManagementPolicy`        | `OrderedReady`/`Parallel` Pods creation/deletion order          | `Parallel`                                       |
-| `statefulset.budget.maxUnavailable`      | k8s PodDisruptionBudget parameter                               | `1`                                              |
-| `statefulset.args`                       | Extra command-line arguments                                    | `[]`                                             |
-| `statefulset.env`                        | Extra env vars                                                  | `[]`                                             |
-| `statefulset.secretMounts`               | Additional Secrets to mount at cluster members                  | `[]`                                             |
-| `statefulset.labels`                     | Additional labels of StatefulSet and its Pods                   | `{"app.kubernetes.io/component": "cockroachdb"}` |
-| `statefulset.annotations`                | Additional annotations of StatefulSet Pods                      | `{}`                                             |
-| `statefulset.nodeAffinity`               | [Node affinity rules][2] of StatefulSet Pods                    | `{}`                                             |
-| `statefulset.podAffinity`                | [Inter-Pod affinity rules][1] of StatefulSet Pods               | `{}`                                             |
-| `statefulset.podAntiAffinity`            | [Anti-affinity rules][1] of StatefulSet Pods                    | auto                                             |
-| `statefulset.podAntiAffinity.topologyKey`| The topologyKey for auto [anti-affinity rules][1]               | `kubernetes.io/hostname`                         |
-| `statefulset.podAntiAffinity.type`       | Type of auto [anti-affinity rules][1]                           | `soft`                                           |
-| `statefulset.podAntiAffinity.weight`     | Weight for `soft` auto [anti-affinity rules][1]                 | `100`                                            |
-| `statefulset.nodeSelector`               | Node labels for StatefulSet Pods assignment                     | `{}`                                             |
-| `statefulset.priorityClassName`          | [PriorityClassName][4] for StatefulSet Pods                     | `""`                                             |
-| `statefulset.tolerations`                | Node taints to tolerate by StatefulSet Pods                     | `[]`                                             |
-| `statefulset.resources`                  | Resource requests and limits for StatefulSet Pods               | `{}`                                             |
-| `service.ports.grpc.external.port`       | CockroachDB primary serving port in Services                    | `26257`                                          |
-| `service.ports.grpc.external.name`       | CockroachDB primary serving port name in Services               | `grpc`                                           |
-| `service.ports.grpc.internal.port`       | CockroachDB inter-communication port in Services                | `26257`                                          |
-| `service.ports.grpc.internal.name`       | CockroachDB inter-communication port name in Services           | `grpc-internal`                                  |
-| `service.ports.http.port`                | CockroachDB HTTP port in Services                               | `8080`                                           |
-| `service.ports.http.name`                | CockroachDB HTTP port name in Services                          | `http`                                           |
-| `service.public.type`                    | Public Service type                                             | `ClusterIP`                                      |
-| `service.public.labels`                  | Additional labels of public Service                             | `{"app.kubernetes.io/component": "cockroachdb"}` |
-| `service.public.annotations`             | Additional annotations of public Service                        | `{}`                                             |
-| `service.discovery.labels`               | Additional labels of discovery Service                          | `{"app.kubernetes.io/component": "cockroachdb"}` |
-| `service.discovery.annotations`          | Additional annotations of discovery Service                     | `{}`                                             |
-| `ingress.enabled`                        | Enable ingress resource for CockroachDB                     | `false`                                             |
-| `ingress.labels`                         | Additional labels of Ingress                     | `{}`                                             |
-| `ingress.annotations`                    | Additional annotations of Ingress                     | `{}`                                             |
-| `ingress.paths`                          | Paths for the default host                     | `[/]`                                             |
-| `ingress.hosts`                          | CockroachDB Ingress hostnames                     | `[]`                                             |
-| `ingress.tls[0].hosts`                   | CockroachDB Ingress tls hostnames                     | `nil`                                             |
-| `ingress.tls[0].secretName`              | CockroachDB Ingress tls secret name                     | `nil`                                             |
-| `serviceMonitor.enabled`                 | Create [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/design.md#servicemonitor) Resource for scraping metrics using [PrometheusOperator](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/getting-started.md#prometheus-operator)                     | `false`                                             |
-| `serviceMonitor.labels`                  | Additional labels of ServiceMonitor                     | `{}`                                             |
-| `serviceMonitor.annotations`             | Additional annotations of ServiceMonitor                     | `{}`                                             |
-| `serviceMonitor.interval`                | ServiceMonitor scrape metrics interval                     | `10s`                                             |
-| `serviceMonitor.scrapeTimeout`           | ServiceMonitor scrape timeout                     | `nil`                                             |
-| `storage.hostPath`                       | Absolute path on host to store data                             | `""`                                             |
-| `storage.persistentVolume.enabled`       | Whether to use PersistentVolume to store data                   | `yes`                                            |
-| `storage.persistentVolume.size`          | PersistentVolume size                                           | `100Gi`                                          |
-| `storage.persistentVolume.storageClass`  | PersistentVolume class                                          | `""`                                             |
-| `storage.persistentVolume.labels`        | Additional labels of PersistentVolumeClaim                      | `{}`                                             |
-| `storage.persistentVolume.annotations`   | Additional annotations of PersistentVolumeClaim                 | `{}`                                             |
-| `init.labels`                            | Additional labels of init Job and its Pod                       | `{"app.kubernetes.io/component": "init"}`        |
-| `init.annotations`                       | Additional labels of the Pod of init Job                        | `{}`                                             |
-| `init.affinity`                          | [Affinity rules][2] of init Job Pod                             | `{}`                                             |
-| `init.nodeSelector`                      | Node labels for init Job Pod assignment                         | `{}`                                             |
-| `init.tolerations`                       | Node taints to tolerate by init Job Pod                         | `[]`                                             |
-| `init.resources`                         | Resource requests and limits for the Pod of init Job            | `{}`                                             |
-| `tls.enabled`                            | Whether to run securely using TLS certificates                  | `no`                                             |
-| `tls.serviceAccount.create`              | Whether to create a new RBAC service account                    | `yes`                                            |
-| `tls.serviceAccount.name`                | Name of RBAC service account to use                             | `""`                                             |
-| `tls.certs.provided`                     | Bring your own certs scenario, i.e certificates are provided    | `no`                                             |
-| `tls.certs.clientRootSecret`             | If certs are provided, secret name for client root cert         | `cockroachdb-root`                               |
-| `tls.certs.nodeSecret`                   | If certs are provided, secret name for node cert                | `cockroachdb-node`                               |
-| `tls.certs.tlsSecret`                    | Own certs are stored in TLS secret                              | `no`                                             |
-| `tls.init.image.repository`              | Image to use for requesting TLS certificates                    | `cockroachdb/cockroach-k8s-request-cert`         |
-| `tls.init.image.tag`                     | Image tag to use for requesting TLS certificates                | `0.4`                                            |
-| `tls.init.image.pullPolicy`              | Requesting TLS certificates container pull policy               | `IfNotPresent`                                   |
-| `tls.init.image.credentials`             | `registry`, `user` and `pass` credentials to pull private image | `{}`                                             |
-| `networkPolicy.enabled`                  | Enable NetworkPolicy for CockroachDB's Pods                     | `no`                                             |
-| `networkPolicy.ingress.grpc`             | Whitelist resources to access gRPC port of CockroachDB's Pods   | `[]`                                             |
-| `networkPolicy.ingress.http`             | Whitelist resources to access gRPC port of CockroachDB's Pods   | `[]`                                             |
+| Parameter                                                 | Description                                                     | Default                                          |
+| ---------                                                 | -----------                                                     | -------                                          |
+| `clusterDomain`                                           | Cluster's default DNS domain                                    | `cluster.local`                                  |
+| `conf.attrs`                                              | CockroachDB node attributes                                     | `[]`                                             |
+| `conf.cache`                                              | Size of CockroachDB's in-memory cache                           | `25%`                                            |
+| `conf.cluster-name`                                       | Name of CockroachDB cluster                                     | `""`                                             |
+| `conf.disable-cluster-name-verification`                  | Disable CockroachDB cluster name verification                   | `no`                                             |
+| `conf.join`                                               | List of already-existing CockroachDB instances                  | `[]`                                             |
+| `conf.max-disk-temp-storage`                              | Max storage capacity for temp data                              | `0`                                              |
+| `conf.max-offset`                                         | Max allowed clock offset for CockroachDB cluster                | `500ms`                                          |
+| `conf.max-sql-memory`                                     | Max memory to use processing SQL querie                         | `25%`                                            |
+| `conf.locality`                                           | Locality attribute for this deployment                          | `""`                                             |
+| `conf.single-node`                                        | Disable CockroachDB clustering (standalone mode)                | `no`                                             |
+| `conf.sql-audit-dir`                                      | Directory for SQL audit log                                     | `""`                                             |
+| `conf.port`                                               | CockroachDB primary serving port in Pods                        | `26257`                                          |
+| `conf.http-port`                                          | CockroachDB HTTP port in Pods                                   | `8080`                                           |
+| `image.repository`                                        | Container image name                                            | `cockroachdb/cockroach`                          |
+| `image.tag`                                               | Container image tag                                             | `v20.1.6`                                        |
+| `image.pullPolicy`                                        | Container pull policy                                           | `IfNotPresent`                                   |
+| `image.credentials`                                       | `registry`, `user` and `pass` credentials to pull private image | `{}`                                             |
+| `statefulset.replicas`                                    | StatefulSet replicas number                                     | `3`                                              |
+| `statefulset.updateStrategy`                              | Update strategy for StatefulSet Pods                            | `{"type": "RollingUpdate"}`                      |
+| `statefulset.podManagementPolicy`                         | `OrderedReady`/`Parallel` Pods creation/deletion order          | `Parallel`                                       |
+| `statefulset.budget.maxUnavailable`                       | k8s PodDisruptionBudget parameter                               | `1`                                              |
+| `statefulset.args`                                        | Extra command-line arguments                                    | `[]`                                             |
+| `statefulset.env`                                         | Extra env vars                                                  | `[]`                                             |
+| `statefulset.secretMounts`                                | Additional Secrets to mount at cluster members                  | `[]`                                             |
+| `statefulset.labels`                                      | Additional labels of StatefulSet and its Pods                   | `{"app.kubernetes.io/component": "cockroachdb"}` |
+| `statefulset.annotations`                                 | Additional annotations of StatefulSet Pods                      | `{}`                                             |
+| `statefulset.nodeAffinity`                                | [Node affinity rules][2] of StatefulSet Pods                    | `{}`                                             |
+| `statefulset.podAffinity`                                 | [Inter-Pod affinity rules][1] of StatefulSet Pods               | `{}`                                             |
+| `statefulset.podAntiAffinity`                             | [Anti-affinity rules][1] of StatefulSet Pods                    | auto                                             |
+| `statefulset.podAntiAffinity.topologyKey`                 | The topologyKey for auto [anti-affinity rules][1]               | `kubernetes.io/hostname`                         |
+| `statefulset.podAntiAffinity.type`                        | Type of auto [anti-affinity rules][1]                           | `soft`                                           |
+| `statefulset.podAntiAffinity.weight`                      | Weight for `soft` auto [anti-affinity rules][1]                 | `100`                                            |
+| `statefulset.nodeSelector`                                | Node labels for StatefulSet Pods assignment                     | `{}`                                             |
+| `statefulset.priorityClassName`                           | [PriorityClassName][4] for StatefulSet Pods                     | `""`                                             |
+| `statefulset.tolerations`                                 | Node taints to tolerate by StatefulSet Pods                     | `[]`                                             |
+| `statefulset.topologySpreadConstraints`                   | [Topology Spread Constraints rules][5] of StatefulSet Pods      | auto                                             |
+| `statefulset.topologySpreadConstraints.maxSkew`           | Degree to which Pods may be unevenly distributed                | `1`                                              |
+| `statefulset.topologySpreadConstraints.topologyKey`       | The key of node labels                                          | `topology.kubernetes.io/zone`                    |
+| `statefulset.topologySpreadConstraints.whenUnsatisfiable` | `ScheduleAnyway`/`DoNotSchedule` for unsatisfiable constraints  | `ScheduleAnyway`                                 |
+| `statefulset.resources`                                   | Resource requests and limits for StatefulSet Pods               | `{}`                                             |
+| `service.ports.grpc.external.port`                        | CockroachDB primary serving port in Services                    | `26257`                                          |
+| `service.ports.grpc.external.name`                        | CockroachDB primary serving port name in Services               | `grpc`                                           |
+| `service.ports.grpc.internal.port`                        | CockroachDB inter-communication port in Services                | `26257`                                          |
+| `service.ports.grpc.internal.name`                        | CockroachDB inter-communication port name in Services           | `grpc-internal`                                  |
+| `service.ports.http.port`                                 | CockroachDB HTTP port in Services                               | `8080`                                           |
+| `service.ports.http.name`                                 | CockroachDB HTTP port name in Services                          | `http`                                           |
+| `service.public.type`                                     | Public Service type                                             | `ClusterIP`                                      |
+| `service.public.labels`                                   | Additional labels of public Service                             | `{"app.kubernetes.io/component": "cockroachdb"}` |
+| `service.public.annotations`                              | Additional annotations of public Service                        | `{}`                                             |
+| `service.discovery.labels`                                | Additional labels of discovery Service                          | `{"app.kubernetes.io/component": "cockroachdb"}` |
+| `service.discovery.annotations`                           | Additional annotations of discovery Service                     | `{}`                                             |
+| `ingress.enabled`                                         | Enable ingress resource for CockroachDB                         | `false`                                          |
+| `ingress.labels`                                          | Additional labels of Ingress                                    | `{}`                                             |
+| `ingress.annotations`                                     | Additional annotations of Ingress                               | `{}`                                             |
+| `ingress.paths`                                           | Paths for the default host                                      | `[/]`                                            |
+| `ingress.hosts`                                           | CockroachDB Ingress hostnames                                   | `[]`                                             |
+| `ingress.tls[0].hosts`                                    | CockroachDB Ingress tls hostnames                               | `nil`                                            |
+| `ingress.tls[0].secretName`                               | CockroachDB Ingress tls secret name                             | `nil`                                            |
+| `serviceMonitor.enabled`                                  | Create [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/design.md#servicemonitor) Resource for scraping metrics using [PrometheusOperator](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/getting-started.md#prometheus-operator)                     | `false`                                             |
+| `serviceMonitor.labels`                                   | Additional labels of ServiceMonitor                             | `{}`                                             |
+| `serviceMonitor.annotations`                              | Additional annotations of ServiceMonitor                        | `{}`                                             |
+| `serviceMonitor.interval`                                 | ServiceMonitor scrape metrics interval                          | `10s`                                            |
+| `serviceMonitor.scrapeTimeout`                            | ServiceMonitor scrape timeout                                   | `nil`                                            |
+| `storage.hostPath`                                        | Absolute path on host to store data                             | `""`                                             |
+| `storage.persistentVolume.enabled`                        | Whether to use PersistentVolume to store data                   | `yes`                                            |
+| `storage.persistentVolume.size`                           | PersistentVolume size                                           | `100Gi`                                          |
+| `storage.persistentVolume.storageClass`                   | PersistentVolume class                                          | `""`                                             |
+| `storage.persistentVolume.labels`                         | Additional labels of PersistentVolumeClaim                      | `{}`                                             |
+| `storage.persistentVolume.annotations`                    | Additional annotations of PersistentVolumeClaim                 | `{}`                                             |
+| `init.labels`                                             | Additional labels of init Job and its Pod                       | `{"app.kubernetes.io/component": "init"}`        |
+| `init.annotations`                                        | Additional labels of the Pod of init Job                        | `{}`                                             |
+| `init.affinity`                                           | [Affinity rules][2] of init Job Pod                             | `{}`                                             |
+| `init.nodeSelector`                                       | Node labels for init Job Pod assignment                         | `{}`                                             |
+| `init.tolerations`                                        | Node taints to tolerate by init Job Pod                         | `[]`                                             |
+| `init.resources`                                          | Resource requests and limits for the Pod of init Job            | `{}`                                             |
+| `tls.enabled`                                             | Whether to run securely using TLS certificates                  | `no`                                             |
+| `tls.serviceAccount.create`                               | Whether to create a new RBAC service account                    | `yes`                                            |
+| `tls.serviceAccount.name`                                 | Name of RBAC service account to use                             | `""`                                             |
+| `tls.certs.provided`                                      | Bring your own certs scenario, i.e certificates are provided    | `no`                                             |
+| `tls.certs.clientRootSecret`                              | If certs are provided, secret name for client root cert         | `cockroachdb-root`                               |
+| `tls.certs.nodeSecret`                                    | If certs are provided, secret name for node cert                | `cockroachdb-node`                               |
+| `tls.certs.tlsSecret`                                     | Own certs are stored in TLS secret                              | `no`                                             |
+| `tls.init.image.repository`                               | Image to use for requesting TLS certificates                    | `cockroachdb/cockroach-k8s-request-cert`         |
+| `tls.init.image.tag`                                      | Image tag to use for requesting TLS certificates                | `0.4`                                            |
+| `tls.init.image.pullPolicy`                               | Requesting TLS certificates container pull policy               | `IfNotPresent`                                   |
+| `tls.init.image.credentials`                              | `registry`, `user` and `pass` credentials to pull private image | `{}`                                             |
+| `networkPolicy.enabled`                                   | Enable NetworkPolicy for CockroachDB's Pods                     | `no`                                             |
+| `networkPolicy.ingress.grpc`                              | Whitelist resources to access gRPC port of CockroachDB's Pods   | `[]`                                             |
+| `networkPolicy.ingress.http`                              | Whitelist resources to access gRPC port of CockroachDB's Pods   | `[]`                                             |
+
 
 Override the default parameters using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -488,3 +493,4 @@ Note, that if you are running in secure mode (`tls.enabled` is `yes`/`true`) and
 [2]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity
 [3]: https://cert-manager.io/
 [4]: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+[5]: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -128,6 +128,21 @@ spec:
         {{- end }}
       {{- end }}
     {{- end }}
+    {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: {{ template "cockroachdb.name" . }}
+            app.kubernetes.io/instance: {{ .Release.Name | quote }}
+          {{- with .Values.statefulset.labels }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.statefulset.topologySpreadConstraints }}
+        maxSkew: {{ .maxSkew }}
+        topologyKey: {{ .topologyKey }}
+        whenUnsatisfiable: {{ .whenUnsatisfiable }}
+      {{- end }}
+    {{- end }}
     {{- with .Values.statefulset.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -198,6 +198,11 @@ statefulset:
   # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
 
+  # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  topologySpreadConstraints:
+    maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
 
   # Uncomment the following resources definitions or pass them from
   # command line to control the CPU and memory resources allocated


### PR DESCRIPTION
We'd love having this for increased resiliency when losing an AZ, for both small or large CRDB clusters