### PR TITLE
Version update automation

### DIFF
--- a/build/bump.go
+++ b/build/bump.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/Masterminds/semver/v3"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	chartsFile         = "cockroachdb/Chart.yaml"
+	valuesFile         = "cockroachdb/values.yaml"
+	readmeFile         = "cockroachdb/README.md"
+	chartsFileTemplate = "build/templates/Chart.yaml"
+	valuesFileTemplate = "build/templates/values.yaml"
+	readmeFileTemplate = "build/templates/README.md"
+)
+
+type templateArgs struct {
+	Version    string
+	AppVersion string
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: go run build/bump.go crdbversion")
+		os.Exit(1)
+	}
+	if err := run(os.Args[1]); err != nil {
+		fmt.Fprintf(os.Stderr, "cannot run: %s", err)
+		os.Exit(1)
+	}
+
+}
+
+func run(crdbVersion string) error {
+	// Trim the "v" prefix if exists. It will be added explicitly in the templates when needed.
+	crdbVersion = strings.TrimPrefix(crdbVersion, "v")
+	chartVersion, err := getChartVersion(chartsFile)
+	if err != nil {
+		return fmt.Errorf("cannot get chart version: %w", err)
+	}
+	// Bump the charts version to be nice to helm.
+	newChartVersion, err := bumpVersion(chartVersion)
+	if err != nil {
+		return fmt.Errorf("cannot bump chart version: %w", err)
+	}
+	args := templateArgs{
+		Version:    newChartVersion,
+		AppVersion: crdbVersion,
+	}
+	if err := processTemplate(
+		chartsFileTemplate,
+		chartsFile,
+		args,
+		fmt.Sprintf("# Generated file, DO NOT EDIT. Source: %s\n", chartsFileTemplate),
+	); err != nil {
+		return fmt.Errorf("cannot process %s -> %s: %w", chartsFileTemplate, chartsFile, err)
+	}
+	if err := processTemplate(
+		valuesFileTemplate,
+		valuesFile,
+		args,
+		fmt.Sprintf("# Generated file, DO NOT EDIT. Source: %s\n", valuesFileTemplate),
+	); err != nil {
+		return fmt.Errorf("cannot process %s -> %s: %w", valuesFileTemplate, valuesFile, err)
+	}
+	if err := processTemplate(
+		readmeFileTemplate,
+		readmeFile,
+		args,
+		fmt.Sprintf("<!--- Generated file, DO NOT EDIT. Source: %s --->\n", readmeFileTemplate),
+	); err != nil {
+		return fmt.Errorf("cannot process %s -> %s: %w", readmeFileTemplate, readmeFile, err)
+	}
+	return nil
+}
+
+// processTemplate reads a template file, applies the template arguments and writes it to the specified location
+func processTemplate(
+	templateFile string, outputFile string, args templateArgs, header string,
+) error {
+	t, err := template.ParseFiles(templateFile)
+	if err != nil {
+		return fmt.Errorf("failed to parse template %s: %w", templateFile, err)
+	}
+	var buf bytes.Buffer
+	err = t.Execute(&buf, args)
+	if err != nil {
+		return fmt.Errorf("cannot execute template: %w", err)
+	}
+	fileInfo, err := os.Stat(templateFile)
+	if err != nil {
+		return fmt.Errorf("cannot stat %s: %w", templateFile, err)
+	}
+	if err := os.WriteFile(outputFile, []byte(header+buf.String()), fileInfo.Mode()); err != nil {
+		return fmt.Errorf("cannot write file: %w", err)
+	}
+	return nil
+}
+
+// bumpVersion increases the patch release version (the last digit) of a given version
+func bumpVersion(version string) (string, error) {
+	semanticVersion, err := semver.NewVersion(version)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse version: %w", err)
+	}
+	nextVersion := semanticVersion.IncPatch()
+	return nextVersion.Original(), nil
+}
+
+// getChartVersion reads chart version from Chart.yaml file
+func getChartVersion(chartPath string) (string, error) {
+	chartContents, err := ioutil.ReadFile(chartPath)
+	if err != nil {
+		return "", fmt.Errorf("cannot open chart file %s: %w", chartPath, err)
+	}
+	// Minimal definition, only to extract the version
+	chart := struct {
+		Version string
+	}{}
+	if err := yaml.Unmarshal(chartContents, &chart); err != nil {
+		return "", fmt.Errorf("cannot unmarshal %s: %w", chartPath, err)
+	}
+	return chart.Version, nil
+}

--- a/build/teamcity-make-and-publish-charts-release.sh
+++ b/build/teamcity-make-and-publish-charts-release.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 remove_artifacts() {
-  make clean
+  rm -rfv ./build/artifacts
 }
 trap remove_artifacts EXIT
 

--- a/build/templates/Chart.yaml
+++ b/build/templates/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+name: cockroachdb
+home: https://www.cockroachlabs.com
+version: {{ .Version }}
+appVersion: {{ .AppVersion }}
+description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
+icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png
+sources:
+  - https://github.com/cockroachdb/cockroach
+maintainers:
+  - name: cockroachlabs
+    email: helm-charts@cockroachlabs.com

