### PR TITLE
update cronjob version

### DIFF
--- a/cockroachdb/templates/cronjob-ca-certSelfSigner.yaml
+++ b/cockroachdb/templates/cronjob-ca-certSelfSigner.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.tls.enabled (and .Values.tls.certs.selfSigner.enabled (not .Values.tls.certs.selfSigner.caProvided)) }}
   {{- if .Values.tls.certs.selfSigner.rotateCerts }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "rotatecerts.fullname" . }}

--- a/cockroachdb/templates/cronjob-client-node-certSelfSigner.yaml
+++ b/cockroachdb/templates/cronjob-client-node-certSelfSigner.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.tls.certs.selfSigner.enabled .Values.tls.certs.selfSigner.rotateCerts }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "rotatecerts.fullname" . }}-client


### PR DESCRIPTION
update cronjob version:
```
W1006 08:01:00.814415   15161 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
W1006 08:01:00.814415   15161 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
```