### PR TITLE
add flag to switch to cert-manager.io/v1 apiVersion

### DIFF
--- a/cockroachdb/templates/certificate.client.yaml
+++ b/cockroachdb/templates/certificate.client.yaml
@@ -23,8 +23,14 @@ spec:
     - digital signature
     - key encipherment
     - client auth
+{{- if .Values.tls.certs.useCertManagerV1CRDs }}
+  privateKey:
+    algorithm: rsa
+    size: 2048
+{{- else }}
   keySize: 2048
   keyAlgorithm: rsa
+{{- end }}
   commonName: root
   organization:
     - Cockroach

--- a/cockroachdb/templates/certificate.client.yaml
+++ b/cockroachdb/templates/certificate.client.yaml
@@ -29,7 +29,7 @@ spec:
     size: 2048
 {{- else }}
   keySize: 2048
-  keyAlgorithm: RSA
+  keyAlgorithm: rsa
 {{- end }}
   commonName: root
   organization:

--- a/cockroachdb/templates/certificate.client.yaml
+++ b/cockroachdb/templates/certificate.client.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.tls.enabled .Values.tls.certs.certManager }}
+{{- if .Values.tls.certs.useCertManagerV1CRDs }}
+apiVersion: cert-manager.io/v1
+{{- else }}
 apiVersion: cert-manager.io/v1alpha2
+{{- end }}
 kind: Certificate
 metadata:
   name: {{ template "cockroachdb.fullname" . }}-root-client

--- a/cockroachdb/templates/certificate.client.yaml
+++ b/cockroachdb/templates/certificate.client.yaml
@@ -25,11 +25,11 @@ spec:
     - client auth
 {{- if .Values.tls.certs.useCertManagerV1CRDs }}
   privateKey:
-    algorithm: rsa
+    algorithm: RSA
     size: 2048
 {{- else }}
   keySize: 2048
-  keyAlgorithm: rsa
+  keyAlgorithm: RSA
 {{- end }}
   commonName: root
   organization:

--- a/cockroachdb/templates/certificate.node.yaml
+++ b/cockroachdb/templates/certificate.node.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.tls.enabled .Values.tls.certs.certManager }}
+{{- if .Values.tls.certs.useCertManagerV1CRDs }}
+apiVersion: cert-manager.io/v1
+{{- else }}
 apiVersion: cert-manager.io/v1alpha2
+{{- end }}
 kind: Certificate
 metadata:
   name: {{ template "cockroachdb.fullname" . }}-node

--- a/cockroachdb/templates/certificate.node.yaml
+++ b/cockroachdb/templates/certificate.node.yaml
@@ -24,8 +24,14 @@ spec:
     - key encipherment
     - server auth
     - client auth
+{{- if .Values.tls.certs.useCertManagerV1CRDs }}
+  privateKey:
+    algorithm: rsa
+    size: 2048
+{{- else }}
   keySize: 2048
   keyAlgorithm: rsa
+{{- end }}
   commonName: node
   organization:
     - Cockroach

--- a/cockroachdb/templates/certificate.node.yaml
+++ b/cockroachdb/templates/certificate.node.yaml
@@ -26,11 +26,11 @@ spec:
     - client auth
 {{- if .Values.tls.certs.useCertManagerV1CRDs }}
   privateKey:
-    algorithm: rsa
+    algorithm: RSA
     size: 2048
 {{- else }}
   keySize: 2048
-  keyAlgorithm: rsa
+  keyAlgorithm: RSA
 {{- end }}
   commonName: node
   organization:

--- a/cockroachdb/templates/certificate.node.yaml
+++ b/cockroachdb/templates/certificate.node.yaml
@@ -30,7 +30,7 @@ spec:
     size: 2048
 {{- else }}
   keySize: 2048
-  keyAlgorithm: RSA
+  keyAlgorithm: rsa
 {{- end }}
   commonName: node
   organization:

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -403,6 +403,9 @@ tls:
       group: cert-manager.io
       kind: Issuer
       name: cockroachdb
+    # Enable if you run cert-manager >=1.0 on K8s <=1.15 with legacy CRDs
+    # Legacy CRDs only support cert-manager.io/v1 API Versions
+    useCertManagerV1CRDs: false
 
   init:
     # Image to use for requesting TLS certificates.


### PR DESCRIPTION
This adds a flag `.tls.certs.useCertManagerV1CRDs` defaulting to `false`. If set to `true` the cert-manager resources will be rendered using `cert-manager.io/v1` .

Fixes #142 