### PR TITLE
Fix broken db provisioning command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,18 @@
-COCKROACH_BIN ?= https://binaries.cockroachdb.com/cockroach-v20.2.5.linux-amd64.tgz
-HELM_BIN ?= https://get.helm.sh/helm-v3.8.0-linux-amd64.tar.gz
-KIND_BIN ?= https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
-KUBECTL_BIN ?= https://dl.k8s.io/release/v1.23.3/bin/linux/amd64/kubectl
-YQ_BIN ?= https://github.com/mikefarah/yq/releases/download/2.2.1/yq_linux_amd64
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+  COCKROACH_BIN ?= https://binaries.cockroachdb.com/cockroach-v20.2.5.linux-amd64.tgz
+  HELM_BIN ?= https://get.helm.sh/helm-v3.8.0-linux-amd64.tar.gz
+  KIND_BIN ?= https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+  KUBECTL_BIN ?= https://dl.k8s.io/release/v1.23.3/bin/linux/amd64/kubectl
+  YQ_BIN ?= https://github.com/mikefarah/yq/releases/download/2.2.1/yq_linux_amd64
+endif
+ifeq ($(UNAME_S),Darwin)
+  COCKROACH_BIN ?= https://binaries.cockroachdb.com/cockroach-v20.2.5.darwin-10.9-amd64.tgz
+  HELM_BIN ?= https://get.helm.sh/helm-v3.8.0-darwin-amd64.tar.gz
+  KIND_BIN ?= https://kind.sigs.k8s.io/dl/v0.11.1/kind-darwin-amd64
+  KUBECTL_BIN ?= https://dl.k8s.io/release/v1.23.3/bin/darwin/amd64/kubectl
+  YQ_BIN ?= https://github.com/mikefarah/yq/releases/download/2.2.1/yq_darwin_amd64
+endif
 
 KIND_CLUSTER ?= chart-testing
 REPOSITORY ?= gcr.io/cockroachlabs-helm-charts/cockroach-self-signer-cert
@@ -52,7 +62,7 @@ test/cluster: bin/kind ## start a local kind cluster for testing
 	@bin/kind get clusters -q | grep $(KIND_CLUSTER) || bin/kind create cluster --name $(KIND_CLUSTER)
 
 test/e2e/%: PKG=$*
-test/e2e/%: bin/cockroach bin/kubectl build/self-signer test/publish-images-to-kind ## run e2e tests for package (e.g. install or rotate)
+test/e2e/%: bin/cockroach bin/kubectl bin/helm build/self-signer test/publish-images-to-kind ## run e2e tests for package (e.g. install or rotate)
 	@PATH="$(PWD)/bin:${PATH}" go test -v ./tests/e2e/$(PKG)/...
 
 test/lint: bin/helm ## lint the helm chart

--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -133,9 +133,6 @@ spec:
                     {{- else }}
                     --insecure \
                     {{- end }}
-                    {{- with index .Values.conf "cluster-name" }}
-                    --cluster-name={{.}} \
-                    {{- end }}
                     --host={{ template "cockroachdb.fullname" . }}-0.{{ template "cockroachdb.fullname" . -}}
                             :{{ .Values.service.ports.grpc.internal.port | int64 }} \
                     --execute="

