### PR TITLE
Update statefulset.yaml

### DIFF
--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -242,7 +242,7 @@ spec:
           {{- if .Values.tls.enabled }}
             - name: certs
               mountPath: /cockroach/cockroach-certs/
-              {{- if .Values.tls.certs.provided }}
+              {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager }}
             - name: certs-secret
               mountPath: /cockroach/certs/
               {{- end }}


### PR DESCRIPTION
When Certs are provided via CertManager, the /cockroach/certs volume mount needs to be added to allow the secrets to be mounted into the pod