### PR TITLE
Fix for volume name with "bring your own certs"

### DIFF
--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -152,8 +152,8 @@ spec:
         - name: client-certs
           emptyDir: {}
           {{- if .Values.tls.certs.provided }}
-          {{- if .Values.tls.certs.tlsSecret }}
         - name: certs-secret
+          {{- if .Values.tls.certs.tlsSecret }}
           projected:
             sources:
             - secret:


### PR DESCRIPTION
Volume name not templating correctly when "bring your own certs" set to not tls
tls:
  enabled: true
  serviceAccount:
    create: true
    name: "cockroachdb"
  certs:
    provided: true
    clientRootSecret: .....
    nodeSecret: .....
    tlsSecret: false    < =====