### PR TITLE
Add support for argocd and custom annotations to the init job

### DIFF
--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 8.0.0
+version: 8.0.1
 appVersion: 22.1.0
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -21,6 +21,10 @@ metadata:
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-delete-policy: before-hook-creation
+    argocd.argoproj.io/hook: Sync
+    {{- with .Values.init.jobAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   template:
     metadata:

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -362,6 +362,9 @@ init:
   labels:
     app.kubernetes.io/component: init
 
+  # Additional annotations to apply to this Job.
+  jobAnnotations: {}
+
   # Additional annotations to apply to the Pod of this Job.
   annotations: {}
 


### PR DESCRIPTION
Added argocd sync hook to the init job annotations.
Added additional annotations configuration fo the init job.
This addresses https://github.com/cockroachdb/helm-charts/issues/149