### PR TITLE
Add the support of custom user client cert generation

### DIFF
--- a/cmd/self-signer/generate.go
+++ b/cmd/self-signer/generate.go
@@ -36,9 +36,11 @@ var (
 	caDuration, nodeDuration, clientDuration string
 	caExpiry, nodeExpiry, clientExpiry       string
 	caSecret                                 string
+	clientOnly                               bool
 )
 
 func init() {
+	generateCmd.Flags().BoolVar(&clientOnly, "client-only", false, "generate certificates for custom user")
 	rootCmd.AddCommand(generateCmd)
 }
 
@@ -56,7 +58,13 @@ func generate(cmd *cobra.Command, args []string) {
 		log.Panic("Required NAMESPACE env not found")
 	}
 
-	if err := genCert.Do(ctx, namespace); err != nil {
-		log.Panic(err)
+	if clientOnly {
+		if err := genCert.ClientCertGenerate(ctx, namespace); err != nil {
+			log.Panic(err)
+		}
+	} else {
+		if err := genCert.Do(ctx, namespace); err != nil {
+			log.Panic(err)
+		}
 	}
 }

--- a/pkg/generator/generate_cert.go
+++ b/pkg/generator/generate_cert.go
@@ -146,6 +146,7 @@ func (rc *GenerateCert) Do(ctx context.Context, namespace string) error {
 	return nil
 }
 
+// ClientCertGenerate generates the custom user client only certificates and creates the secret.
 func (rc *GenerateCert) ClientCertGenerate(ctx context.Context, namespace string) error {
 	logrus.SetLevel(logrus.InfoLevel)
 
@@ -543,6 +544,7 @@ func (rc *GenerateCert) UpdateNewCA(ctx context.Context, namespace string) error
 	return nil
 }
 
+// LoadCASecret loads the CA secret and write the CA certificate and key to the CA cert directory.
 func (rc *GenerateCert) LoadCASecret(ctx context.Context, namespace string) error {
 	secret, err := resource.LoadTLSSecret(rc.CaSecret, resource.NewKubeResource(ctx, rc.client, namespace, kube.DefaultPersister))
 	if err != nil {

--- a/tests/e2e/rotate/cockroachdb_rotate_certs_test.go
+++ b/tests/e2e/rotate/cockroachdb_rotate_certs_test.go
@@ -78,7 +78,6 @@ func TestCockroachDbRotateCertificates(t *testing.T) {
 		}
 	}()
 
-
 	// Next we wait for the service endpoint
 	serviceName := fmt.Sprintf("%s-cockroachdb-public", releaseName)
 	k8s.WaitUntilServiceAvailable(t, kubectlOptions, serviceName, 30, 2*time.Second)
@@ -98,12 +97,12 @@ func TestCockroachDbRotateCertificates(t *testing.T) {
 	// actual rotation. The cron schedule provide should be greater than the life of the certificate, then only rotation
 	// will be triggered. Here the client and node certificates are valid for 10 days and the next cron is scheduled in
 	// 26 days, hence it will trigger the client and node certificate rotation.
-	testutil.RequireToRunRotateJob(t, crdbCluster, helmValues,"0 0 */26 * *", false)
+	testutil.RequireToRunRotateJob(t, crdbCluster, helmValues, "0 0 */26 * *", false)
 
 	// This will wait for the certificate rotation to complete, which will do a rolling restart of the CRDB cluster.
 	testutil.RequireCertRotateJobToBeCompleted(t, "client-node-certificate-rotate", crdbCluster, 500*time.Second)
 
-	time.Sleep(20*time.Second)
+	time.Sleep(20 * time.Second)
 	// This will check after rotation the database is working properly.
 	testutil.RequireDatabaseToFunction(t, crdbCluster, true)
 
@@ -126,7 +125,7 @@ func TestCockroachDbRotateCertificates(t *testing.T) {
 	// This will wait for the certificate rotation to complete, which will do a rolling restart of the CRDB cluster.
 	testutil.RequireCertRotateJobToBeCompleted(t, "ca-certificate-rotate", crdbCluster, 500*time.Second)
 
-	time.Sleep(20*time.Second)
+	time.Sleep(20 * time.Second)
 	// This will check after rotation the database is working properly.
 	testutil.RequireDatabaseToFunction(t, crdbCluster, true)
 

--- a/tests/testutil/require.go
+++ b/tests/testutil/require.go
@@ -297,7 +297,7 @@ func RequireToRunRotateJob(t *testing.T, crdbCluster CockroachCluster, values ma
 			"--ca",
 			fmt.Sprintf("--ca-duration=%s", values["tls.certs.selfSigner.caCertDuration"]),
 			fmt.Sprintf("--ca-expiry=%s", values["tls.certs.selfSigner.caCertExpiryWindow"]),
-			fmt.Sprintf("--ca-cron=\"%s\"",scheduleToTriggerRotation),
+			fmt.Sprintf("--ca-cron=\"%s\"", scheduleToTriggerRotation),
 			"--readiness-wait=30s",
 		}
 	} else {


### PR DESCRIPTION
User can generate client certificates for any user using following job:
```
apiVersion: batch/v1
kind: Job
metadata:
  name: user-cert-generate
spec:
  backoffLimit: 1
  completions: 1
  parallelism: 1
  template:
    spec:
      restartPolicy: Never
      containers:
      - args:
        - generate
        - --client-only
        env:
        - name: USER_NAME
          value: prafull              ## Provide the user name to which you want to create client certificates
        - name: CA_SECRET
          value: crdb-cockroachdb-ca-secret  ## CA secret where the CA is stored for CRDB
        - name: NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        image: gcr.io/cockroachlabs-helm-charts/cockroach-self-signer-cert:dc73bb7f9a40013696fa342af78872fdaa927163
        imagePullPolicy: Always
        name: user-cert-job
      serviceAccountName: crdb-cockroachdb-self-signer
```