### PR TITLE
allow to provide the users password in an existing secret

### DIFF
--- a/build/templates/values.yaml
+++ b/build/templates/values.yaml
@@ -1,3 +1,6 @@
+nameOverride:
+fullNameOverride:
+
 image:
   repository: cockroachdb/cockroach
   tag: v{{ .AppVersion }}
@@ -314,6 +317,9 @@ ingress:
   # - hosts: [cockroachlabs.com]
   #   secretName: cockroachlabs-tls
 
+prometheus:
+  enabled: true
+
 # CockroachDB's Prometheus operator ServiceMonitor support
 serviceMonitor:
   enabled: false
@@ -403,11 +409,17 @@ init:
     #   password:
     #   # https://www.cockroachlabs.com/docs/stable/create-user.html#parameters
     #   options: [LOGIN]
+    #   # existing secret name containing the password. Ignored in password is defined.
+    #   passwordSecretName:
+    #   # password secret key. Defaults to $name-password. Ignored in password is defined.
+    #   passwordSecretKey:
     databases: []
     # - name:
     #   # https://www.cockroachlabs.com/docs/stable/create-database.html#parameters
     #   options: [encoding='utf-8']
     #   owners: []
+    #   # Backup schedules are not idemponent for now and will fail on next run
+    #   # https://github.com/cockroachdb/cockroach/issues/57892
     #   backup:
     #     into: s3://
     #     # Enterprise-only option (revision_history)

--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -145,7 +145,7 @@ spec:
 
                       {{- range $user := .Values.init.provisioning.users }}
                         CREATE USER IF NOT EXISTS {{ $user.name }} WITH
-                        {{- if $user.password }}
+                        {{- if or $user.password $user.passwordSecretName }}
                           PASSWORD '${{ $user.name }}_PASSWORD'
                         {{- else }}
                           PASSWORD null
@@ -211,6 +211,12 @@ spec:
               secretKeyRef:
                 name: {{ $secretName }}
                 key: {{ $user.name }}-password
+        {{- else if $user.passwordSecretName }}
+          - name: {{ $user.name }}_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ tpl $user.passwordSecretName $ }}
+                key: {{ $user.passwordSecretKey | default (printf "%s-password" $user.name) }}
         {{- end }}
         {{- end }}
         {{- range $clusterSetting, $clusterSettingValue := .Values.init.provisioning.clusterSettings }}


### PR DESCRIPTION
This is useful to not pass the password in the values, for example
when using this chart as a dependency of another one or when working
with sealed secrets.
