### PR TITLE
Quick and dirty fix for secure in EKS

### DIFF
--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -73,6 +73,27 @@ spec:
             - name: client-certs
               mountPath: /cockroach-certs/
     {{- end }}
+    {{- if and .Values.tls.enabled (.Values.tls.certs.provided)}}
+      serviceAccountName: {{ template "cockroachdb.tls.serviceAccount.name" . }}
+      initContainers:
+        - name: copy-certs
+          image: "busybox"
+          imagePullPolicy: {{ .Values.tls.init.image.pullPolicy | quote }}
+          command:
+            - /bin/sh
+            - -c
+            - "cp -f /certs/* /cockroach-certs/; chmod 0400 /cockroach-certs/*.key"
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: client-certs
+              mountPath: /cockroach-certs/
+            - name: certs-secret
+              mountPath: /certs/
+    {{- end }}
     {{- with .Values.init.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -129,8 +150,10 @@ spec:
     {{- if .Values.tls.enabled }}
       volumes:
         - name: client-certs
+          emptyDir: {}
           {{- if .Values.tls.certs.provided }}
           {{- if .Values.tls.certs.tlsSecret }}
+        - name: certs-secret
           projected:
             sources:
             - secret:
@@ -150,8 +173,6 @@ spec:
             secretName: {{ .Values.tls.certs.clientRootSecret }}
             defaultMode: 0400
           {{- end }}
-          {{- else }}
-          emptyDir: {}
           {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Sorry this is part of 2 file update to allow helm to deploy in secure mode to EKS where the kube bug exists to make all mounted volumes (including secrets) mode 0440 thus preventing cockroach from starting