### PR TITLE
Upgrade the chart testing version

### DIFF
--- a/build/tester.sh
+++ b/build/tester.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image="quay.io/helmpack/chart-testing"
-version="v2.4.1"
+version="v3.3.1"
 
 if [ "${1-}" = "pull" ]; then
   docker pull "${image}:${version}"


### PR DESCRIPTION
The default stable chart repository moved and the old testing version pointed
at the old default stable chart repository URL. The upgraded version
fixes that.