### PR TITLE
Add extraPodSpec to statefulset and init job

### DIFF
--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -262,4 +262,7 @@ spec:
           {{- end }}
           {{- end }}
     {{- end }}
+    {{- with .Values.init.extraPodSpec -}}
+      {{- . | toYaml | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -339,6 +339,9 @@ spec:
           secret:
             secretName: {{ template "cockroachdb.fullname" . }}-log-config
       {{- end }}
+      {{- with .Values.statefulset.extraPodSpec -}}
+        {{- . | toYaml | nindent 6 }}
+      {{- end }}
 {{- if .Values.storage.persistentVolume.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -260,6 +260,10 @@ statefulset:
     #   scheme: HTTPS
     # initialDelaySeconds: 30
     # periodSeconds: 5
+  
+  # Add extra fields to the statefulset pod spec
+  extraPodSpec: {} 
+  # shareProcessNamespace: true
 
 service:
   ports:
@@ -418,6 +422,11 @@ init:
     #     schedule:
     #       # https://www.cockroachlabs.com/docs/stable/create-schedule-for-backup.html#schedule-options
     #       options: [first_run = 'now']
+    
+    
+  # Add extra fields to the init job pod spec
+  extraPodSpec: {} 
+  # shareProcessNamespace: true
 
 
 # Whether to run securely using TLS certificates.


### PR DESCRIPTION
This PR allows adding arbitrary values to the statefulset's pod spec. (As well as the init job.) This is needed to allow setting `shareProcessNamespace: true` to the pod spec to accommodate Hashicorp Vault injected dynamic certificates. 