### PR TITLE
fix ingress yaml invalid structure due to missing newlines

### DIFF
--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 5.1.4
+version: 5.1.5
 appVersion: 20.2.7
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb/templates/ingress.yaml
+++ b/cockroachdb/templates/ingress.yaml
@@ -40,16 +40,16 @@ spec:
         paths:
   {{- range $path := $paths }}
           - path: {{ $path }}
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
             pathType: Prefix
             {{- end }}
             backend:
-              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
               service:
                 name: {{ $fullName }}-public
                 port:
                   name: {{ $ports.http.name | quote }}
-              {{- else -}}
+              {{- else }}
               serviceName: {{ $fullName }}-public
               servicePort: {{ $ports.http.name | quote }}
               {{- end }}
@@ -60,16 +60,16 @@ spec:
         paths:
   {{- range $path := $paths }}
           - path: {{ $path }}
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
             pathType: Prefix
             {{- end }}
             backend:
-              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
               service:
                 name: {{ $fullName }}-public
                 port:
                   name: {{ $ports.http.name | quote }}
-              {{- else -}}
+              {{- else }}
               serviceName: {{ $fullName }}-public
               servicePort: {{ $ports.http.name | quote }}
               {{- end }}


### PR DESCRIPTION
With version 5.1.4 `helm template --set ingress.enabled=true cockroachdb` fails due to newlines getting removed too eagerly. This fixes the issue.

A test that would catch the regression would be useful. By running something like

```
helm template \
  --set conf.store.enabled=true \
  --set ingress.enabled=true \
  --set serviceMonitor.enabled=true \
  --set tls.enabled=true \
  --set networkPolicy.enabled=true \
  --set iap.enabled=true \
  --set iap.clientId=abc \
  --set iap.clientSecret=abc \
  cockroachdb
```