--- a/build/templates/README.md
+++ b/build/templates/README.md
@@ -1,0 +1,574 @@
+# CockroachDB Helm Chart
+
+[CockroachDB](https://github.com/cockroachdb/cockroach) - the open source, cloud-native distributed SQL database.
+
+## Documentation
+
+Below is a brief overview of operating the CockroachDB Helm Chart and some specific implementation details. For additional information on deploying CockroachDB, please see:
+> <https://www.cockroachlabs.com/docs/stable/orchestrate-cockroachdb-with-kubernetes.html>
+
+Note that the documentation requires Helm 3.0 or higher.
+
+## Prerequisites Details
+
+* Kubernetes 1.8
+* PV support on the underlying infrastructure (only if using `storage.persistentVolume`). [Docker for windows hostpath provisioner is not supported](https://github.com/cockroachdb/docs/issues/3184).
+* If you want to secure your cluster to use TLS certificates for all network communication, [Helm must be installed with RBAC privileges](https://helm.sh/docs/topics/rbac/) or else you will get an "attempt to grant extra privileges" error.
+
+## StatefulSet Details
+
+* <http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/>
+
+## StatefulSet Caveats
+
+* <http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/#limitations>
+
+## Chart Details
+
+This chart will do the following:
+
+* Set up a dynamically scalable CockroachDB cluster using a Kubernetes StatefulSet.
+
+## Add the CockroachDB Repository
+
+```shell
+helm repo add cockroachdb https://charts.cockroachdb.com/
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```shell
+helm install my-release cockroachdb/cockroachdb
+```
+
+Note that for a production cluster, you will likely want to override the following parameters in [`values.yaml`](values.yaml) with your own values.
+
+- `statefulset.resources.requests.memory` and `statefulset.resources.limits.memory` allocate memory resources to CockroachDB pods in your cluster.
+- `conf.cache` and `conf.max-sql-memory` are memory limits that we recommend setting to 1/4 of the above resource allocation. When running CockroachDB, you must set these limits explicitly to avoid running out of memory.
+- `storage.persistentVolume.size` defaults to `100Gi` of disk space per pod, which you may increase or decrease for your use case.
+- `storage.persistentVolume.storageClass` uses the default storage class for your environment. We strongly recommend that you specify a storage class which uses an SSD.
+- `tls.enabled` must be set to `yes`/`true` to deploy in secure mode.
+
+For more information on overriding the `values.yaml` parameters, please see:
+> <https://www.cockroachlabs.com/docs/stable/orchestrate-cockroachdb-with-kubernetes.html#step-2-start-cockroachdb>
+
+Confirm that all pods are `Running` successfully and init has been completed:
+
+```shell
+kubectl get pods
+```
+
+```
+NAME                                READY     STATUS      RESTARTS   AGE
+my-release-cockroachdb-0            1/1       Running     0          1m
+my-release-cockroachdb-1            1/1       Running     0          1m
+my-release-cockroachdb-2            1/1       Running     0          1m
+my-release-cockroachdb-init-k6jcr   0/1       Completed   0          1m
+```
+
+Confirm that persistent volumes are created and claimed for each pod:
+
+```shell
+kubectl get pv
+```
+
+```
+NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS    CLAIM                                      STORAGECLASS   REASON    AGE
+pvc-64878ebf-f3f0-11e8-ab5b-42010a8e0035   100Gi      RWO            Delete           Bound     default/datadir-my-release-cockroachdb-0   standard                 51s
+pvc-64945b4f-f3f0-11e8-ab5b-42010a8e0035   100Gi      RWO            Delete           Bound     default/datadir-my-release-cockroachdb-1   standard                 51s
+pvc-649d920d-f3f0-11e8-ab5b-42010a8e0035   100Gi      RWO            Delete           Bound     default/datadir-my-release-cockroachdb-2   standard                 51s
+```
+
+### Running in secure mode
+
+In order to set up a secure cockroachdb cluster set `tls.enabled` to `yes`/`true`
+
+There are 3 ways to configure a secure cluster, with this chart. This all relates to how the certificates are issued:
+
+* Self-signer (default)
+* Cert-manager
+* Manual
+
+#### Self-signer
+
+This is the default behaviour, and requires no configuration beyond setting certificate durations if user wants to set custom duration.
+
+If you are running in this mode, self-signed certificates are created by self-signed utility for the nodes and root client and are stored in a secret.
+You can look for the certificates created:
+```shell
+kubectl get secrets
+```
+
+```shell
+crdb-cockroachdb-ca-secret                 Opaque                                2      23s
+crdb-cockroachdb-client-secret             kubernetes.io/tls                     3      22s
+crdb-cockroachdb-node-secret               kubernetes.io/tls                     3      23s
+```
+
+
+#### Manual
+
+If you wish to supply the certificates to the nodes yourself set `tls.certs.provided` to `yes`/`true`. You may want to use this if you want to use a different certificate authority from the one being used by Kubernetes or if your Kubernetes cluster doesn't fully support certificate-signing requests. To use this, first set up your certificates and load them into your Kubernetes cluster as Secrets using the commands below:
+
+```shell
+$ mkdir certs
+$ mkdir my-safe-directory
+$ cockroach cert create-ca --certs-dir=certs --ca-key=my-safe-directory/ca.key
+$ cockroach cert create-client root --certs-dir=certs --ca-key=my-safe-directory/ca.key
+$ kubectl create secret generic cockroachdb-root --from-file=certs
+secret/cockroachdb-root created
+$ cockroach cert create-node --certs-dir=certs --ca-key=my-safe-directory/ca.key localhost 127.0.0.1 my-release-cockroachdb-public my-release-cockroachdb-public.my-namespace my-release-cockroachdb-public.my-namespace.svc.cluster.local *.my-release-cockroachdb *.my-release-cockroachdb.my-namespace *.my-release-cockroachdb.my-namespace.svc.cluster.local
+$ kubectl create secret generic cockroachdb-node --from-file=certs
+secret/cockroachdb-node created
+```
+
+> Note: The subject alternative names are based on a release called `my-release` in the `my-namespace` namespace. Make sure they match the services created with the release during `helm install`
+
+If your certificates are stored in tls secrets such as secrets generated by cert-manager, the secret will contain files named:
+
+* `ca.crt`
+* `tls.crt`
+* `tls.key`
+
+Cockroachdb, however, expects the files to be named like this:
+
+* `ca.crt`
+* `node.crt`
+* `node.key`
+* `client.root.crt`
+* `client.root.key`
+
+By enabling `tls.certs.tlsSecret` the tls secrets are projected on to the correct filenames, when they are mounted to the cockroachdb pods.
+
+#### Cert-manager
+
+If you wish to supply certificates with [cert-manager][3], set
+
+* `tls.certs.certManager` to `yes`/`true`
+* `tls.certs.certManagerIssuer` to an IssuerRef (as they appear in certificate resources) pointing to a clusterIssuer or issuer, you have set up in the cluster
+
+Example issuer:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cockroachdb-ca
+  namespace: cockroachdb
+data:
+  tls.crt: [BASE64 Encoded ca.crt]
+  tls.key: [BASE64 Encoded ca.key]
+type: kubernetes.io/tls
+---
+apiVersion: cert-manager.io/v1alpha3
+kind: Issuer
+metadata:
+  name: cockroachdb-cert-issuer
+  namespace: cockroachdb
+spec:
+  ca:
+    secretName: cockroachdb-ca
+```
+
+## Upgrading the cluster
+
+### Chart version 3.0.0 and after
+
+Launch a temporary interactive pod and start the built-in SQL client:
+
+```shell
+kubectl run cockroachdb --rm -it \
+--image=cockroachdb/cockroach \
+--restart=Never \
+-- sql --insecure --host=my-release-cockroachdb-public
+```
+
+> If you are running in secure mode, you will have to provide a client certificate to the cluster in order to authenticate, so the above command will not work. See [here](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/client-secure.yaml) for an example of how to set up an interactive SQL shell against a secure cluster or [here](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/example-app-secure.yaml) for an example application connecting to a secure cluster.
+
+Set `cluster.preserve_downgrade_option`, where `$current_version` is the CockroachDB version currently running (e.g., `19.2`):
+
+```sql
+> SET CLUSTER SETTING cluster.preserve_downgrade_option = '$current_version';
+```
+
+Exit the shell and delete the temporary pod:
+
+```sql
+> \q
+```
+
+Kick off the upgrade process by changing the new Docker image, where `$new_version` is the CockroachDB version to which you are upgrading:
+
+```shell
+helm upgrade my-release cockroachdb/cockroachdb \
+--set image.tag=$new_version \
+--reuse-values
+```
+
+Kubernetes will carry out a safe [rolling upgrade](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets) of your CockroachDB nodes one-by-one. Monitor the cluster's pods until all have been successfully restarted:
+
+```shell
+kubectl get pods
+```
+
+```
+NAME                                READY     STATUS              RESTARTS   AGE
+my-release-cockroachdb-0            1/1       Running             0          2m
+my-release-cockroachdb-1            1/1       Running             0          3m
+my-release-cockroachdb-2            1/1       Running             0          3m
+my-release-cockroachdb-3            0/1       ContainerCreating   0          25s
+my-release-cockroachdb-init-nwjkh   0/1       ContainerCreating   0          6s
+```
+
+```shell
+kubectl get pods \
+-o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[0].image}{"\n"}'
+```
+
+```
+my-release-cockroachdb-0    cockroachdb/cockroach:v{{ .AppVersion }}
+my-release-cockroachdb-1    cockroachdb/cockroach:v{{ .AppVersion }}
+my-release-cockroachdb-2    cockroachdb/cockroach:v{{ .AppVersion }}
+my-release-cockroachdb-3    cockroachdb/cockroach:v{{ .AppVersion }}
+```
+
+Resume normal operations. Once you are comfortable that the stability and performance of the cluster is what you'd expect post-upgrade, finalize the upgrade:
+
+```shell
+kubectl run cockroachdb --rm -it \
+--image=cockroachdb/cockroach \
+--restart=Never \
+-- sql --insecure --host=my-release-cockroachdb-public
+```
+
+```sql
+> RESET CLUSTER SETTING cluster.preserve_downgrade_option;
+> \q
+```
+
+### Chart versions prior to 3.0.0
+
+Due to a change in the label format in version 3.0.0 of this chart, upgrading requires that you delete the StatefulSet. Luckily there is a way to do it without actually deleting all the resources managed by the StatefulSet. Use the workaround below to upgrade from charts versions previous to 3.0.0:
+
+Get the new labels from the specs rendered by Helm:
+
+```shell
+helm template -f deploy.vals.yml cockroachdb/cockroachdb -x templates/statefulset.yaml \
+| yq r - spec.template.metadata.labels
+```
+
+```
+app.kubernetes.io/name: cockroachdb
+app.kubernetes.io/instance: my-release
+app.kubernetes.io/component: cockroachdb
+```
+
+Place the new labels on all pods of the StatefulSet (change `my-release-cockroachdb-0` to the name of each pod):
+
+```shell
+kubectl label pods my-release-cockroachdb-0 \
+app.kubernetes.io/name=cockroachdb \
+app.kubernetes.io/instance=my-release \
+app.kubernetes.io/component=cockroachdb
+```
+
+Delete the StatefulSet without deleting pods:
+
+```shell
+kubectl delete statefulset my-release-cockroachdb --cascade=false
+```
+
+Verify that no pod is deleted and then upgrade as normal. A new StatefulSet will be created, taking over the management of the existing pods and upgrading them if needed.
+
+### See also
+
+For more information about upgrading a cluster to the latest major release of CockroachDB, see [Upgrade to CockroachDB v21.1](https://www.cockroachlabs.com/docs/stable/upgrade-cockroach-version.html).
+
+Note that there are some backward-incompatible changes to SQL features between versions 20.2 and 21.1. For details, see the [CockroachDB v{{ .AppVersion }} release notes](https://www.cockroachlabs.com/docs/releases/v{{ .AppVersion }}.html#backward-incompatible-changes).
+
+## Configuration
+
+The following table lists the configurable parameters of the CockroachDB chart and their default values.
+For details see the [`values.yaml`](values.yaml) file.
+
+| Parameter                                                 | Description                                                     | Default                                               |
+| ---------                                                 | -----------                                                     | -------                                               |
+| `clusterDomain`                                           | Cluster's default DNS domain                                    | `cluster.local`                                       |
+| `conf.attrs`                                              | CockroachDB node attributes                                     | `[]`                                                  |
+| `conf.cache`                                              | Size of CockroachDB's in-memory cache                           | `25%`                                                 |
+| `conf.cluster-name`                                       | Name of CockroachDB cluster                                     | `""`                                                  |
+| `conf.disable-cluster-name-verification`                  | Disable CockroachDB cluster name verification                   | `no`                                                  |
+| `conf.join`                                               | List of already-existing CockroachDB instances                  | `[]`                                                  |
+| `conf.max-disk-temp-storage`                              | Max storage capacity for temp data                              | `0`                                                   |
+| `conf.max-offset`                                         | Max allowed clock offset for CockroachDB cluster                | `500ms`                                               |
+| `conf.max-sql-memory`                                     | Max memory to use processing SQL querie                         | `25%`                                                 |
+| `conf.locality`                                           | Locality attribute for this deployment                          | `""`                                                  |
+| `conf.single-node`                                        | Disable CockroachDB clustering (standalone mode)                | `no`                                                  |
+| `conf.sql-audit-dir`                                      | Directory for SQL audit log                                     | `""`                                                  |
+| `conf.port`                                               | CockroachDB primary serving port in Pods                        | `26257`                                               |
+| `conf.http-port`                                          | CockroachDB HTTP port in Pods                                   | `8080`                                                |
+| `conf.path`                                               | CockroachDB data directory mount path                           | `cockroach-data`                                      |
+| `conf.store.enabled`                                      | Enable store configuration for CockroachDB                      | `false`                                               |
+| `conf.store.type`                                         | CockroachDB storage type                                        | `""`                                                  |
+| `conf.store.size`                                         | CockroachDB storage size                                        | `""`                                                  |
+| `conf.store.attrs`                                        | CockroachDB storage attributes                                  | `""`                                                  |
+| `image.repository`                                        | Container image name                                            | `cockroachdb/cockroach`                               |
+| `image.tag`                                               | Container image tag                                             | `v{{ .AppVersion }}`                                             |
+| `image.pullPolicy`                                        | Container pull policy                                           | `IfNotPresent`                                        |
+| `image.credentials`                                       | `registry`, `user` and `pass` credentials to pull private image | `{}`                                                  |
+| `statefulset.replicas`                                    | StatefulSet replicas number                                     | `3`                                                   |
+| `statefulset.updateStrategy`                              | Update strategy for StatefulSet Pods                            | `{"type": "RollingUpdate"}`                           |
+| `statefulset.podManagementPolicy`                         | `OrderedReady`/`Parallel` Pods creation/deletion order          | `Parallel`                                            |
+| `statefulset.budget.maxUnavailable`                       | k8s PodDisruptionBudget parameter                               | `1`                                                   |
+| `statefulset.args`                                        | Extra command-line arguments                                    | `[]`                                                  |
+| `statefulset.env`                                         | Extra env vars                                                  | `[]`                                                  |
+| `statefulset.secretMounts`                                | Additional Secrets to mount at cluster members                  | `[]`                                                  |
+| `statefulset.labels`                                      | Additional labels of StatefulSet and its Pods                   | `{"app.kubernetes.io/component": "cockroachdb"}`      |
+| `statefulset.annotations`                                 | Additional annotations of StatefulSet Pods                      | `{}`                                                  |
+| `statefulset.nodeAffinity`                                | [Node affinity rules][2] of StatefulSet Pods                    | `{}`                                                  |
+| `statefulset.podAffinity`                                 | [Inter-Pod affinity rules][1] of StatefulSet Pods               | `{}`                                                  |
+| `statefulset.podAntiAffinity`                             | [Anti-affinity rules][1] of StatefulSet Pods                    | auto                                                  |
+| `statefulset.podAntiAffinity.topologyKey`                 | The topologyKey for auto [anti-affinity rules][1]               | `kubernetes.io/hostname`                              |
+| `statefulset.podAntiAffinity.type`                        | Type of auto [anti-affinity rules][1]                           | `soft`                                                |
+| `statefulset.podAntiAffinity.weight`                      | Weight for `soft` auto [anti-affinity rules][1]                 | `100`                                                 |
+| `statefulset.nodeSelector`                                | Node labels for StatefulSet Pods assignment                     | `{}`                                                  |
+| `statefulset.priorityClassName`                           | [PriorityClassName][4] for StatefulSet Pods                     | `""`                                                  |
+| `statefulset.tolerations`                                 | Node taints to tolerate by StatefulSet Pods                     | `[]`                                                  |
+| `statefulset.topologySpreadConstraints`                   | [Topology Spread Constraints rules][5] of StatefulSet Pods      | auto                                                  |
+| `statefulset.topologySpreadConstraints.maxSkew`           | Degree to which Pods may be unevenly distributed                | `1`                                                   |
+| `statefulset.topologySpreadConstraints.topologyKey`       | The key of node labels                                          | `topology.kubernetes.io/zone`                         |
+| `statefulset.topologySpreadConstraints.whenUnsatisfiable` | `ScheduleAnyway`/`DoNotSchedule` for unsatisfiable constraints  | `ScheduleAnyway`                                      |
+| `statefulset.resources`                                   | Resource requests and limits for StatefulSet Pods               | `{}`                                                  |
+| `statefulset.customLivenessProbe`                         | Custom Liveness probe                                           | `{}`                                             |
+| `statefulset.customReadinessProbe`                        | Custom Rediness probe                                           | `{}`                                             |
+| `service.ports.grpc.external.port`                        | CockroachDB primary serving port in Services                    | `26257`                                               |
+| `service.ports.grpc.external.name`                        | CockroachDB primary serving port name in Services               | `grpc`                                                |
+| `service.ports.grpc.internal.port`                        | CockroachDB inter-communication port in Services                | `26257`                                               |
+| `service.ports.grpc.internal.name`                        | CockroachDB inter-communication port name in Services           | `grpc-internal`                                       |
+| `service.ports.http.port`                                 | CockroachDB HTTP port in Services                               | `8080`                                                |
+| `service.ports.http.name`                                 | CockroachDB HTTP port name in Services                          | `http`                                                |
+| `service.public.type`                                     | Public Service type                                             | `ClusterIP`                                           |
+| `service.public.labels`                                   | Additional labels of public Service                             | `{"app.kubernetes.io/component": "cockroachdb"}`      |
+| `service.public.annotations`                              | Additional annotations of public Service                        | `{}`                                                  |
+| `service.discovery.labels`                                | Additional labels of discovery Service                          | `{"app.kubernetes.io/component": "cockroachdb"}`      |
+| `service.discovery.annotations`                           | Additional annotations of discovery Service                     | `{}`                                                  |
+| `ingress.enabled`                                         | Enable ingress resource for CockroachDB                         | `false`                                               |
+| `ingress.labels`                                          | Additional labels of Ingress                                    | `{}`                                                  |
+| `ingress.annotations`                                     | Additional annotations of Ingress                               | `{}`                                                  |
+| `ingress.paths`                                           | Paths for the default host                                      | `[/]`                                                 |
+| `ingress.hosts`                                           | CockroachDB Ingress hostnames                                   | `[]`                                                  |
+| `ingress.tls[0].hosts`                                    | CockroachDB Ingress tls hostnames                               | `nil`                                                 |
+| `ingress.tls[0].secretName`                               | CockroachDB Ingress tls secret name                             | `nil`                                                 |
+| `serviceMonitor.enabled`                                  | Create [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/design.md#servicemonitor) Resource for scraping metrics using [PrometheusOperator](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/getting-started.md#prometheus-operator)                     | `false`                                             |
+| `serviceMonitor.labels`                                   | Additional labels of ServiceMonitor                             | `{}`                                                  |
+| `serviceMonitor.annotations`                              | Additional annotations of ServiceMonitor                        | `{}`                                                  |
+| `serviceMonitor.interval`                                 | ServiceMonitor scrape metrics interval                          | `10s`                                                 |
+| `serviceMonitor.scrapeTimeout`                            | ServiceMonitor scrape timeout                                   | `nil`                                                 |
+| `serviceMonitor.namespaced`                               | Limit ServiceMonitor to current namespace                       | `false`                                               |
+| `storage.hostPath`                                        | Absolute path on host to store data                             | `""`                                                  |
+| `storage.persistentVolume.enabled`                        | Whether to use PersistentVolume to store data                   | `yes`                                                 |
+| `storage.persistentVolume.size`                           | PersistentVolume size                                           | `100Gi`                                               |
+| `storage.persistentVolume.storageClass`                   | PersistentVolume class                                          | `""`                                                  |
+| `storage.persistentVolume.labels`                         | Additional labels of PersistentVolumeClaim                      | `{}`                                                  |
+| `storage.persistentVolume.annotations`                    | Additional annotations of PersistentVolumeClaim                 | `{}`                                                  |
+| `init.labels`                                             | Additional labels of init Job and its Pod                       | `{"app.kubernetes.io/component": "init"}`             |
+| `init.annotations`                                        | Additional labels of the Pod of init Job                        | `{}`                                                  |
+| `init.affinity`                                           | [Affinity rules][2] of init Job Pod                             | `{}`                                                  |
+| `init.nodeSelector`                                       | Node labels for init Job Pod assignment                         | `{}`                                                  |
+| `init.tolerations`                                        | Node taints to tolerate by init Job Pod                         | `[]`                                                  |
+| `init.resources`                                          | Resource requests and limits for the Pod of init Job            | `{}`                                                  |
+| `tls.enabled`                                             | Whether to run securely using TLS certificates                  | `no`                                                  |
+| `tls.serviceAccount.create`                               | Whether to create a new RBAC service account                    | `yes`                                                 |
+| `tls.serviceAccount.name`                                 | Name of RBAC service account to use                             | `""`                                                  |
+| `tls.certs.provided`                                      | Bring your own certs scenario, i.e certificates are provided    | `no`                                                  |
+| `tls.certs.clientRootSecret`                              | If certs are provided, secret name for client root cert         | `cockroachdb-root`                                    |
+| `tls.certs.nodeSecret`                                    | If certs are provided, secret name for node cert                | `cockroachdb-node`                                    |
+| `tls.certs.tlsSecret`                                     | Own certs are stored in TLS secret                              | `no`                                                  |
+| `tls.certs.selfSigner.enabled`                            | Whether cockroachdb should generate its own self-signed certs   | `true`                                           |
+| `tls.certs.selfSigner.caProvided`                         | Bring your own CA scenario. This CA will be used to generate node and client cert                                  | `false`                                              |
+| `tls.certs.selfSigner.caSecret`                           | If CA is provided, secret name for CA cert                      | `""`                                             |
+| `tls.certs.selfSigner.minimumCertDuration`                | Minimum cert duration for all the certs, all certs duration will be validated against this duration                | `624h`                                               |
+| `tls.certs.selfSigner.caCertDuration`                     | Duration of CA cert in hour                                     | `43824h`                                         |
+| `tls.certs.selfSigner.caCertExpiryWindow`                 | Expiry window of CA cert means a window before actual expiry in which CA cert should be rotated                    | `648h`                                               |
+| `tls.certs.selfSigner.clientCertDuration`                 | Duration of client cert in hour                                 | `672h                                            |
+| `tls.certs.selfSigner.clientCertExpiryWindow`             | Expiry window of client cert means a window before actual expiry in which client cert should be rotated            | `48h`                                                |
+| `tls.certs.selfSigner.nodeCertDuration`                   | Duration of node cert in hour                                   | `8760h`                                          |
+| `tls.certs.selfSigner.nodeCertExpiryWindow`               | Expiry window of node cert means a window before actual expiry in which node certs should be rotated               | `168h`                                               |
+| `tls.certs.selfSigner.rotateCerts`                        | Whether to rotate the certs generate by cockroachdb             | `true`                                           |
+| `tls.certs.selfSigner.readinessWait`                      | Wait time for each cockroachdb replica to become ready once it comes in running state. Only considered when rotateCerts is set to true                                    | `30s`                                             |
+| `tls.certs.selfSigner.podUpdateTimeout`                   | Wait time for each cockroachdb replica to get to running state. Only considered when rotateCerts is set to true                                    | `2m`                                             |
+| `tls.certs.certManager`                                   | Provision certificates with cert-manager                        | `false`                                               |
+| `tls.certs.certManagerIssuer.group`                       | IssuerRef group to use when generating certificates             | `cert-manager.io`                                     |
+| `tls.certs.certManagerIssuer.kind`                        | IssuerRef kind to use when generating certificates              | `Issuer`                                              |
+| `tls.certs.certManagerIssuer.name`                        | IssuerRef name to use when generating certificates              | `cockroachdb`                                         |
+| `tls.selfSigner.image.repository`                         | Image to use for self signing TLS certificates                  | `cockroachlabs-helm-charts/cockroach-self-signer-cert`|
+| `tls.selfSigner.image.tag`                                | Image tag to use for self signing TLS certificates              | `0.1`                                                 |
+| `tls.selfSigner.image.pullPolicy`                         | Self signing TLS certificates container pull policy             | `IfNotPresent`                                        |
+| `tls.selfSigner.image.credentials`                        | `registry`, `user` and `pass` credentials to pull private image | `{}`                                                  |
+| `networkPolicy.enabled`                                   | Enable NetworkPolicy for CockroachDB's Pods                     | `no`                                                  |
+| `networkPolicy.ingress.grpc`                              | Whitelist resources to access gRPC port of CockroachDB's Pods   | `[]`                                                  |
+| `networkPolicy.ingress.http`                              | Whitelist resources to access gRPC port of CockroachDB's Pods   | `[]`                                                  |
+
+
+Override the default parameters using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies custom values for the parameters can be provided while installing the chart. For example:
+
+```shell
+helm install my-release -f my-values.yaml cockroachdb/cockroachdb
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Deep dive
+
+### Connecting to the CockroachDB cluster
+
+Once you've created the cluster, you can start talking to it by connecting to its `-public` Service. CockroachDB is PostgreSQL wire protocol compatible, so there's a [wide variety of supported clients](https://www.cockroachlabs.com/docs/install-client-drivers.html). As an example, we'll open up a SQL shell using CockroachDB's built-in shell and play around with it a bit, like this (likely needing to replace `my-release-cockroachdb-public` with the name of the `-public` Service that was created with your installed chart):
+
+```shell
+kubectl run cockroach-client --rm -it \
+--image=cockroachdb/cockroach \
+--restart=Never \
+-- sql --insecure --host my-release-cockroachdb-public
+```
+
+```
+Waiting for pod default/cockroach-client to be running, status is Pending,
+pod ready: false
+If you don't see a command prompt, try pressing enter.
+root@my-release-cockroachdb-public:26257> SHOW DATABASES;
++--------------------+
+|      Database      |
++--------------------+
+| information_schema |
+| pg_catalog         |
+| system             |
++--------------------+
+(3 rows)
+root@my-release-cockroachdb-public:26257> CREATE DATABASE bank;
+CREATE DATABASE
+root@my-release-cockroachdb-public:26257> CREATE TABLE bank.accounts (id INT
+PRIMARY KEY, balance DECIMAL);
+CREATE TABLE
+root@my-release-cockroachdb-public:26257> INSERT INTO bank.accounts VALUES
+(1234, 10000.50);
+INSERT 1
+root@my-release-cockroachdb-public:26257> SELECT * FROM bank.accounts;
++------+---------+
+|  id  | balance |
++------+---------+
+| 1234 | 10000.5 |
++------+---------+
+(1 row)
+root@my-release-cockroachdb-public:26257> \q
+Waiting for pod default/cockroach-client to terminate, status is Running
+pod "cockroach-client" deleted
+```
+
+> If you are running in secure mode, you will have to provide a client certificate to the cluster in order to authenticate, so the above command will not work. See [here](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/client-secure.yaml) for an example of how to set up an interactive SQL shell against a secure cluster or [here](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/example-app-secure.yaml) for an example application connecting to a secure cluster.
+
+### Cluster health
+
+Because our pod spec includes regular health checks of the CockroachDB processes, simply running `kubectl get pods` and looking at the `STATUS` column is sufficient to determine the health of each instance in the cluster.
+
+If you want more detailed information about the cluster, the best place to look is the Admin UI.
+
+### Accessing the Admin UI
+
+If you want to see information about how the cluster is doing, you can try pulling up the CockroachDB Admin UI by port-forwarding from your local machine to one of the pods (replacing `my-release-cockroachdb-0` with the name of one of your pods:
+
+```shell
+kubectl port-forward my-release-cockroachdb-0 8080
+```
+
+You should then be able to access the Admin UI by visiting <http://localhost:8080/> in your web browser.
+
+### Failover
+
+If any CockroachDB member fails, it is restarted or recreated automatically by the Kubernetes infrastructure, and will re-join the cluster automatically when it comes back up. You can test this scenario by killing any of the CockroachDB pods:
+
+```shell
+kubectl delete pod my-release-cockroachdb-1
+```
+
+```shell
+kubectl get pods -l "app.kubernetes.io/instance=my-release,app.kubernetes.io/component=cockroachdb"
+```
+
+```
+NAME                      READY     STATUS        RESTARTS   AGE
+my-release-cockroachdb-0  1/1       Running       0          5m
+my-release-cockroachdb-2  1/1       Running       0          5m
+```
+
+After a while:
+
+```shell
+kubectl get pods -l "app.kubernetes.io/instance=my-release,app.kubernetes.io/component=cockroachdb"
+```
+
+```
+NAME                      READY     STATUS        RESTARTS   AGE
+my-release-cockroachdb-0  1/1       Running       0          5m
+my-release-cockroachdb-1  1/1       Running       0          20s
+my-release-cockroachdb-2  1/1       Running       0          5m
+```
+
+You can check the state of re-joining from the new pod's logs:
+
+```shell
+kubectl logs my-release-cockroachdb-1
+```
+
+```
+[...]
+I161028 19:32:09.754026 1 server/node.go:586  [n1] node connected via gossip and
+verified as part of cluster {"35ecbc27-3f67-4e7d-9b8f-27c31aae17d6"}
+[...]
+cockroachdb-0.my-release-cockroachdb.default.svc.cluster.local:26257
+build:      beta-20161027-55-gd2d3c7f @ 2016/10/28 19:27:25 (go1.7.3)
+admin:      http://0.0.0.0:8080
+sql:
+postgresql://root@my-release-cockroachdb-1.my-release-cockroachdb.default.svc.cluster.local:26257?sslmode=disable
+logs:       cockroach-data/logs
+store[0]:   path=cockroach-data
+status:     restarted pre-existing node
+clusterID:  {35ecbc27-3f67-4e7d-9b8f-27c31aae17d6}
+nodeID:     2
+[...]
+```
+
+### NetworkPolicy
+
+To enable NetworkPolicy for CockroachDB, install [a networking plugin that implements the Kubernetes NetworkPolicy spec](https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy#before-you-begin), and set `networkPolicy.enabled` to `yes`/`true`.
+
+For Kubernetes v1.5 & v1.6, you must also turn on NetworkPolicy by setting the `DefaultDeny` Namespace annotation. Note: this will enforce policy for _all_ pods in the Namespace:
+
+```shell
+kubectl annotate namespace default "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
+```
+
+For more precise policy, set `networkPolicy.ingress.grpc` and `networkPolicy.ingress.http` rules. This will only allow pods that match the provided rules to connect to CockroachDB.
+
+### Scaling
+
+Scaling should be managed via the `helm upgrade` command. After resizing your cluster on your cloud environment (e.g., GKE or EKS), run the following command to add a pod. This assumes you scaled from 3 to 4 nodes:
+
+```shell
+helm upgrade \
+my-release \
+cockroachdb/cockroachdb \
+--set statefulset.replicas=4 \
+--reuse-values
+```
+
+Note, that if you are running in secure mode (`tls.enabled` is `yes`/`true`) and increase the size of your cluster, you will also have to approve the CSR (certificate-signing request) of each new node (using `kubectl get csr` and `kubectl certificate approve`).
+
+[1]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+[2]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity
+[3]: https://cert-manager.io/
+[4]: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+[5]: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/

--- a/build/templates/values.yaml
+++ b/build/templates/values.yaml
@@ -1,0 +1,523 @@
+image:
+  repository: cockroachdb/cockroach
+  tag: v{{ .AppVersion }}
+  pullPolicy: IfNotPresent
+  credentials: {}
+    # registry: docker.io
+    # username: john_doe
+    # password: changeme
+
+
+# Additional labels to apply to all Kubernetes resources created by this chart.
+labels: {}
+  # app.kubernetes.io/part-of: my-app
+
+
+# Cluster's default DNS domain.
+# You should overwrite it if you're using a different one,
+# otherwise CockroachDB nodes discovery won't work.
+clusterDomain: cluster.local
+
+
+conf:
+  # An ordered list of CockroachDB node attributes.
+  # Attributes are arbitrary strings specifying machine capabilities.
+  # Machine capabilities might include specialized hardware or number of cores
+  # (e.g. "gpu", "x16c").
+  attrs: []
+    # - x16c
+    # - gpu
+
+  # Total size in bytes for caches, shared evenly if there are multiple
+  # storage devices. Size suffixes are supported (e.g. `1GB` and `1GiB`).
+  # A percentage of physical memory can also be specified (e.g. `.25`).
+  cache: 25%
+
+  # Sets a name to verify the identity of a cluster.
+  # The value must match between all nodes specified via `conf.join`.
+  # This can be used as an additional verification when either the node or
+  # cluster, or both, have not yet been initialized and do not yet know their
+  # cluster ID.
+  # To introduce a cluster name into an already-initialized cluster, pair this
+  # option with `conf.disable-cluster-name-verification: yes`.
+  cluster-name: ""
+
+  # Tell the server to ignore `conf.cluster-name` mismatches.
+  # This is meant for use when opting an existing cluster into starting to use
+  # cluster name verification, or when changing the cluster name.
+  # The cluster should be restarted once with `conf.cluster-name` and
+  # `conf.disable-cluster-name-verification: yes` combined, and once all nodes
+  # have been updated to know the new cluster name, the cluster can be restarted
+  # again with `conf.disable-cluster-name-verification: no`.
+  # This option has no effect if `conf.cluster-name` is not specified.
+  disable-cluster-name-verification: false
+
+  # The addresses for connecting a CockroachDB nodes to an existing cluster.
+  # If you are deploying a second CockroachDB instance that should join a first
+  # one, use the below list to join to the existing instance.
+  # Each item in the array should be a FQDN (and port if needed) resolvable by
+  # new Pods.
+  join: []
+
+  # New logging configuration.
+  log:
+    enabled: false
+    # https://www.cockroachlabs.com/docs/v21.1/configure-logs
+    config: {}
+      # file-defaults:
+      #   dir: /custom/dir/path/
+      # fluent-defaults:
+      #   format: json-fluent
+      # sinks:
+      #   stderr:
+      #     channels: [DEV]
+
+  # Logs at or above this threshold to STDERR. Ignored when "log" is enabled
+  logtostderr: INFO
+
+  # Maximum storage capacity available to store temporary disk-based data for
+  # SQL queries that exceed the memory budget (e.g. join, sorts, etc are
+  # sometimes able to spill intermediate results to disk).
+  # Accepts numbers interpreted as bytes, size suffixes (e.g. `32GB` and
+  # `32GiB`) or a percentage of disk size (e.g. `10%`).
+  # The location of the temporary files is within the first store dir.
+  # If expressed as a percentage, `max-disk-temp-storage` is interpreted
+  # relative to the size of the storage device on which the first store is
+  # placed. The temp space usage is never counted towards any store usage
+  # (although it does share the device with the first store) so, when
+  # configuring this, make sure that the size of this temp storage plus the size
+  # of the first store don't exceed the capacity of the storage device.
+  # If the first store is an in-memory one (i.e. `type=mem`), then this
+  # temporary "disk" data is also kept in-memory.
+  # A percentage value is interpreted as a percentage of the available internal
+  # memory.
+  # max-disk-temp-storage: 0GB
+
+  # Maximum allowed clock offset for the cluster. If observed clock offsets
+  # exceed this limit, servers will crash to minimize the likelihood of
+  # reading inconsistent data. Increasing this value will increase the time
+  # to recovery of failures as well as the frequency of uncertainty-based
+  # read restarts.
+  # Note, that this value must be the same on all nodes in the cluster.
+  # In order to change it, all nodes in the cluster must be stopped
+  # simultaneously and restarted with the new value.
+  # max-offset: 500ms
+
+  # Maximum memory capacity available to store temporary data for SQL clients,
+  # including prepared queries and intermediate data rows during query
+  # execution. Accepts numbers interpreted as bytes, size suffixes
+  # (e.g. `1GB` and `1GiB`) or a percentage of physical memory (e.g. `.25`).
+  max-sql-memory: 25%
+
+  # An ordered, comma-separated list of key-value pairs that describe the
+  # topography of the machine. Topography might include country, datacenter
+  # or rack designations. Data is automatically replicated to maximize
+  # diversities of each tier. The order of tiers is used to determine
+  # the priority of the diversity, so the more inclusive localities like
+  # country should come before less inclusive localities like datacenter.
+  # The tiers and order must be the same on all nodes. Including more tiers
+  # is better than including fewer. For example:
+  #   locality: country=us,region=us-west,datacenter=us-west-1b,rack=12
+  #   locality: country=ca,region=ca-east,datacenter=ca-east-2,rack=4
+  #   locality: planet=earth,province=manitoba,colo=secondary,power=3
+  locality: ""
+
+  # Run CockroachDB instances in standalone mode with replication disabled
+  # (replication factor = 1).
+  # Enabling this option makes the following values to be ignored:
+  # - `conf.cluster-name`
+  # - `conf.disable-cluster-name-verification`
+  # - `conf.join`
+  #
+  # WARNING: Enabling this option makes each deployed Pod as a STANDALONE
+  #          CockroachDB instance, so the StatefulSet does NOT FORM A CLUSTER.
+  #          Don't use this option for production deployments unless you clearly
+  #          understand what you're doing.
+  #          Usually, this option is intended to be used in conjunction with
+  #          `statefulset.replicas: 1` for temporary one-time deployments (like
+  #          running E2E tests, for example).
+  single-node: false
+
+  # If non-empty, create a SQL audit log in the specified directory.
+  sql-audit-dir: ""
+
+  # CockroachDB's port to listen to inter-communications and client connections.
+  port: 26257
+
+  # CockroachDB's port to listen to HTTP requests.
+  http-port: 8080
+
+  # CockroachDB's data mount path.
+  path: cockroach-data
+
+  # CockroachDB's storage configuration https://www.cockroachlabs.com/docs/v21.1/cockroach-start.html#storage
+  # Uses --store flag
+  store:
+    enabled: false
+    # Should be empty or 'mem'
+    type:
+    # Required for type=mem. If type and size is empty - storage.persistentVolume.size is used
+    size:
+    # Arbitrary strings, separated by colons, specifying disk type or capability
+    attrs:
+
+statefulset:
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  budget:
+    maxUnavailable: 1
+
+  # List of additional command-line arguments you want to pass to the
+  # `cockroach start` command.
+  args: []
+    # - --disable-cluster-name-verification
+
+  # List of extra environment variables to pass into container
+  env: []
+    # - name: COCKROACH_ENGINE_MAX_SYNC_DURATION
+    #   value: "24h"
+
+  # List of Secrets names in the same Namespace as the CockroachDB cluster,
+  # which shall be mounted into `/etc/cockroach/secrets/` for every cluster
+  # member.
+  secretMounts: []
+
+  # Additional labels to apply to this StatefulSet and all its Pods.
+  labels:
+    app.kubernetes.io/component: cockroachdb
+
+  # Additional annotations to apply to the Pods of this StatefulSet.
+  annotations: {}
+
+  # Affinity rules for scheduling Pods of this StatefulSet on Nodes.
+  # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity
+  nodeAffinity: {}
+  # Inter-Pod Affinity rules for scheduling Pods of this StatefulSet.
+  # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  podAffinity: {}
+  # Anti-affinity rules for scheduling Pods of this StatefulSet.
+  # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  # You may either toggle options below for default anti-affinity rules,
+  # or specify the whole set of anti-affinity rules instead of them.
+  podAntiAffinity:
+    # The topologyKey to be used.
+    # Can be used to spread across different nodes, AZs, regions etc.
+    topologyKey: kubernetes.io/hostname
+    # Type of anti-affinity rules: either `soft`, `hard` or empty value (which
+    # disables anti-affinity rules).
+    type: soft
+    # Weight for `soft` anti-affinity rules.
+    # Does not apply for other anti-affinity types.
+    weight: 100
+
+  # Node selection constraints for scheduling Pods of this StatefulSet.
+  # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  nodeSelector: {}
+
+  # PriorityClassName given to Pods of this StatefulSet
+  # https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+  priorityClassName: ""
+
+  # Taints to be tolerated by Pods of this StatefulSet.
+  # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
+
+  # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  topologySpreadConstraints:
+    maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+
+  # Uncomment the following resources definitions or pass them from
+  # command line to control the CPU and memory resources allocated
+  # by Pods of this StatefulSet.
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 512Mi
+
+  # Custom Liveness probe
+  # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request
+  customLivenessProbe: {}
+    # httpGet:
+    #   path: /health
+    #   port: http
+    #   scheme: HTTPS
+    # initialDelaySeconds: 30
+    # periodSeconds: 5
+
+  # Custom Rediness probe
+  # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes
+  customReadinessProbe: {}
+    # httpGet:
+    #   path: /health
+    #   port: http
+    #   scheme: HTTPS
+    # initialDelaySeconds: 30
+    # periodSeconds: 5
+
+service:
+  ports:
+    # You can set a different external and internal gRPC ports and their name.
+    grpc:
+      external:
+        port: 26257
+        name: grpc
+      # If the port number is different than `external.port`, then it will be
+      # named as `internal.name` in Service.
+      internal:
+        port: 26257
+        # If using Istio set it to `cockroach`.
+        name: grpc-internal
+    http:
+      port: 8080
+      name: http
+
+  # This Service is meant to be used by clients of the database.
+  # It exposes a ClusterIP that will automatically load balance connections
+  # to the different database Pods.
+  public:
+    type: ClusterIP
+    # Additional labels to apply to this Service.
+    labels:
+      app.kubernetes.io/component: cockroachdb
+    # Additional annotations to apply to this Service.
+    annotations: {}
+
+  # This service only exists to create DNS entries for each pod in
+  # the StatefulSet such that they can resolve each other's IP addresses.
+  # It does not create a load-balanced ClusterIP and should not be used directly
+  # by clients in most circumstances.
+  discovery:
+    # Additional labels to apply to this Service.
+    labels:
+      app.kubernetes.io/component: cockroachdb
+    # Additional annotations to apply to this Service.
+    annotations: {}
+
+# CockroachDB's ingress for web ui.
+ingress:
+  enabled: false
+  labels: {}
+  annotations: {}
+  #   kubernetes.io/ingress.class: nginx
+  #   cert-manager.io/cluster-issuer: letsencrypt
+  paths: [/]
+  hosts: []
+  # - cockroachlabs.com
+  tls: []
+  # - hosts: [cockroachlabs.com]
+  #   secretName: cockroachlabs-tls
+
+# CockroachDB's Prometheus operator ServiceMonitor support
+serviceMonitor:
+  enabled: false
+  labels: {}
+  annotations: {}
+  interval: 10s
+  # scrapeTimeout: 10s
+  # Limits the ServiceMonitor to the current namespace if set to `true`.
+  namespaced: false
+
+# CockroachDB's data persistence.
+# If neither `persistentVolume` nor `hostPath` is used, then data will be
+# persisted in ad-hoc `emptyDir`.
+storage:
+  # Absolute path on host to store CockroachDB's data.
+  # If not specified, then `emptyDir` will be used instead.
+  # If specified, but `persistentVolume.enabled` is `true`, then has no effect.
+  hostPath: ""
+
+  # If `enabled` is `true` then a PersistentVolumeClaim will be created and
+  # used to store CockroachDB's data, otherwise `hostPath` is used.
+  persistentVolume:
+    enabled: true
+
+    size: 100Gi
+
+    # If defined, then `storageClassName: <storageClass>`.
+    # If set to "-", then `storageClassName: ""`, which disables dynamic
+    # provisioning.
+    # If undefined or empty (default), then no `storageClassName` spec is set,
+    # so the default provisioner will be chosen (gp2 on AWS, standard on
+    # GKE, AWS & OpenStack).
+    storageClass: ""
+
+    # Additional labels to apply to the created PersistentVolumeClaims.
+    labels: {}
+    # Additional annotations to apply to the created PersistentVolumeClaims.
+    annotations: {}
+
+
+# Kubernetes Job which initializes multi-node CockroachDB cluster.
+# It's not created if `statefulset.replicas` is `1`.
+init:
+  # Additional labels to apply to this Job and its Pod.
+  labels:
+    app.kubernetes.io/component: init
+
+  # Additional annotations to apply to the Pod of this Job.
+  annotations: {}
+
+  # Affinity rules for scheduling the Pod of this Job.
+  # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity
+  affinity: {}
+
+  # Node selection constraints for scheduling the Pod of this Job.
+  # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  nodeSelector: {}
+
+  # Taints to be tolerated by the Pod of this Job.
+  # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
+
+  # The init Pod runs at cluster creation to initialize CockroachDB. It finishes
+  # quickly and doesn't continue to consume resources in the Kubernetes
+  # cluster. Normally, you should leave this section commented out, but if your
+  # Kubernetes cluster uses Resource Quotas and requires all pods to specify
+  # resource requests or limits, you can set those here.
+  resources: {}
+    # requests:
+    #   cpu: "10m"
+    #   memory: "128Mi"
+    # limits:
+    #   cpu: "10m"
+    #   memory: "128Mi"
+
+  provisioning:
+    enabled: false
+    # https://www.cockroachlabs.com/docs/stable/cluster-settings.html
+    clusterSettings:
+      # cluster.organization: "'FooCorp - Local Testing'"
+      # enterprise.license: "'xxxxx'"
+    users: []
+    # - name:
+    #   password:
+    #   # https://www.cockroachlabs.com/docs/stable/create-user.html#parameters
+    #   options: [LOGIN]
+    databases: []
+    # - name:
+    #   # https://www.cockroachlabs.com/docs/stable/create-database.html#parameters
+    #   options: [encoding='utf-8']
+    #   owners: []
+    #   # Backup schedules are not idemponent for now and will fail on next run
+    #   # https://github.com/cockroachdb/cockroach/issues/57892
+    #   backup:
+    #     into: s3://
+    #     # Enterprise-only option (revision_history)
+    #     # https://www.cockroachlabs.com/docs/stable/create-schedule-for-backup.html#backup-options
+    #     options: [revision_history]
+    #     recurring: '@always'
+    #     # Enterprise-only feature. Remove this value to use `FULL BACKUP ALWAYS`
+    #     fullBackup: '@daily'
+    #     schedule:
+    #       # https://www.cockroachlabs.com/docs/stable/create-schedule-for-backup.html#schedule-options
+    #       options: [first_run = 'now']
+
+
+# Whether to run securely using TLS certificates.
+tls:
+  enabled: true
+  serviceAccount:
+    # Specifies whether this ServiceAccount should be created.
+    create: true
+    # The name of this ServiceAccount to use.
+    # If not set and `create` is `true`, then a name is auto-generated.
+    name: ""
+  certs:
+    # Bring your own certs scenario. If provided, tls.init section will be ignored.
+    provided: false
+    # Secret name for the client root cert.
+    clientRootSecret: cockroachdb-root
+    # Secret name for node cert.
+    nodeSecret: cockroachdb-node
+    # Enable if the secret is a dedicated TLS.
+    # TLS secrets are created by cert-mananger, for example.
+    tlsSecret: false
+    # Enable if the you want cockroach db to create its own certificates
+    selfSigner:
+      # If set, the cockroach db will generate its own certificates
+      enabled: true
+      # If set, the user should provide the CA certificate to sign other certificates.
+      caProvided: false
+      # It holds the name of the secret with caCerts. If caProvided is set, this can not be empty.
+      caSecret: ""
+      # Minimum Certificate duration for all the certificates, all certs duration will be validated against this.
+      minimumCertDuration: 624h
+      # Duration of CA certificates in hour
+      caCertDuration: 43800h
+      # Expiry window of CA certificates means a window before actual expiry in which CA certs should be rotated.
+      caCertExpiryWindow: 648h
+      # Duration of Client certificates in hour
+      clientCertDuration: 672h
+      # Expiry window of client certificates means a window before actual expiry in which client certs should be rotated.
+      clientCertExpiryWindow: 48h
+      # Duration of node certificates in hour
+      nodeCertDuration: 8760h
+      # Expiry window of node certificates means a window before actual expiry in which node certs should be rotated.
+      nodeCertExpiryWindow: 168h
+      # If set, the cockroachdb cert selfSigner will rotate the certificates before expiry.
+      rotateCerts: true
+      # Wait time for each cockroachdb replica to become ready once it comes in running state. Only considered when rotateCerts is set to true
+      readinessWait: 30s
+      # Wait time for each cockroachdb replica to get to running state. Only considered when rotateCerts is set to true
+      podUpdateTimeout: 2m
+
+    # Use cert-manager to issue certificates for mTLS.
+    certManager: false
+    # Specify an Issuer or a ClusterIssuer to use, when issuing
+    # node and client certificates. The values correspond to the
+    # issuerRef specified in the certificate.
+    certManagerIssuer:
+      group: cert-manager.io
+      kind: Issuer
+      name: cockroachdb
+    # Enable if you run cert-manager >=1.0 on K8s <=1.15 with legacy CRDs
+    # Legacy CRDs only support cert-manager.io/v1 API Versions
+    useCertManagerV1CRDs: false
+
+  selfSigner:
+    # Image Placeholder for the selfSigner utility. This will be changed once the CI workflows for the image is in place.
+    image:
+      repository: cockroachlabs-helm-charts/cockroach-self-signer-cert
+      tag: "1.3"
+      pullPolicy: IfNotPresent
+      credentials: {}
+      registry: gcr.io
+      # username: john_doe
+      # password: changeme
+
+networkPolicy:
+  enabled: false
+
+  ingress:
+    # List of sources which should be able to access the CockroachDB Pods via
+    # gRPC port. Items in this list are combined using a logical OR operation.
+    # Rules for allowing inter-communication are applied automatically.
+    # If empty, then connections from any Pod is allowed.
+    grpc: []
+      # - podSelector:
+      #     matchLabels:
+      #       app.kubernetes.io/name: my-app-django
+      #       app.kubernetes.io/instance: my-app
+
+    # List of sources which should be able to access the CockroachDB Pods via
+    # HTTP port. Items in this list are combined using a logical OR operation.
+    # If empty, then connections from any Pod is allowed.
+    http: []
+      # - namespaceSelector:
+      #     matchLabels:
+      #       project: my-project
+
+# To put the admin interface behind Identity Aware Proxy (IAP) on Google Cloud Platform
+# make sure to set ingress.paths: ['/*']
+iap:
+  enabled: false
+  # Create Google Cloud OAuth credentials and set client id and secret
+  # clientId:
+  # clientSecret:

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,7 @@ github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4K
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.0.2/go.mod h1:oesJ8kPONMONaZgtiHNzUShJbksypC5kWczhZAf6+aU=
 github.com/Masterminds/vcs v1.13.1/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=


### PR DESCRIPTION
Previously, in order to update the CockroachDB version, we used `sed` to
manipulate the files. This approach is error prone.

This patch adds a tool, that updates `Chart.yaml` and `values.yaml` files
with proper versions.