### PR TITLE
Add configurable pod termination grace period

### DIFF
--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -138,7 +138,7 @@ spec:
     {{- end }}
       # No pre-stop hook is required, a SIGTERM plus some time is all that's
       # needed for graceful shutdown of a node.
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: {{ .Values.statefulset.terminationGracePeriodSeconds }}
       containers:
         - name: db
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -213,6 +213,10 @@ statefulset:
     # Does not apply for other anti-affinity types.
     weight: 100
 
+  # Pod termination grace period
+  # https://www.cockroachlabs.com/docs/stable/node-shutdown.html#termination-grace-period
+  terminationGracePeriodSeconds: 60
+
   # Node selection constraints for scheduling Pods of this StatefulSet.
   # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
   nodeSelector: {}


### PR DESCRIPTION
The [CockroadhDB documentation](https://www.cockroachlabs.com/docs/stable/node-shutdown.html#termination-grace-period) implies that the pod termination grace period should be configurable depending on the cluster specifics.

The helm chart not only hardcodes the termination grace period but also sets it to a significantly shorter value than the recommended value in the documentation.

This merge request makes the termination grace period configurable.