### PR TITLE
Update templates and bump to v21.2.10

### DIFF
--- a/build/templates/README.md
+++ b/build/templates/README.md
@@ -382,6 +382,7 @@ For details see the [`values.yaml`](values.yaml) file.
 | `tls.enabled`                                             | Whether to run securely using TLS certificates                  | `no`                                                  |
 | `tls.serviceAccount.create`                               | Whether to create a new RBAC service account                    | `yes`                                                 |
 | `tls.serviceAccount.name`                                 | Name of RBAC service account to use                             | `""`                                                  |
+| `tls.copyCerts.image`                                     | Image used in copy certs init container                         | `busybox`                                             |
 | `tls.certs.provided`                                      | Bring your own certs scenario, i.e certificates are provided    | `no`                                                  |
 | `tls.certs.clientRootSecret`                              | If certs are provided, secret name for client root cert         | `cockroachdb-root`                                    |
 | `tls.certs.nodeSecret`                                    | If certs are provided, secret name for node cert                | `cockroachdb-node`                                    |
@@ -403,6 +404,10 @@ For details see the [`values.yaml`](values.yaml) file.
 | `tls.certs.certManagerIssuer.group`                       | IssuerRef group to use when generating certificates             | `cert-manager.io`                                     |
 | `tls.certs.certManagerIssuer.kind`                        | IssuerRef kind to use when generating certificates              | `Issuer`                                              |
 | `tls.certs.certManagerIssuer.name`                        | IssuerRef name to use when generating certificates              | `cockroachdb`                                         |
+| `tls.certs.certManagerIssuer.clientCertDuration`          | Duration of client cert in hours                                | `672h`                                                |
+| `tls.certs.certManagerIssuer.clientCertExpiryWindow`      | Expiry window of client cert means a window before actual expiry in which client cert should be rotated                   | `48h`                                       |
+| `tls.certs.certManagerIssuer.nodeCertDuration`            | Duration of node cert in hours                                  | `8760h`                                               |
+| `tls.certs.certManagerIssuer.nodeCertExpiryWindow`        | Expiry window of node certificates means a window before actual expiry in which node certs should be rotated.             | `168h`                                      |
 | `tls.selfSigner.image.repository`                         | Image to use for self signing TLS certificates                  | `cockroachlabs-helm-charts/cockroach-self-signer-cert`|
 | `tls.selfSigner.image.tag`                                | Image tag to use for self signing TLS certificates              | `0.1`                                                 |
 | `tls.selfSigner.image.pullPolicy`                         | Self signing TLS certificates container pull policy             | `IfNotPresent`                                        |

--- a/build/templates/values.yaml
+++ b/build/templates/values.yaml
@@ -429,6 +429,8 @@ tls:
     # The name of this ServiceAccount to use.
     # If not set and `create` is `true`, then a name is auto-generated.
     name: ""
+  copyCerts:
+    image: busybox
   certs:
     # Bring your own certs scenario. If provided, tls.init section will be ignored.
     provided: false
@@ -477,6 +479,14 @@ tls:
       group: cert-manager.io
       kind: Issuer
       name: cockroachdb
+      # Duration of Client certificates in hours
+      clientCertDuration: 672h
+      # Expiry window of client certificates means a window before actual expiry in which client certs should be rotated.
+      clientCertExpiryWindow: 48h
+      # Duration of node certificates in hours
+      nodeCertDuration: 8760h
+      # Expiry window of node certificates means a window before actual expiry in which node certs should be rotated.
+      nodeCertExpiryWindow: 168h
     # Enable if you run cert-manager >=1.0 on K8s <=1.15 with legacy CRDs
     # Legacy CRDs only support cert-manager.io/v1 API Versions
     useCertManagerV1CRDs: false

--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 7.0.2
-appVersion: 21.2.9
+version: 7.0.3
+appVersion: 21.2.10
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png
 sources:

--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -229,10 +229,10 @@ kubectl get pods \
 ```
 
 ```
-my-release-cockroachdb-0    cockroachdb/cockroach:v21.2.9
-my-release-cockroachdb-1    cockroachdb/cockroach:v21.2.9
-my-release-cockroachdb-2    cockroachdb/cockroach:v21.2.9
-my-release-cockroachdb-3    cockroachdb/cockroach:v21.2.9
+my-release-cockroachdb-0    cockroachdb/cockroach:v21.2.10
+my-release-cockroachdb-1    cockroachdb/cockroach:v21.2.10
+my-release-cockroachdb-2    cockroachdb/cockroach:v21.2.10
+my-release-cockroachdb-3    cockroachdb/cockroach:v21.2.10
 ```
 
 Resume normal operations. Once you are comfortable that the stability and performance of the cluster is what you'd expect post-upgrade, finalize the upgrade:
@@ -287,7 +287,7 @@ Verify that no pod is deleted and then upgrade as normal. A new StatefulSet will
 
 For more information about upgrading a cluster to the latest major release of CockroachDB, see [Upgrade to CockroachDB v21.1](https://www.cockroachlabs.com/docs/stable/upgrade-cockroach-version.html).
 
-Note that there are some backward-incompatible changes to SQL features between versions 20.2 and 21.1. For details, see the [CockroachDB v21.2.9 release notes](https://www.cockroachlabs.com/docs/releases/v21.2.9.html#backward-incompatible-changes).
+Note that there are some backward-incompatible changes to SQL features between versions 20.2 and 21.1. For details, see the [CockroachDB v21.2.10 release notes](https://www.cockroachlabs.com/docs/releases/v21.2.10.html#backward-incompatible-changes).
 
 ## Configuration
 
@@ -316,7 +316,7 @@ For details see the [`values.yaml`](values.yaml) file.
 | `conf.store.size`                                         | CockroachDB storage size                                        | `""`                                                  |
 | `conf.store.attrs`                                        | CockroachDB storage attributes                                  | `""`                                                  |
 | `image.repository`                                        | Container image name                                            | `cockroachdb/cockroach`                               |
-| `image.tag`                                               | Container image tag                                             | `v21.2.9`                                             |
+| `image.tag`                                               | Container image tag                                             | `v21.2.10`                                             |
 | `image.pullPolicy`                                        | Container pull policy                                           | `IfNotPresent`                                        |
 | `image.credentials`                                       | `registry`, `user` and `pass` credentials to pull private image | `{}`                                                  |
 | `statefulset.replicas`                                    | StatefulSet replicas number                                     | `3`                                                   |

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -1,7 +1,7 @@
 # Generated file, DO NOT EDIT. Source: build/templates/values.yaml
 image:
   repository: cockroachdb/cockroach
-  tag: v21.2.9
+  tag: v21.2.10
   pullPolicy: IfNotPresent
   credentials: {}
     # registry: docker.io


### PR DESCRIPTION
In #217 some new configuration parameters were introduced, but we forgot
to update the template used to generate the actual files.

This PR updates the templates in order to reflect the current state.