### PR TITLE
Tidying up the Makefile to make it easy to run tests locally.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 2
 
       - name: Install yq
-        run: make install-yq
+        run: make bin/yq
 
       - name: Check Tag Change
         id: changetag
@@ -51,7 +51,7 @@ jobs:
           password: ${{ secrets.GCR_HELM_CHART_SA_JSON }}
 
       - name: Build Self-signer
-        run: make build-self-signer
+        run: make build/self-signer
 
       - name: Push Self-signer
-        run: make push-self-signer
+        run: make push/self-signer

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,11 +61,8 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
-      - name: Get repositories
-        uses: hiberbee/github-action-helm@latest
-
       - name: Lint chart
-        run: helm lint cockroachdb
+        run: make test/lint
         working-directory: .
 
   # pre job to run the unit tests
@@ -84,14 +81,11 @@ jobs:
         with:
           go-version: 1.15
 
-      - name: Install cockroach binary
-        run: make install-cockroach
- 
       - name: HelmTemplate
-        run: go test -v ./tests/template/...
+        run: make test/template
 
       - name: Unit
-        run: go test -v ./pkg/...
+        run: make test/units
 
   self-signer-tag-change:
     name: Tag Change
@@ -107,7 +101,7 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Install yq
-        run: make install-yq
+        run: make bin/yq
 
       - name: Verify tag change
         id: changetag
@@ -127,25 +121,13 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
-      - name: Install Kind
-        uses: helm/kind-action@v1.2.0
-
-      - name: Install cockroach binary
-        run: make install-cockroach
-
-      - name: Build Self-signer
-        run: make build-self-signer
-
-      - name: Load docker images to kind
-        run: make load-docker-image-to-kind
-
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.15
 
       - name: Run E2E Test
-        run: go test -v ./tests/e2e/install/...
+        run: make test/e2e/install
 
   helm-rotate-cert-e2e:
     name: Helm-rotate-cert-Test
@@ -157,22 +139,10 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
-      - name: Install Kind
-        uses: helm/kind-action@v1.2.0
-
-      - name: Install cockroach binary
-        run: make install-cockroach
-
-      - name: Build Self-signer
-        run: make build-self-signer
-
-      - name: Load docker images to kind
-        run: make load-docker-image-to-kind
-
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.15
 
       - name: Run E2E Test
-        run: go test -v ./tests/e2e/rotate/...
+        run: make test/e2e/rotate

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+bin/
+build/artifacts

--- a/Makefile
+++ b/Makefile
@@ -1,50 +1,100 @@
+COCKROACH_BIN ?= https://binaries.cockroachdb.com/cockroach-v20.2.5.linux-amd64.tgz
+HELM_BIN ?= https://get.helm.sh/helm-v3.8.0-linux-amd64.tar.gz
+KIND_BIN ?= https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+KUBECTL_BIN ?= https://dl.k8s.io/release/v1.23.3/bin/linux/amd64/kubectl
+YQ_BIN ?= https://github.com/mikefarah/yq/releases/download/2.2.1/yq_linux_amd64
+
+KIND_CLUSTER ?= chart-testing
 REPOSITORY ?= gcr.io/cockroachlabs-helm-charts/cockroach-self-signer-cert
 
 .DEFAULT_GOAL := all
 all: build
 
