### PR TITLE
Replace deprecated GitVersion with Version

### DIFF
--- a/cockroachdb/templates/_helpers.tpl
+++ b/cockroachdb/templates/_helpers.tpl
@@ -45,9 +45,9 @@ Create the name of the ServiceAccount to use.
 Return the appropriate apiVersion for NetworkPolicy.
 */}}
 {{- define "cockroachdb.networkPolicy.apiVersion" -}}
-{{- if semverCompare ">=1.4-0, <=1.7-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.4-0, <=1.7-0" .Capabilities.KubeVersion.Version -}}
     {{- print "extensions/v1beta1" -}}
-{{- else if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare "^1.7-0" .Capabilities.KubeVersion.Version -}}
     {{- print "networking.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}
@@ -56,7 +56,7 @@ Return the appropriate apiVersion for NetworkPolicy.
 Return the appropriate apiVersion for StatefulSets
 */}}
 {{- define "cockroachdb.statefulset.apiVersion" -}}
-{{- if semverCompare "<1.12-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.12-0" .Capabilities.KubeVersion.Version -}}
     {{- print "apps/v1beta1" -}}
 {{- else -}}
     {{- print "apps/v1" -}}

--- a/cockroachdb/templates/ingress.yaml
+++ b/cockroachdb/templates/ingress.yaml
@@ -2,9 +2,9 @@
 {{- $paths := .Values.ingress.paths -}}
 {{- $ports := .Values.service.ports -}}
 {{- $fullName := include "cockroachdb.fullname" . -}}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -40,11 +40,11 @@ spec:
         paths:
   {{- range $path := $paths }}
           - path: {{ $path }}
-            {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+            {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version -}}
             pathType: Prefix
             {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+              {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version -}}
               service:
                 name: {{ $fullName }}-public
                 port:
@@ -60,11 +60,11 @@ spec:
         paths:
   {{- range $path := $paths }}
           - path: {{ $path }}
-            {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+            {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version -}}
             pathType: Prefix
             {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+              {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.Version -}}
               service:
                 name: {{ $fullName }}-public
                 port:

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -148,7 +148,7 @@ spec:
         {{- end }}
       {{- end }}
     {{- end }}
-    {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
+    {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.Version }}
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
@@ -199,7 +199,7 @@ spec:
             # See details explained here:
             # https://github.com/helm/charts/pull/18993#issuecomment-558795102
             - >-
-              exec /cockroach/cockroach 
+              exec /cockroach/cockroach
             {{- if index .Values.conf `single-node` }}
               start-single-node
             {{- else }}


### PR DESCRIPTION
This replaces the deprecated `GitVersion` with `Version`.

Fixes #77