### PR TITLE
Fix the SHA value of E2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,6 +126,8 @@ jobs:
 
       - name: Run E2E Test
         run: go test -v ./tests/e2e/install/...
+        env:
+          TAG: ${{github.event.pull_request.head.sha}}
 
   helm-rotate-cert-e2e:
     name: Helm-rotate-cert-Test
@@ -155,3 +157,5 @@ jobs:
 
       - name: Run E2E Test
         run: go test -v ./tests/e2e/rotate/...
+        env:
+          TAG: ${{github.event.pull_request.head.sha}}


### PR DESCRIPTION
Need to add a env variable TAG which will have PR commit sha.
Currently in tests we are using default GITHUB_SHA which have the master commits sha not the PR commits sha and hence the docker build happen with different sha and tests run with different sha