### PR TITLE
chore(prometheus): Avoid tls problems related to pod IP.

### DIFF
--- a/cockroachdb/templates/serviceMonitor.yaml
+++ b/cockroachdb/templates/serviceMonitor.yaml
@@ -1,5 +1,6 @@
 {{- $serviceMonitor := .Values.serviceMonitor -}}
 {{- $ports := .Values.service.ports -}}
+{{- $tlsEnabled := .Values.tls.enabled -}}
 {{- if $serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -42,5 +43,9 @@ spec:
     {{- end }}
     {{- if $serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ $serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    {{- if $tlsEnabled }}
+    tlsConfig:
+      insecureSkipVerify: true
     {{- end }}
 {{- end }}


### PR DESCRIPTION
When using secure installations, and your own certificates, Prometheus will fail the scrapping because the pod IP was not in the original CSR.

The error on Prometheus looks like this:
```
Get https://10.6.26.160:8080/_status/vars: x509: certificate is valid for 127.0.0.1, not 10.6.26.160
```

This PR disabled the TLS verification, similar to what you need to do when setting other third parties integrations like Datadog's

Signed-off-by: Sergio Morales <sergio@cornershopapp.com>