### PR TITLE
Fix issuer ref for the client and node certificates

### DIFF
--- a/cockroachdb/templates/certificate.client.yaml
+++ b/cockroachdb/templates/certificate.client.yaml
@@ -41,5 +41,8 @@ spec:
     - Cockroach
 {{- end }}
   secretName: {{ .Values.tls.certs.clientRootSecret }}
-  issuerRef: {{- toYaml .Values.tls.certs.certManagerIssuer | nindent 4 }}
+  issuerRef:
+    name: {{ .Values.tls.certs.certManagerIssuer.name }}
+    kind: {{ .Values.tls.certs.certManagerIssuer.kind }}
+    group: {{ .Values.tls.certs.certManagerIssuer.group }}
 {{- end }}

--- a/cockroachdb/templates/certificate.node.yaml
+++ b/cockroachdb/templates/certificate.node.yaml
@@ -51,5 +51,8 @@ spec:
     - {{ printf "*.%s.%s" (include "cockroachdb.fullname" .) .Release.Namespace | quote }}
     - {{ printf "*.%s.%s.svc.%s" (include "cockroachdb.fullname" .) .Release.Namespace .Values.clusterDomain | quote }}
   secretName: {{ .Values.tls.certs.nodeSecret }}
-  issuerRef: {{- toYaml .Values.tls.certs.certManagerIssuer | nindent 4 }}
+  issuerRef:
+    name: {{ .Values.tls.certs.certManagerIssuer.name }}
+    kind: {{ .Values.tls.certs.certManagerIssuer.kind }}
+    group: {{ .Values.tls.certs.certManagerIssuer.group }}
 {{- end }}


### PR DESCRIPTION
* the tls.certs.certManagerIssuer now also contains fields for the duration and expiry window