### PR TITLE
include Ingress object in APIVersions check

### DIFF
--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 5.1.5
+version: 5.1.6
 appVersion: 20.2.7
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb/templates/ingress.yaml
+++ b/cockroachdb/templates/ingress.yaml
@@ -2,9 +2,9 @@
 {{- $paths := .Values.ingress.paths -}}
 {{- $ports := .Values.service.ports -}}
 {{- $fullName := include "cockroachdb.fullname" . -}}
-{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+{{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
 apiVersion: networking.k8s.io/v1
-{{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+{{- else if $.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -40,11 +40,11 @@ spec:
         paths:
   {{- range $path := $paths }}
           - path: {{ $path }}
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: Prefix
             {{- end }}
             backend:
-              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: {{ $fullName }}-public
                 port:
@@ -60,11 +60,11 @@ spec:
         paths:
   {{- range $path := $paths }}
           - path: {{ $path }}
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: Prefix
             {{- end }}
             backend:
-              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
               service:
                 name: {{ $fullName }}-public
                 port:


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/helm-charts/issues/82.

I've verified this structure to work in https://github.com/estafette/estafette-ci-api/blob/main/helm/estafette-ci-api/templates/ingress.yaml#L2-L8 by running it against both kubernetes 1.17 and 1.19 in my build pipeline successfully.

It's actually elasticsearch' Helm charts that do more extensive testing (not grafana as I mentioned before), see https://github.com/elastic/helm-charts/blob/master/CONTRIBUTING.md#testing.