### PR TITLE
Fix the job failure on merging the PRs without tag change

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,8 +27,9 @@ jobs:
         id: changetag
         shell: bash
         run: |
-          ./build/self-signer-utility.sh
-          if [[ $? -eq 0 ]]; then
+          output=$(./build/self-signer-utility.sh)
+          echo $output | grep "You have not changed the tag of selfSigner utility"
+          if [[ $? -ne 0 ]]; then
             echo ::set-output name=tagChange::true
           fi
 

--- a/build/self-signer-utility.sh
+++ b/build/self-signer-utility.sh
@@ -8,6 +8,4 @@ lastCommit=$(git rev-parse @~)
 git diff "${lastCommit}" "${currentCommit}" cockroachdb/values.yaml | grep -w "$tag" | grep +
 if [[ $? -ne 0 ]]; then
   echo "You have not changed the tag of selfSigner utility"
-  exit 1
 fi
-exit 0


### PR DESCRIPTION
RCA:
 In case of tag not changed: `build/self-signer-utility.sh` returns exit code 1 which is treated as failure by github actions.

Fix:
 Instead of using the return code in the github actions, use the output returned by the script