### PR TITLE
Add bin/ prefix in self-signer-utility.sh

### DIFF
--- a/build/self-signer-utility.sh
+++ b/build/self-signer-utility.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-tag=$(yq r ./cockroachdb/values.yaml 'tls.selfSigner.image.tag')
+tag=$(bin/yq r ./cockroachdb/values.yaml 'tls.selfSigner.image.tag')
 echo "Your current tag is ${tag}"
 currentCommit=$(git rev-parse HEAD)
 lastCommit=$(git rev-parse @~)


### PR DESCRIPTION
With the updates to the Makefile, binaries are now in bin directory
rather than globally on the path. I've updated the self-signer utility
script (used in the build action) to use bin/yq for fetching the current
tag.