### PR TITLE
Add option to set the ingress class name

### DIFF
--- a/build/templates/values.yaml
+++ b/build/templates/values.yaml
@@ -440,6 +440,7 @@ ingress:
   annotations: {}
   #   kubernetes.io/ingress.class: nginx
   #   cert-manager.io/cluster-issuer: letsencrypt
+  className: ""
   paths: [/]
   hosts: []
   # - cockroachlabs.com

--- a/cockroachdb/templates/ingress.yaml
+++ b/cockroachdb/templates/ingress.yaml
@@ -32,6 +32,9 @@ metadata:
 {{- toYaml .Values.ingress.labels | nindent 4 }}
 {{- end }}
 spec:
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+{{- end }}
   rules:
   {{- if .Values.ingress.hosts }}
   {{- range $host := .Values.ingress.hosts }}

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -441,6 +441,7 @@ ingress:
   annotations: {}
   #   kubernetes.io/ingress.class: nginx
   #   cert-manager.io/cluster-issuer: letsencrypt
+  className: ""
   paths: [/]
   hosts: []
   # - cockroachlabs.com


### PR DESCRIPTION
The ingressClassName configuration option should be used instead of custom ingress dependent annotations. This adds a new value to the ingress configuration to set this option.