### PR TITLE
sort storage params for stable helm upgrade

### DIFF
--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 6.0.0
+version: 6.0.1
 appVersion: 21.1.0
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb/templates/_helpers.tpl
+++ b/cockroachdb/templates/_helpers.tpl
@@ -76,5 +76,5 @@ Return CockroachDB store expression
 {{- $_ := set $store "size" (print "size=" ($isInMemory | ternary .Values.conf.store.size $persistentSize)) -}}
 {{- $_ := set $store "attrs" (empty .Values.conf.store.attrs | ternary "" (print "attrs=" .Values.conf.store.attrs)) -}}
 
-{{ compact (values $store) | join "," }}
+{{ compact (values $store) | sortAlpha | join "," }}
 {{- end -}}


### PR DESCRIPTION
subsequent `helm upgrade` may fail because the StatefulSet allows only handful of changes, and "cockroachdb.conf.store" function may return different output every time