### PR TITLE
Fixes cockroachdb/helm-charts#34

### DIFF
--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -72,6 +72,9 @@ spec:
           volumeMounts:
             - name: client-certs
               mountPath: /cockroach-certs/
+        {{- with .Values.init.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+        {{- end }}
     {{- end }}
     {{- with .Values.init.affinity }}
       affinity: {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Re-using the same chart logic that was used for the other init containers on the cluster-init job's init container in order to fix #34. I tested this on a 1.18 cluster with  resource quotas in place and it resolved the issue.