### PR TITLE
don't specify max-disk-temp-storage and max-offset by default

### DIFF
--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 4.1.9
+version: 4.1.10
 appVersion: 20.1.7
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -248,8 +248,8 @@ For details see the [`values.yaml`](values.yaml) file.
 | `conf.cluster-name`                      | Name of CockroachDB cluster                                     | `""`                                             |
 | `conf.disable-cluster-name-verification` | Disable CockroachDB cluster name verification                   | `no`                                             |
 | `conf.join`                              | List of already-existing CockroachDB instances                  | `[]`                                             |
-| `conf.max-disk-temp-storage`             | Max storage capacity for temp data                              | `0`                                              |
-| `conf.max-offset`                        | Max allowed clock offset for CockroachDB cluster                | `500ms`                                          |
+| `conf.max-disk-temp-storage`             | Max storage capacity for temp data                              | `nil`                                              |
+| `conf.max-offset`                        | Max allowed clock offset for CockroachDB cluster                | `nil`                                          |
 | `conf.max-sql-memory`                    | Max memory to use processing SQL querie                         | `25%`                                            |
 | `conf.locality`                          | Locality attribute for this deployment                          | `""`                                             |
 | `conf.single-node`                       | Disable CockroachDB clustering (standalone mode)                | `no`                                             |

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -197,8 +197,12 @@ spec:
               --http-port={{ index .Values.conf `http-port` | int64 }}
               --port={{ .Values.conf.port | int64 }}
               --cache={{ .Values.conf.cache }}
-              --max-disk-temp-storage={{ index .Values.conf `max-disk-temp-storage` }}
-              --max-offset={{ index .Values.conf `max-offset` }}
+            {{- with index .Values.conf `max-disk-temp-storage` }}
+              --max-disk-temp-storage={{ . }}
+            {{- end }}
+            {{- with index .Values.conf `max-offset` }}
+              --max-offset={{ . }}
+            {{- end }}
               --max-sql-memory={{ index .Values.conf `max-sql-memory` }}
             {{- with .Values.conf.locality }}
               --locality={{ . }}

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -78,7 +78,7 @@ conf:
   # temporary "disk" data is also kept in-memory.
   # A percentage value is interpreted as a percentage of the available internal
   # memory.
-  max-disk-temp-storage: 0
+  # max-disk-temp-storage: 0GB
 
   # Maximum allowed clock offset for the cluster. If observed clock offsets
   # exceed this limit, servers will crash to minimize the likelihood of
@@ -88,7 +88,7 @@ conf:
   # Note, that this value must be the same on all nodes in the cluster.
   # In order to change it, all nodes in the cluster must be stopped
   # simultaneously and restarted with the new value.
-  max-offset: 500ms
+  # max-offset: 500ms
 
   # Maximum memory capacity available to store temporary data for SQL clients,
   # including prepared queries and intermediate data rows during query


### PR DESCRIPTION
When starting CockroachDB with `cockroach start(-single-node)`, we should not
be specifying the `max-disk-temp-storage` or `max-offset` flags unless the
user is intentionally overriding these values.

This actuallly resulted in some undesirable behaviour - our Helm chart was
setting the `max-disk-temp-storage` to zero bytes by default, which is not
the intended default value in CockroachDB. Previously, CockroachDB errroneously
reported zero bytes as the default value, but
[that has been fixed upstream](github.com/cockroachdb/cockroach/pull/54853).