### PR TITLE
Add Security Context Support

### DIFF
--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -336,6 +336,7 @@ For details see the [`values.yaml`](values.yaml) file.
 | `statefulset.resources`                                   | Resource requests and limits for StatefulSet Pods               | `{}`                                             |
 | `statefulset.customLivenessProbe`                         | Custom Liveness probe                                           | `{}`                                             |
 | `statefulset.customReadinessProbe`                        | Custom Rediness probe                                           | `{}`                                             |
+| `statefulset.securityContext`                             | Security context for containers                                 | `{}`                                             |
 | `service.ports.grpc.external.port`                        | CockroachDB primary serving port in Services                    | `26257`                                          |
 | `service.ports.grpc.external.name`                        | CockroachDB primary serving port name in Services               | `grpc`                                           |
 | `service.ports.grpc.internal.port`                        | CockroachDB inter-communication port in Services                | `26257`                                          |
@@ -371,6 +372,7 @@ For details see the [`values.yaml`](values.yaml) file.
 | `init.nodeSelector`                                       | Node labels for init Job Pod assignment                         | `{}`                                             |
 | `init.tolerations`                                        | Node taints to tolerate by init Job Pod                         | `[]`                                             |
 | `init.resources`                                          | Resource requests and limits for the Pod of init Job            | `{}`                                             |
+| `init.securityContext`                                    | Security context for containers                                 | `{}`                                             |
 | `tls.enabled`                                             | Whether to run securely using TLS certificates                  | `no`                                             |
 | `tls.serviceAccount.create`                               | Whether to create a new RBAC service account                    | `yes`                                            |
 | `tls.serviceAccount.name`                                 | Name of RBAC service account to use                             | `""`                                             |
@@ -389,6 +391,7 @@ For details see the [`values.yaml`](values.yaml) file.
 | `networkPolicy.enabled`                                   | Enable NetworkPolicy for CockroachDB's Pods                     | `no`                                             |
 | `networkPolicy.ingress.grpc`                              | Whitelist resources to access gRPC port of CockroachDB's Pods   | `[]`                                             |
 | `networkPolicy.ingress.http`                              | Whitelist resources to access gRPC port of CockroachDB's Pods   | `[]`                                             |
+| `securityContext`                                         | Security Context for Pods                                       | `{}`                                             |
 
 
 Override the default parameters using the `--set key=value[,key=value]` argument to `helm install`.

--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -33,6 +33,10 @@ spec:
     spec:
       restartPolicy: OnFailure
       terminationGracePeriodSeconds: 0
+      {{- if .Values.securityContext }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- end }}
     {{- if or .Values.image.credentials (and .Values.tls.enabled .Values.tls.init.image.credentials (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager)) }}
       imagePullSecrets:
       {{- if .Values.image.credentials }}
@@ -57,6 +61,10 @@ spec:
         - name: init-certs
           image: "{{ .Values.tls.init.image.repository }}:{{ .Values.tls.init.image.tag }}"
           imagePullPolicy: {{ .Values.tls.init.image.pullPolicy | quote }}
+          {{- if .Values.statefulset.securityContext }}
+          securityContext:
+            {{- toYaml .Values.init.securityContext | nindent 12 }}
+          {{- end }}
           command:
             - /bin/ash
             - -ecx
@@ -82,6 +90,10 @@ spec:
         - name: copy-certs
           image: "busybox"
           imagePullPolicy: {{ .Values.tls.init.image.pullPolicy | quote }}
+          {{- if .Values.statefulset.securityContext }}
+          securityContext:
+            {{- toYaml .Values.init.securityContext | nindent 12 }}
+          {{- end }}
           command:
             - /bin/sh
             - -c
@@ -110,6 +122,10 @@ spec:
         - name: cluster-init
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.statefulset.securityContext }}
+          securityContext:
+            {{- toYaml .Values.init.securityContext | nindent 12 }}
+          {{- end }}
           # Run the command in an `while true` loop because this Job is bound
           # to come up before the CockroachDB Pods (due to the time needed to
           # get PersistentVolumes attached to Nodes), and sleeping 5 seconds

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -41,6 +41,10 @@ spec:
       annotations: {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
+      {{- if .Values.securityContext }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- end }}
     {{- if or .Values.image.credentials (and .Values.tls.enabled .Values.tls.init.image.credentials (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager)) }}
       imagePullSecrets:
       {{- if .Values.image.credentials }}
@@ -93,6 +97,10 @@ spec:
         - name: copy-certs
           image: "busybox"
           imagePullPolicy: {{ .Values.tls.init.image.pullPolicy | quote }}
+          {{- if .Values.init.securityContext }}
+          securityContext:
+            {{- toYaml .Values.init.securityContext | nindent 12 }}
+          {{- end }}
           command:
             - /bin/sh
             - -c
@@ -179,6 +187,10 @@ spec:
         - name: db
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.statefulset.securityContext }}
+          securityContext:
+            {{- toYaml .Values.statefulset.securityContext | nindent 12 }}
+          {{- end }}
           args:
             - shell
             - -ecx

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -156,6 +156,11 @@ statefulset:
   budget:
     maxUnavailable: 1
 
+  # Set the pod security context for the StatefulSet
+  securityContext: {}
+    # runAsUser: 1000
+    # runAsGroup: 2000
+
   # List of additional command-line arguments you want to pass to the
   # `cockroach start` command.
   args: []
@@ -374,6 +379,10 @@ init:
     #   cpu: "10m"
     #   memory: "128Mi"
 
+  # Set the pod security context for the init pods
+  securityContext: {}
+    # runAsUser: 1000
+    # runAsGroup: 2000
 
 # Whether to run securely using TLS certificates.
 tls:
@@ -444,3 +453,6 @@ iap:
   # Create Google Cloud OAuth credentials and set client id and secret
   # clientId:
   # clientSecret:
+
+securityContext:
+  # fsGroup: 3000


### PR DESCRIPTION
This should close #67 by adding the necessary config options to support the various levels of pod security.

I can document the creation of the `ClusterRole`, `ClusterRoleBinding`, and the `PodSecurityPolicy` yaml to show how to setup the security context explicitly for this service. Also, it may be desirable to add those configurations in to allow for managing the security within this chart.
