### PR TITLE
examples: annotate for increased clarity

### DIFF
--- a/examples/client-secure.yaml
+++ b/examples/client-secure.yaml
@@ -20,10 +20,10 @@ kind: Pod
 metadata:
   name: cockroachdb-client-secure
 spec:
-  serviceAccountName: cockroachdb
+  serviceAccountName: cockroachdb # Change to {release}
   containers:
   - name: cockroachdb-client-secure
-    image: cockroachdb/cockroach:v21.1.11
+    image: cockroachdb/cockroach:v21.1.11 # Change to cockroachdb/cockroach:{version}
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: client-certs
@@ -37,7 +37,7 @@ spec:
     projected:
         sources:
           - secret:
-              name: cockroachdb-client-secret
+              name: cockroachdb-client-secret # Change to {release}-client-secret
               items:
                 - key: ca.crt
                   path: ca.crt


### PR DESCRIPTION
    This commit annotates client-secure.yaml with notes about which
    fields need to be changed when following the "Deploy CockroachDB in
    a Single Kubernetes Cluster" [1] tutorial.

    [1] https://www.cockroachlabs.com/docs/stable/deploy-cockroachdb-with-kubernetes.html