### PR TITLE
backups are now idempotent so warning is no longer needed

### DIFF
--- a/build/templates/values.yaml
+++ b/build/templates/values.yaml
@@ -408,8 +408,6 @@ init:
     #   # https://www.cockroachlabs.com/docs/stable/create-database.html#parameters
     #   options: [encoding='utf-8']
     #   owners: []
-    #   # Backup schedules are not idemponent for now and will fail on next run
-    #   # https://github.com/cockroachdb/cockroach/issues/57892
     #   backup:
     #     into: s3://
     #     # Enterprise-only option (revision_history)


### PR DESCRIPTION
Backup idempotency was fixed as part of #57892 and so this comment is no longer accurate