### PR TITLE
Update cockroachdb chart to version 20.2.3

### DIFF
--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 5.0.2
-appVersion: 20.2.2
+version: 5.0.3
+appVersion: 20.2.3
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png
 sources:

--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -175,10 +175,10 @@ kubectl get pods \
 ```
 
 ```
-my-release-cockroachdb-0    cockroachdb/cockroach:v20.2.2
-my-release-cockroachdb-1    cockroachdb/cockroach:v20.2.2
-my-release-cockroachdb-2    cockroachdb/cockroach:v20.2.2
-my-release-cockroachdb-3    cockroachdb/cockroach:v20.2.2
+my-release-cockroachdb-0    cockroachdb/cockroach:v20.2.3
+my-release-cockroachdb-1    cockroachdb/cockroach:v20.2.3
+my-release-cockroachdb-2    cockroachdb/cockroach:v20.2.3
+my-release-cockroachdb-3    cockroachdb/cockroach:v20.2.3
 ```
 
 Resume normal operations. Once you are comfortable that the stability and performance of the cluster is what you'd expect post-upgrade, finalize the upgrade:
@@ -257,7 +257,7 @@ For details see the [`values.yaml`](values.yaml) file.
 | `conf.port`                                               | CockroachDB primary serving port in Pods                        | `26257`                                          |
 | `conf.http-port`                                          | CockroachDB HTTP port in Pods                                   | `8080`                                           |
 | `image.repository`                                        | Container image name                                            | `cockroachdb/cockroach`                          |
-| `image.tag`                                               | Container image tag                                             | `v20.2.2`                                        |
+| `image.tag`                                               | Container image tag                                             | `v20.2.3`                                        |
 | `image.pullPolicy`                                        | Container pull policy                                           | `IfNotPresent`                                   |
 | `image.credentials`                                       | `registry`, `user` and `pass` credentials to pull private image | `{}`                                             |
 | `statefulset.replicas`                                    | StatefulSet replicas number                                     | `3`                                              |

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: cockroachdb/cockroach
-  tag: v20.2.2
+  tag: v20.2.3
   pullPolicy: IfNotPresent
   credentials: {}
     # registry: docker.io


### PR DESCRIPTION
This commit updates the cockroachdb helm charts version using e381aa73e6bed05b42b6c7eda9f63398efa37f1a as a template.