### PR TITLE
Revert "Adding Artifact Hub repository metadata file"

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,6 +1,0 @@
-# Artifact Hub repository metadata file
-# Template here: https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-repo.yml
-repositoryID: 512b17d4-7376-4d95-9f9c-8d24ba964cab
-owners:
-  - name: cockroachlabs
-    email: helm-charts@cockroachlabs.com


### PR DESCRIPTION
It turns out the repository that Artifact Hub looks for is the chart repository (https://charts.cockroachdb.com/ in our case), not the source code repository. Removing from the source code repository...

Reverts cockroachdb/helm-charts#41