### PR TITLE
Add support for Kubernetes v1.25

### DIFF
--- a/cockroachdb/templates/cronjob-ca-certSelfSigner.yaml
+++ b/cockroachdb/templates/cronjob-ca-certSelfSigner.yaml
@@ -1,6 +1,10 @@
 {{- if and .Values.tls.enabled (and .Values.tls.certs.selfSigner.enabled (not .Values.tls.certs.selfSigner.caProvided)) }}
   {{- if .Values.tls.certs.selfSigner.rotateCerts }}
+    {{- if .Capabilities.APIVersions.Has "batch/v1/CronJob" }}
+apiVersion: batch/v1
+    {{- else }}
 apiVersion: batch/v1beta1
+    {{- end }}
 kind: CronJob
 metadata:
   name: {{ template "rotatecerts.fullname" . }}

--- a/cockroachdb/templates/cronjob-client-node-certSelfSigner.yaml
+++ b/cockroachdb/templates/cronjob-client-node-certSelfSigner.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.tls.certs.selfSigner.enabled .Values.tls.certs.selfSigner.rotateCerts }}
+  {{- if .Capabilities.APIVersions.Has "batch/v1/CronJob" }}
+apiVersion: batch/v1
+  {{- else }}
 apiVersion: batch/v1beta1
+  {{- end }}
 kind: CronJob
 metadata:
   name: {{ template "rotatecerts.fullname" . }}-client

--- a/cockroachdb/templates/poddisruptionbudget.yaml
+++ b/cockroachdb/templates/poddisruptionbudget.yaml
@@ -1,5 +1,9 @@
 kind: PodDisruptionBudget
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 metadata:
   name: {{ template "cockroachdb.fullname" . }}-budget
   namespace: {{ .Release.Namespace | quote }}


### PR DESCRIPTION
I have implemented the conditional use of `batch/v1/CronJob` and `policy/v1/PodDisruptionBudget`, if available, to support Kubernetes v1.25.