+BOLD = \033[1m
+CLEAR = \033[0m
+CYAN = \033[36m
+
+help: ## Display this help
+	@awk '\
+		BEGIN {FS = ":.*##"; printf "Usage: make $(CYAN)<target>$(CLEAR)\n"} \
+		/^[a-z0-9]+([\/]%)?([\/](%-)?[a-z\-0-9%]+)*:.*? ##/ { printf "  $(CYAN)%-15s$(CLEAR) %s\n", $$1, $$2 } \
+		/^##@/ { printf "\n$(BOLD)%s$(CLEAR)\n", substr($$0, 5) }' \
+		$(MAKEFILE_LIST)
+
+##@ Build
+
 .PHONY: build
-build:
-	build/make.sh
+build: build/chart build/self-signer ## build the helm chart and self-signer
 
-.PHONY: lint
-lint:
-	build/lint.sh
+build/chart: bin/helm ## build the helm chart to build/artifacts
+	@build/make.sh
 
-.PHONY: release
-release:
-	build/release.sh
+build/self-signer: bin/yq ## build the self-signer image
+	@docker build \
+		-f build/docker-image/Dockerfile \
+		-t ${REPOSITORY}:$(shell bin/yq r ./cockroachdb/values.yaml 'tls.selfSigner.image.tag') .
 
-.PHONY: clean
-clean:
-	rm -r build/artifacts/
+##@ Release
 
-get-tag: install-yq
-	yq r ./cockroachdb/values.yaml 'tls.selfSigner.image.tag'
+release: ## publish the build artifacts to S3
+	@build/release.sh
 
-build-self-signer: install-yq
-	$(eval TAG=$(shell yq r ./cockroachdb/values.yaml 'tls.selfSigner.image.tag'))
-	docker build -f build/docker-image/Dockerfile -t ${REPOSITORY}:${TAG} .
+push/self-signer: bin/yq ## push the self-signer image
+	@docker push ${REPOSITORY}:$(shell bin/yq r ./cockroachdb/values.yaml 'tls.selfSigner.image.tag')
 
-push-self-signer:
-	$(eval TAG=$(shell yq r ./cockroachdb/values.yaml 'tls.selfSigner.image.tag'))
-	docker push ${REPOSITORY}:${TAG}
+##@ Dev
+dev/clean: ## remove built artifacts
+	@rm -r build/artifacts/
 
-install-yq:
-	curl -Lo yq https://github.com/mikefarah/yq/releases/download/2.2.1/yq_linux_amd64 && \
-	chmod +x yq && sudo mv yq /usr/bin/
+##@ Test
 
-install-cockroach:
-	sudo apt-get install wget -y
-	wget https://binaries.cockroachdb.com/cockroach-v20.2.5.linux-amd64.tgz
-	tar zxf cockroach-v20.2.5.linux-amd64.tgz
-	sudo cp cockroach-v20.2.5.linux-amd64/cockroach /usr/local/bin/
+test/cluster: bin/kind ## start a local kind cluster for testing
+	@bin/kind get clusters -q | grep $(KIND_CLUSTER) || bin/kind create cluster --name $(KIND_CLUSTER)
 
-load-docker-image-to-kind:
-	$(eval TAG=$(shell yq r ./cockroachdb/values.yaml 'tls.selfSigner.image.tag'))
-	wget https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
-	sudo mv kind-linux-amd64 /usr/local/bin/kind
-	sudo chmod +x /usr/local/bin/kind
-	docker pull cockroachdb/cockroach:v21.1.1
-	kind load docker-image ${REPOSITORY}:${TAG} --name chart-testing
-	kind load docker-image cockroachdb/cockroach:v21.1.1 --name chart-testing
+test/e2e/%: PKG=$*
+test/e2e/%: bin/cockroach bin/kubectl build/self-signer test/publish-images-to-kind ## run e2e tests for package (e.g. install or rotate)
+	@PATH="$(PWD)/bin:${PATH}" go test -v ./tests/e2e/$(PKG)/...
+
+test/lint: bin/helm ## lint the helm chart
+	@build/lint.sh && bin/helm lint cockroachdb
+
+test/publish-images-to-kind: bin/yq test/cluster ## publish signer and cockroach image to local kind registry
+	@docker pull cockroachdb/cockroach:v21.1.1
+	@bin/kind load docker-image cockroachdb/cockroach:v21.1.1 --name $(KIND_CLUSTER)
+	@bin/kind load docker-image \
+		${REPOSITORY}:$(shell bin/yq r ./cockroachdb/values.yaml 'tls.selfSigner.image.tag') \
+		--name $(KIND_CLUSTER)
+
+test/template: bin/cockroach bin/helm ## Run template tests
+	@PATH="$(PWD)/bin:${PATH}" go test -v ./tests/template/...
+
+test/units: bin/cockroach ## Run unit tests in ./pkg/...
+	@PATH="$(PWD)/bin:${PATH}" go test -v ./pkg/...
+
+##@ Binaries
+bin: bin/cockroach bin/helm bin/kind bin/kubectl bin/yq ## install all binaries
+
+bin/cockroach: ## install cockroach
+	@mkdir -p bin
+	@curl -L $(COCKROACH_BIN) | tar -xzf - -C bin/ --strip-components 1
+	@rm -rf bin/lib
+
+bin/helm: ## install helm
+	@mkdir -p bin
+	@curl -L $(HELM_BIN) | tar -xzf - -C bin/ --strip-components 1
+	@rm -f bin/README.md bin/LICENSE
+
+bin/kind: ## install kind
+	@mkdir -p bin
+	@curl -Lo bin/kind $(KIND_BIN)	
+	@chmod +x bin/kind
+
+bin/kubectl: ## install kubectl
+	@mkdir -p bin
+	@curl -Lo bin/kubectl $(KUBECTL_BIN)
+	@chmod +x bin/kubectl
+
+bin/yq: ## install yq
+	@mkdir -p bin
+	@curl -Lo bin/yq $(YQ_BIN)
+	@chmod +x bin/yq


### PR DESCRIPTION
While looking into #220 I find it a bit of a pain to get everything
right in order to setup a test. Rather than forgetting and having to
figure it out again later, I figured I'd codify it.

Running `make help` will spit out a list of all targets. All binaries
needed by the tests/dev env will be installed as needed into `./bin`
which has been gitignored along with the artifacts directory.

Run e2e tests with `make test/e2e/install`, templates via `make
tests/template', and unit tests with `make test/units`. GitHub workflow
files have been updated accordingly.

Local runs by changing whatever you want in _./cockroachdb_, then running:

* `make bin` - ensures all binaries are install in _./bin_
* `make test/cluster` - starts a kind cluster
* `bin/helm install crdb ./cockroachdb` - installs the chart 
* `bin/kind delete clusters --name chart-testing` - drop the cluster