### PR TITLE
#147 Fix the certificate manager installation of cockroachdb

### DIFF
--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -76,7 +76,7 @@ spec:
             - name: client-certs
               mountPath: /cockroach-certs/
     {{- end }}
-    {{- if and .Values.tls.enabled (.Values.tls.certs.provided)}}
+    {{- if or .Values.tls.certs.certManager (and .Values.tls.enabled (.Values.tls.certs.provided))}}
       serviceAccountName: {{ template "cockroachdb.tls.serviceAccount.name" . }}
       initContainers:
         - name: copy-certs

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -88,7 +88,7 @@ spec:
             - name: certs
               mountPath: /cockroach-certs/
       {{- end }}
-      {{- if .Values.tls.certs.provided }}
+      {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager }}
       initContainers:
         - name: copy-certs
           image: "busybox"


### PR DESCRIPTION
The certificate managers certificates also needs to be copied to the /cockroach-certs . 

Closes #147 