### PR TITLE
Add a docker build and push steps through Makefile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
         run: go test -v ./tests/template/...
 
       - name: Unit
-        run: go test -v ./cmd/...
+        run: go test -v ./pkg/...
 
   # pre job to build and push the self signer utility
   pre-build:
@@ -81,9 +81,6 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
       - name: Login to GCR
         uses: docker/login-action@v1
         with:
@@ -91,13 +88,11 @@ jobs:
           username: _json_key
           password: ${{ secrets.GCR_HELM_CHART_SA_JSON }}
 
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          tags: gcr.io/cockroachdb/cockroach-self-signer-cert:${{ github.sha }}
-          file: build/docker-image/Dockerfile
+      - name: Build Self-signer
+        run: make build-self-signer
+
+      - name: Push Self-signer
+        run: make push-self-signer
 
   # pre job to run helm integration tests
   helm-integration:
@@ -122,3 +117,5 @@ jobs:
 
       - name: Integration Test
         run: go test -v ./tests/integration/...
+        env:
+          TAG: ${{github.event.pull_request.head.ref}}

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+REPOSITORY ?= cockroachdb/cockroach-self-signer-cert
+TAG ?= $(shell git rev-parse HEAD)
+
 .DEFAULT_GOAL := all
 all: build
 
@@ -16,3 +19,9 @@ release:
 .PHONY: clean
 clean:
 	rm -r build/artifacts/
+
+build-self-signer:
+	docker build -f build/docker-image/Dockerfile -t ${REPOSITORY}:${TAG} .
+
+push-self-signer:
+	docker push ${REPOSITORY}:${TAG}


### PR DESCRIPTION
- Removed the docker build from buildx as it is not checking out the latest code. 
- Added Makefile build commands for building self-signer utility.
- Added the TAG environment variable with the sha1 the self-signer utility is build and pushed. This environment variable will be used in the helm install of the CRDB.
- Changed the go test from `cmd` folder to `pkg` folder.