### PR TITLE
Add support for custom annotations to the Init Job 

### DIFF
--- a/build/templates/README.md
+++ b/build/templates/README.md
@@ -374,7 +374,8 @@ For details see the [`values.yaml`](values.yaml) file.
 | `storage.persistentVolume.labels`                         | Additional labels of PersistentVolumeClaim                      | `{}`                                                  |
 | `storage.persistentVolume.annotations`                    | Additional annotations of PersistentVolumeClaim                 | `{}`                                                  |
 | `init.labels`                                             | Additional labels of init Job and its Pod                       | `{"app.kubernetes.io/component": "init"}`             |
-| `init.annotations`                                        | Additional labels of the Pod of init Job                        | `{}`                                                  |
+| `init.jobAnnotations`                                     | Additional annotations of the init Job itself                   | `{}`                                                  |
+| `init.annotations`                                        | Additional annotations of the Pod of init Job                   | `{}`                                                  |
 | `init.affinity`                                           | [Affinity rules][2] of init Job Pod                             | `{}`                                                  |
 | `init.nodeSelector`                                       | Node labels for init Job Pod assignment                         | `{}`                                                  |
 | `init.tolerations`                                        | Node taints to tolerate by init Job Pod                         | `[]`                                                  |

--- a/build/templates/values.yaml
+++ b/build/templates/values.yaml
@@ -361,6 +361,9 @@ init:
   labels:
     app.kubernetes.io/component: init
 
+  # Additional annotations to apply to this Job.
+  jobAnnotations: {}
+
   # Additional annotations to apply to the Pod of this Job.
   annotations: {}
 

--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 8.0.1
+version: 8.1.0
 appVersion: 22.1.1
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -375,7 +375,8 @@ For details see the [`values.yaml`](values.yaml) file.
 | `storage.persistentVolume.labels`                         | Additional labels of PersistentVolumeClaim                      | `{}`                                                  |
 | `storage.persistentVolume.annotations`                    | Additional annotations of PersistentVolumeClaim                 | `{}`                                                  |
 | `init.labels`                                             | Additional labels of init Job and its Pod                       | `{"app.kubernetes.io/component": "init"}`             |
-| `init.annotations`                                        | Additional labels of the Pod of init Job                        | `{}`                                                  |
+| `init.jobAnnotations`                                     | Additional annotations of the init Job itself                   | `{}`                                                  |
+| `init.annotations`                                        | Additional annotations of the Pod of init Job                   | `{}`                                                  |
 | `init.affinity`                                           | [Affinity rules][2] of init Job Pod                             | `{}`                                                  |
 | `init.nodeSelector`                                       | Node labels for init Job Pod assignment                         | `{}`                                                  |
 | `init.tolerations`                                        | Node taints to tolerate by init Job Pod                         | `[]`                                                  |

--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -21,6 +21,9 @@ metadata:
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-delete-policy: before-hook-creation
+    {{- with .Values.init.jobAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   template:
     metadata:

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -362,6 +362,9 @@ init:
   labels:
     app.kubernetes.io/component: init
 
+  # Additional annotations to apply to this Job.
+  jobAnnotations: {}
+
   # Additional annotations to apply to the Pod of this Job.
   annotations: {}
 


### PR DESCRIPTION
In some cases, there is a need for adding custom annotations to the Init job.
For example, when using ArgoCD, we need to instruct ArgoCD to start the job
still during the Sync phase and not as a PostSync hook. Otherwise, the job never
starts. And this is done by adding the following annotation to the job.
```
argocd.argoproj.io/hook: Sync
```

This is to continue the work started in https://github.com/cockroachdb/helm-charts/pull/246 and https://github.com/cockroachdb/helm-charts/pull/206
to address https://github.com/cockroachdb/helm-charts/issues/149