### PR TITLE
put ip addr for localhost (127.0.0.1) into more specific field.

### DIFF
--- a/cockroachdb/templates/certificate.node.yaml
+++ b/cockroachdb/templates/certificate.node.yaml
@@ -27,13 +27,14 @@ spec:
     - Cockroach
   dnsNames:
     - "localhost"
-    - "127.0.0.1"
     - {{ printf "%s-public" (include "cockroachdb.fullname" .) | quote }}
     - {{ printf "%s-public.%s" (include "cockroachdb.fullname" .) .Release.Namespace | quote }}
     - {{ printf "%s-public.%s.svc.%s" (include "cockroachdb.fullname" .) .Release.Namespace .Values.clusterDomain | quote }}
     - {{ printf "*.%s" (include "cockroachdb.fullname" .) | quote }}
     - {{ printf "*.%s.%s" (include "cockroachdb.fullname" .) .Release.Namespace | quote }}
     - {{ printf "*.%s.%s.svc.%s" (include "cockroachdb.fullname" .) .Release.Namespace .Values.clusterDomain | quote }}
+  ipAddresses:
+    - "127.0.0.1"
   secretName: {{ .Values.tls.certs.nodeSecret }}
   issuerRef: {{- toYaml .Values.tls.certs.certManagerIssuer | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
For the node certificate resource, the IP address for localhost is set via the field `spec.dnsNames`. This seems to work in the TLS clients used within Kubernetes.
But it is not correct according to the standard. There are two separate extensions to be used for this. Cert-manager handles this by differentiating between `spec.dnsNames` and `spec.ipAddresses`.

This change simply moves the IP address "127.0.0.1" into the appropriate field. 

It should not change any behaviour, only avoid potential problems with more restrictive TLS clients.