### PR TITLE
Improve the CI and build workflows of cert-manager utility

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,16 +9,36 @@ on:
 
 jobs:
 
-  # Post job to build and push the self signer utility whenever any PR gets merged
-  post-build:
-    name: build-self-signer-cert-utility
+  needs-build:
+    name: is-building-self-signer-utility-required
     runs-on: ubuntu-latest
+    outputs:
+      tagChange: ${{ steps.changetag.outputs.tagChange }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          fetch-depth: 2
+
+      - name: Check Tag Change
+        id: changetag
+        shell: bash
+        run: |
+          ./build/self-signer-utility.sh
+          if [[ $? -eq 0 ]]; then
+            echo ::set-output name=tagChange::true
+          fi
+
+
+  # Post job to build and push the self signer utility whenever any PR gets merged
+  post-build:
+    name: build-self-signer-cert-utility
+    runs-on: ubuntu-latest
+    needs: needs-build
+    if: (needs.needs-build.outputs.tagChange == 'true')
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
 
       - name: Login to GCR
         uses: docker/login-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,10 +6,36 @@ on:
       - 'cert-manager-feature-branch'
 
 jobs:
+
+
+  detect-self-signer-change:
+    name: is-self-signer-changed
+    runs-on: ubuntu-latest
+    outputs:
+      certUtility: ${{ steps.filter.outputs.certUtility }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Verify Changed files
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+              certUtility: &certUtility
+              - 'pkg/**'
+              - 'tests/**'
+
   # pre job run golangci-lint
   go-lint:
     name: 'Golint'
     runs-on: ubuntu-latest
+    needs: detect-self-signer-change
+    if: (needs.detect-self-signer-change.outputs.certUtility == 'true')
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -67,6 +93,26 @@ jobs:
       - name: Unit
         run: go test -v ./pkg/...
 
+  self-signer-tag-change:
+    name: Tag Change
+    runs-on: ubuntu-latest
+    needs: detect-self-signer-change
+    if: (needs.detect-self-signer-change.outputs.certUtility == 'true')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Verify tag change
+        run: |
+          ./build/self-signer-utility.sh
+          if [[ $? -ne 0 ]]; then
+            exit 1
+          fi
+
   # pre job to run helm e2e tests
   helm-install-e2e:
     name: Helm-E2E-Test
@@ -97,8 +143,6 @@ jobs:
 
       - name: Run E2E Test
         run: go test -v ./tests/e2e/install/...
-        env:
-          TAG: ${{github.event.pull_request.head.sha}}
 
   helm-rotate-cert-e2e:
     name: Helm-rotate-cert-Test
@@ -129,5 +173,3 @@ jobs:
 
       - name: Run E2E Test
         run: go test -v ./tests/e2e/rotate/...
-        env:
-          TAG: ${{github.event.pull_request.head.sha}}

--- a/build/self-signer-utility.sh
+++ b/build/self-signer-utility.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+tag=$(yq r ./cockroachdb/values.yaml 'tls.selfSigner.image.tag')
+echo "Your current tag is ${tag}"
+currentCommit=$(git rev-parse HEAD)
+lastCommit=$(git rev-parse @~)
+
+git diff "${lastCommit}" "${currentCommit}" cockroachdb/values.yaml | grep "$tag" | grep +
+if [[ $? -ne 0 ]]; then
+  echo "You have not changed the tag of selfSigner utility"
+  exit 1
+fi
+exit 0

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -435,7 +435,7 @@ tls:
     # Image Placeholder for the selfSigner utility. This will be changed once the CI workflows for the image is in place.
     image:
       repository: cockroachlabs-helm-charts/cockroach-self-signer-cert
-      tag: "0.1"
+      tag: "0.2"
       pullPolicy: IfNotPresent
       credentials: {}
       registry: gcr.io

--- a/tests/e2e/install/cockroachdb_helm_e2e_test.go
+++ b/tests/e2e/install/cockroachdb_helm_e2e_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -28,7 +27,6 @@ var (
 	k8sClient, _   = client.New(cfg, client.Options{})
 	releaseName    = "crdb-test"
 	customCASecret = "custom-ca-secret"
-	imageTag       = os.Getenv("TAG")
 )
 
 func TestCockroachDbHelmInstall(t *testing.T) {
@@ -59,7 +57,6 @@ func TestCockroachDbHelmInstall(t *testing.T) {
 	options := &helm.Options{
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 		SetValues: map[string]string{
-			"tls.selfSigner.image.tag":      imageTag,
 			"storage.persistentVolume.size": "1Gi",
 		},
 	}
@@ -138,7 +135,6 @@ func TestCockroachDbHelmInstallWithCAProvided(t *testing.T) {
 	options := &helm.Options{
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 		SetValues: map[string]string{
-			"tls.selfSigner.image.tag":        imageTag,
 			"tls.certs.selfSigner.caProvided": "true",
 			"tls.certs.selfSigner.caSecret":   customCASecret,
 			"storage.persistentVolume.size":   "1Gi",
@@ -256,12 +252,11 @@ func TestCockroachDbHelmMigration(t *testing.T) {
 	options := &helm.Options{
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 		SetValues: map[string]string{
-			"tls.selfSigner.image.tag":     imageTag,
-			"tls.certs.provided":           "true",
-			"tls.certs.selfSigner.enabled": "false",
-			"tls.certs.clientRootSecret":   crdbCluster.ClientSecret,
-			"tls.certs.nodeSecret":         crdbCluster.NodeSecret,
-			"storage.persistentVolume.size":      "1Gi",
+			"tls.certs.provided":            "true",
+			"tls.certs.selfSigner.enabled":  "false",
+			"tls.certs.clientRootSecret":    crdbCluster.ClientSecret,
+			"tls.certs.nodeSecret":          crdbCluster.NodeSecret,
+			"storage.persistentVolume.size": "1Gi",
 		},
 	}
 
@@ -293,7 +288,6 @@ func TestCockroachDbHelmMigration(t *testing.T) {
 	options = &helm.Options{
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 		SetValues: map[string]string{
-			"tls.selfSigner.image.tag":        imageTag,
 			"storage.persistentVolume.size":   "1Gi",
 			"statefulset.updateStrategy.type": "OnDelete",
 		},

--- a/tests/template/cockroachdb_helm_template_test.go
+++ b/tests/template/cockroachdb_helm_template_test.go
@@ -18,13 +18,13 @@ import (
 )
 
 var (
-	err error
+	err           error
 	helmChartPath string
 	releaseName   = "helm-basic"
 	namespaceName = "crdb-" + strings.ToLower(random.UniqueId())
 )
 
-func init()  {
+func init() {
 	helmChartPath, err = filepath.Abs("../../cockroachdb")
 	if err != nil {
 		panic(err)
@@ -44,15 +44,15 @@ func TestTLSEnable(t *testing.T) {
 			"Self Signer and cert manager set to false",
 			map[string]string{
 				"tls.certs.selfSigner.enabled": "false",
-				"tls.certs.certManager": "false",
+				"tls.certs.certManager":        "false",
 			},
 			"You have to enable either self signed certificates or certificate manager, if you have enabled tls",
 		},
 		{
 			"Self Signer and cert manager set to true",
 			map[string]string{
-				"tls.certs.selfSigner.enabled":     "true",
-				"tls.certs.certManager": "true",
+				"tls.certs.selfSigner.enabled": "true",
+				"tls.certs.certManager":        "true",
 			},
 			"Can not enable the self signed certificates and certificate manager at the same time",
 		},
@@ -100,7 +100,7 @@ func TestHelmSelfCertSignerServiceAccount(t *testing.T) {
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 		SetValues: map[string]string{
 			"tls.certs.selfSigner.enabled": "false",
-			"tls.certs.certManager": "true",
+			"tls.certs.certManager":        "true",
 		},
 	}
 
@@ -132,7 +132,7 @@ func TestHelmSelfCertSignerRole(t *testing.T) {
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 		SetValues: map[string]string{
 			"tls.certs.selfSigner.enabled": "false",
-			"tls.certs.certManager": "true",
+			"tls.certs.certManager":        "true",
 		},
 	}
 
@@ -163,7 +163,7 @@ func TestHelmSelfCertSignerRoleBinding(t *testing.T) {
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 		SetValues: map[string]string{
 			"tls.certs.selfSigner.enabled": "false",
-			"tls.certs.certManager": "true",
+			"tls.certs.certManager":        "true",
 		},
 	}
 
@@ -194,7 +194,7 @@ func TestHelmSelfCertSignerJob(t *testing.T) {
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 		SetValues: map[string]string{
 			"tls.certs.selfSigner.enabled": "false",
-			"tls.certs.certManager": "true",
+			"tls.certs.certManager":        "true",
 		},
 	}
 
@@ -233,7 +233,7 @@ func TestHelmSelfCertSignerCronJob(t *testing.T) {
 			"Self Signer disable",
 			map[string]string{
 				"tls.certs.selfSigner.enabled": "false",
-				"tls.certs.certManager": "true",
+				"tls.certs.certManager":        "true",
 			},
 		},
 		{
@@ -368,7 +368,7 @@ func TestHelmSelfCertSignerStatefulSet(t *testing.T) {
 			"Self Signer disable",
 			map[string]string{
 				"tls.certs.selfSigner.enabled": "false",
-				"tls.certs.certManager": "true",
+				"tls.certs.certManager":        "true",
 			},
 			"copy-certs",
 		},


### PR DESCRIPTION
Changed the workflow of CI:
- Added a job which will check the tag is increased or not if the cert utility has been changed.
- Post job will build the new tag mentioned in values.yaml and push it to the repo. This will be done only if the utility has been changed.
- Now, we are using the tag of values.yaml, so no more need of TAG env variable in tests