--- a/tests/e2e/install/cockroachdb_helm_e2e_test.go
+++ b/tests/e2e/install/cockroachdb_helm_e2e_test.go
@@ -50,10 +50,16 @@ func TestCockroachDbHelmInstall(t *testing.T) {
 	// ... and make sure to delete the namespace at the end of the test
 	defer k8s.DeleteNamespace(t, kubectlOptions, namespaceName)
 
+	const testDBName = "testdb"
+
 	// Setup the args. For this test, we will set the following input values:
 	options := &helm.Options{
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 		SetValues: map[string]string{
+			"conf.cluster-name": "test",
+			"init.provisioning.enabled": "true",
+			"init.provisioning.databases[0].name": testDBName,
+			"init.provisioning.databases[0].owners[0]": "root",
 			"storage.persistentVolume.size": "1Gi",
 		},
 	}
@@ -89,7 +95,8 @@ func TestCockroachDbHelmInstall(t *testing.T) {
 	testutil.RequireCertificatesToBeValid(t, crdbCluster)
 	testutil.RequireClusterToBeReadyEventuallyTimeout(t, crdbCluster, 500*time.Second)
 	time.Sleep(20 * time.Second)
-	testutil.RequireDatabaseToFunction(t, crdbCluster, false, true)
+	testutil.RequireCRDBToFunction(t, crdbCluster, false)
+	testutil.RequireDatabaseToFunction(t, crdbCluster, testDBName)
 }
 
 func TestCockroachDbHelmInstallWithCAProvided(t *testing.T) {
@@ -180,7 +187,7 @@ func TestCockroachDbHelmInstallWithCAProvided(t *testing.T) {
 	testutil.RequireCertificatesToBeValid(t, crdbCluster)
 	testutil.RequireClusterToBeReadyEventuallyTimeout(t, crdbCluster, 500*time.Second)
 	time.Sleep(20 * time.Second)
-	testutil.RequireDatabaseToFunction(t, crdbCluster, false, true)
+	testutil.RequireCRDBToFunction(t, crdbCluster, false)
 }
 
 // Test to check migration from Bring your own certificate method to self-sginer cert utility
@@ -334,7 +341,7 @@ func TestCockroachDbHelmMigration(t *testing.T) {
 	testutil.RequireCertificatesToBeValid(t, crdbCluster)
 	testutil.RequireClusterToBeReadyEventuallyTimeout(t, crdbCluster, 500*time.Second)
 	time.Sleep(20 * time.Second)
-	testutil.RequireDatabaseToFunction(t, crdbCluster, false, true)
+	testutil.RequireCRDBToFunction(t, crdbCluster, false)
 }
 
 func TestCockroachDbWithInsecureMode(t *testing.T) {
@@ -382,5 +389,5 @@ func TestCockroachDbWithInsecureMode(t *testing.T) {
 
 	testutil.RequireClusterToBeReadyEventuallyTimeout(t, crdbCluster, 500*time.Second)
 	time.Sleep(20 * time.Second)
-	testutil.RequireDatabaseToFunction(t, crdbCluster, false, false)
+	testutil.RequireCRDBToFunction(t, crdbCluster, false)
 }

--- a/tests/e2e/rotate/cockroachdb_rotate_certs_test.go
+++ b/tests/e2e/rotate/cockroachdb_rotate_certs_test.go
@@ -95,7 +95,7 @@ func TestCockroachDbRotateCertificates(t *testing.T) {
 	testutil.RequireClusterToBeReadyEventuallyTimeout(t, crdbCluster, 500*time.Second)
 	time.Sleep(20 * time.Second)
 	// This will create a database, a table and insert two rows into that table.
-	testutil.RequireDatabaseToFunction(t, crdbCluster, false, true)
+	testutil.RequireCRDBToFunction(t, crdbCluster, false)
 
 	t.Log("Rotating the Client and Node certificate for the CRDB")
 
@@ -113,7 +113,7 @@ func TestCockroachDbRotateCertificates(t *testing.T) {
 
 	time.Sleep(20 * time.Second)
 	// This will check after rotation the database is working properly.
-	testutil.RequireDatabaseToFunction(t, crdbCluster, true, true)
+	testutil.RequireCRDBToFunction(t, crdbCluster, true)
 
 	t.Log("Verify that client and node certificate duration is changed")
 	newClientCert := k8s.GetSecret(t, kubectlOptions, crdbCluster.ClientSecret)
@@ -136,7 +136,7 @@ func TestCockroachDbRotateCertificates(t *testing.T) {
 
 	time.Sleep(20 * time.Second)
 	// This will check after rotation the database is working properly.
-	testutil.RequireDatabaseToFunction(t, crdbCluster, true, true)
+	testutil.RequireCRDBToFunction(t, crdbCluster, true)
 
 	t.Log("Verify that CA certificate duration is changed")
 	newCaCert := k8s.GetSecret(t, kubectlOptions, crdbCluster.ClientSecret)

--- a/tests/testutil/require.go
+++ b/tests/testutil/require.go
@@ -113,9 +113,8 @@ func statefulSetIsReady(ss *appsv1.StatefulSet) bool {
 	return ss.Status.ReadyReplicas == ss.Status.Replicas
 }
 
-// RequireDatabaseToFunction creates a database, a table and insert two rows if it is a fresh install of the cluster.
-// If certificate is rotated and cluster rolling restart has happened, this will check that existing two rows are present.
-func RequireDatabaseToFunction(t *testing.T, crdbCluster CockroachCluster, rotate bool, isSecure bool) {
+func getDBConn(t *testing.T, crdbCluster CockroachCluster, dbName string) *sql.DB {
+	isSecure := crdbCluster.CaSecret != ""
 	sqlPort := int32(26257)
 	conn := &database.DBConnection{
 		Ctx:    context.TODO(),
@@ -126,7 +125,7 @@ func RequireDatabaseToFunction(t *testing.T, crdbCluster CockroachCluster, rotat
 		RestConfig:   crdbCluster.Cfg,
 		ServiceName:  fmt.Sprintf("%s-0.%s", crdbCluster.StatefulSetName, crdbCluster.StatefulSetName),
 		Namespace:    crdbCluster.Namespace,
-		DatabaseName: "system",
+		DatabaseName: dbName,
 
 		RunningInsideK8s:            false,
 		ClientCertificateSecretName: crdbCluster.ClientSecret,
@@ -136,7 +135,30 @@ func RequireDatabaseToFunction(t *testing.T, crdbCluster CockroachCluster, rotat
 	// Create a new database connection for the update.
 	db, err := database.NewDbConnection(conn)
 	require.NoError(t, err)
-	defer db.Close()
+	t.Cleanup(func() {
+		db.Close()
+	})
+	return db
+}
+
+// RequireDatabaseToFunction creates a table and insert two rows.
+func RequireDatabaseToFunction(t *testing.T, crdbCluster CockroachCluster, dbName string) {
+	db := getDBConn(t, crdbCluster, dbName)
+	if _, err := db.Exec("CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert two rows into the "accounts" table.
+	if _, err := db.Exec(
+		"INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// RequireCRDBToFunction creates a database, a table and insert two rows if it is a fresh install of the cluster.
+// If certificate is rotated and cluster rolling restart has happened, this will check that existing two rows are present.
+func RequireCRDBToFunction(t *testing.T, crdbCluster CockroachCluster, rotate bool) {
+	db := getDBConn(t, crdbCluster, "system")
 
 	if rotate {
 		t.Log("Verifying the existing data in the database after certificate rotation")


### PR DESCRIPTION
`sql` command does not have a `cluster-name`
flag. This causes the init process to fail.

This bug is reported in #220.