### PR TITLE
avoid using .Release.Namespace

### DIFF
--- a/cmd/self-signer/cleanup.go
+++ b/cmd/self-signer/cleanup.go
@@ -38,13 +38,18 @@ var namespace string
 
 func init() {
 	cleanupCmd.Flags().StringVar(&namespace, "namespace", "", "namespace of the resources to be cleaned up")
-	if err := cleanupCmd.MarkFlagRequired("namespace"); err != nil {
-		log.Fatal(err)
-	}
+	cleanupCmd.Flags().MarkDeprecated("namespace", "namespace is deprecated, use the environment variable NAMESPACE instead")
 	rootCmd.AddCommand(cleanupCmd)
 }
 
 func cleanup(cmd *cobra.Command, args []string) {
+	if nsName, exists := os.LookupEnv("NAMESPACE"); exists {
+		namespace = nsName
+	}
+
+	if namespace == "" {
+		log.Fatal("Required NAMESPACE env not found")
+	}
 
 	stsName, exists := os.LookupEnv("STATEFULSET_NAME")
 	if !exists {

--- a/cockroachdb/templates/cronjob-ca-certSelfSigner.yaml
+++ b/cockroachdb/templates/cronjob-ca-certSelfSigner.yaml
@@ -34,7 +34,9 @@ spec:
             - name: STATEFULSET_NAME
               value: {{ template "cockroachdb.fullname" . }}
             - name: NAMESPACE
-              value: {{ .Release.Namespace }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: CLUSTER_DOMAIN
               value: {{ .Values.clusterDomain}}
           serviceAccountName: {{ template "rotatecerts.fullname" . }}

--- a/cockroachdb/templates/cronjob-client-node-certSelfSigner.yaml
+++ b/cockroachdb/templates/cronjob-client-node-certSelfSigner.yaml
@@ -42,7 +42,9 @@ spec:
             - name: STATEFULSET_NAME
               value: {{ template "cockroachdb.fullname" . }}
             - name: NAMESPACE
-              value: {{ .Release.Namespace }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: CLUSTER_DOMAIN
               value: {{ .Values.clusterDomain}}
           serviceAccountName: {{ template "rotatecerts.fullname" . }}

--- a/cockroachdb/templates/job-certSelfSigner.yaml
+++ b/cockroachdb/templates/job-certSelfSigner.yaml
@@ -46,7 +46,9 @@ spec:
           - name: STATEFULSET_NAME
             value: {{ template "cockroachdb.fullname" . }}
           - name: NAMESPACE
-            value: {{ .Release.Namespace | quote }}
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           - name: CLUSTER_DOMAIN
             value: {{ .Values.clusterDomain}}
       serviceAccountName: {{ template "selfcerts.fullname" . }}

--- a/cockroachdb/templates/job-cleaner.yaml
+++ b/cockroachdb/templates/job-cleaner.yaml
@@ -32,9 +32,12 @@ spec:
           imagePullPolicy: "{{ .Values.tls.selfSigner.image.pullPolicy }}"
           args:
             - cleanup
-            - --namespace={{ .Release.Namespace }}
           env:
           - name: STATEFULSET_NAME
             value: {{ template "cockroachdb.fullname" . }}
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
       serviceAccountName: {{ template "rotatecerts.fullname" . }}
 {{- end}}

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -173,7 +173,7 @@ spec:
               {{- else }}
                 {{- range $i, $_ := until 3 -}}
                   {{- if gt $i 0 -}},{{- end -}}
-                  ${STATEFULSET_NAME}-{{ $i }}.${STATEFULSET_FQDN}:{{ $.Values.service.ports.grpc.internal.port | int64 -}}
+                  ${STATEFULSET_NAME}-{{ $i }}.${STATEFULSET_SVC}.${NAMESPACE}.svc.${CLUSTER_DOMAIN}:{{ $.Values.service.ports.grpc.internal.port | int64 -}}
                 {{- end -}}
               {{- end }}
             {{- with index .Values.conf `cluster-name` }}
@@ -183,7 +183,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
-              --advertise-host=$(hostname).${STATEFULSET_FQDN}
+              --advertise-host=$(hostname).${STATEFULSET_SVC}.${NAMESPACE}.svc.${CLUSTER_DOMAIN}
             {{- if .Values.tls.enabled }}
               --certs-dir=/cockroach/cockroach-certs/
             {{- else }}
@@ -222,8 +222,14 @@ spec:
           env:
             - name: STATEFULSET_NAME
               value: {{ template "cockroachdb.fullname" . }}
-            - name: STATEFULSET_FQDN
-              value: {{ template "cockroachdb.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+            - name: STATEFULSET_SVC
+              value: {{ template "cockroachdb.fullname" . }}
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CLUSTER_DOMAIN
+              value: {{ .Values.clusterDomain }}
             - name: COCKROACH_CHANNEL
               value: kubernetes-helm
           {{- with .Values.statefulset.env }}

--- a/cockroachdb/templates/tests/client.yaml
+++ b/cockroachdb/templates/tests/client.yaml
@@ -58,7 +58,7 @@ spec:
         - --insecure
         {{- end}}
         - --host
-        - {{ template "cockroachdb.fullname" . }}-public.{{ .Release.Namespace }}
+        - {{ template "cockroachdb.fullname" . }}-public
         - --port
         - {{ .Values.service.ports.grpc.external.port | quote }}
         - -e


### PR DESCRIPTION
It's difficult to use any sort of [post-render](https://helm.sh/docs/topics/advanced/#post-rendering) such as Kustomize when {{ .Release.Namespace }} is used inside cmds, args or scripts.

Usage of {{ .Release.Namespace }} can be replaced with:
```
    - name: NAMESPACE
      valueFrom:
        fieldRef:
          fieldPath: metadata.namespace
```

In addition to the chart templates, the cleanup command takes `namespace` as a flag. Which is not consistent with other command and forces the use of bash for substitution.
 