### PR TITLE
Converting the hours into valid cron schedule as per kubernetes

### DIFF
--- a/cockroachdb/templates/_helpers.tpl
+++ b/cockroachdb/templates/_helpers.tpl
@@ -96,15 +96,71 @@ Define the default values for the certificate selfSigner inputs
 {{- end -}}
 
 {{/*
-Define the cron schedules for certificate rotate jobs
+Define the cron schedules for certificate rotate jobs and converting from hours to valid cron string.
+We assume that each month has 31 days, hence the cron job may run few days earlier in a year.
 */}}
 {{- define "selfcerts.caRotateSchedule" -}}
-{{- $schedule := sub (.Values.tls.certs.selfSigner.caCertDuration | trimSuffix "h") (.Values.tls.certs.selfSigner.caCertExpiryWindow | trimSuffix "h") -}}
-{{- printf "0 %s%s * * *" "*/" (toString $schedule) | quote -}}
+{{- $tempHours := sub (.Values.tls.certs.selfSigner.caCertDuration | trimSuffix "h") (.Values.tls.certs.selfSigner.caCertExpiryWindow | trimSuffix "h") -}}
+{{- $days := "*" -}}
+{{- $months := "*" -}}
+{{- $years := "*" -}}
+{{- $hours := mod $tempHours 24 -}}
+{{- if not (eq $hours $tempHours) -}}
+{{- $tempDays := div $tempHours 24 -}}
+{{- $days = mod $tempDays 31 -}}
+{{- if not (eq $days $tempDays) -}}
+{{- $tempMonths := div $tempDays 31 -}}
+{{- $months = mod $tempMonths 12 -}}
+{{- if not (eq $months $tempMonths) -}}
+{{- $years = div $tempMonths 12 -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if ne $hours 0 -}}
+{{- $hours = printf "*/%s" (toString $hours) -}}
+{{- end -}}
+{{- if and (ne (toString $days) "*") (ne (toString $days) "0") -}}
+{{- $days = printf "*/%s" (toString $days) -}}
+{{- end -}}
+{{- if and (ne (toString $months) "*") (ne (toString $months) "0") -}}
+{{- $months = printf "*/%s" (toString $months) -}}
+{{- end -}}
+{{- if and (ne (toString $years) "*") (ne (toString $years) "0") -}}
+{{- $years = printf "*/%s" (toString $years) -}}
+{{- end -}}
+{{- printf "0 %s %s %s %s" (toString $hours) (toString $days) (toString $months) (toString $years) | quote -}}
 {{- end -}}
 
 {{- define "selfcerts.clientRotateSchedule" -}}
-{{- printf "0 %s%s * * *" "*/" (include "selfcerts.minimumCertDuration" .) | quote -}}
+{{- $tempHours := int64 (include "selfcerts.minimumCertDuration" .) -}}
+{{- $days := "*" -}}
+{{- $months := "*" -}}
+{{- $years := "*" -}}
+{{- $hours := mod $tempHours 24 -}}
+{{- if not (eq $hours $tempHours) -}}
+{{- $tempDays := div $tempHours 24 -}}
+{{- $days = mod $tempDays 31 -}}
+{{- if not (eq $days $tempDays) -}}
+{{- $tempMonths := div $tempDays 31 -}}
+{{- $months = mod $tempMonths 12 -}}
+{{- if not (eq $months $tempMonths) -}}
+{{- $years = div $tempMonths 12 -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if ne $hours 0 -}}
+{{- $hours = printf "*/%s" (toString $hours) -}}
+{{- end -}}
+{{- if and (ne (toString $days) "*") (ne (toString $days) "0") -}}
+{{- $days = printf "*/%s" (toString $days) -}}
+{{- end -}}
+{{- if and (ne (toString $months) "*") (ne (toString $months) "0") -}}
+{{- $months = printf "*/%s" (toString $months) -}}
+{{- end -}}
+{{- if and (ne (toString $years) "*") (ne (toString $years) "0") -}}
+{{- $years = printf "*/%s" (toString $years) -}}
+{{- end -}}
+{{- printf "0 %s %s %s %s" (toString $hours) (toString $days) (toString $months) (toString $years) | quote -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Kubernetes doesn't support cron schedule like `0 */624 * * *` where the hours are greater than 24, days are greater than 31 and months are greater than 12. Hence added a mechanism to convert cron schedule from hours to supported cron schedule in hours, days, months and years.