### PR TITLE
Fix cronjob names exceeding max allowed 52 characters

### DIFF
--- a/cockroachdb/templates/_helpers.tpl
+++ b/cockroachdb/templates/_helpers.tpl
@@ -83,11 +83,11 @@ Return CockroachDB store expression
 Define the default values for the certificate selfSigner inputs
 */}}
 {{- define "selfcerts.fullname" -}}
-  {{- printf "%s-%s" (include "cockroachdb.fullname" .) "self-signer" | trunc 56 | trimSuffix "-" -}}
+  {{- printf "%s-%s" (include "cockroachdb.fullname" .) "self-signer" | trunc 52 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "rotatecerts.fullname" -}}
-  {{- printf "%s-%s" (include "cockroachdb.fullname" .) "rotate-self-signer" | trunc 56 | trimSuffix "-" -}}
+  {{- printf "%s-%s" (include "cockroachdb.fullname" .) "rotate-self-signer" | trunc 44 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "selfcerts.minimumCertDuration" -}}


### PR DESCRIPTION
When a release with a too long name get created it will currently fail with an error message:
```
Error: UPGRADE FAILED: failed to create resource: CronJob.batch "<releaseName>-rotate-self-sign-client" is invalid: metadata.name: Invalid value: "<releaseName>-rotate-self-sign-client": must be no more than 52 characters
```

This PR resolves this issue by truncating the job names earlier then what was already configured in the `_helpers.tpl`.

Another possible solution would be to truncate the release name instead of the job name, this might be the better approach but will also be a breaking change for people who already have installed the chart with a long release name. This is why I choose to truncate the job name instead.