### PR TITLE
Adding security context for Statefulsets

### DIFF
--- a/cockroachdb/templates/_helpers.tpl
+++ b/cockroachdb/templates/_helpers.tpl
@@ -255,3 +255,14 @@ Validate that if user enabled tls, then either self-signed certificates or certi
 {{ include "cockroachdb.tls.certs.selfSigner.nodeCertValidation" . }}
 {{- end -}}
 
+{{- define "cockroachdb.securityContext.versionValidation" }}
+{{- if semverCompare ">=21.2.13, <22.1.0" .Values.image.tag -}}
+    {{ print true }}
+{{- else }}
+{{- if semverCompare ">=22.1.2" .Values.image.tag -}}
+    {{ print true }}
+{{- else }}
+    {{ print false }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/cockroachdb/templates/_helpers.tpl
+++ b/cockroachdb/templates/_helpers.tpl
@@ -256,10 +256,10 @@ Validate that if user enabled tls, then either self-signed certificates or certi
 {{- end -}}
 
 {{- define "cockroachdb.securityContext.versionValidation" }}
-{{- if semverCompare ">=21.2.13, <22.1.0" .Values.image.tag -}}
+{{- if semverCompare ">=22.1.2" .Values.image.tag -}}
     {{ print true }}
 {{- else }}
-{{- if semverCompare ">=22.1.2" .Values.image.tag -}}
+{{- if semverCompare ">=21.2.13, <22.1.0" .Values.image.tag -}}
     {{ print true }}
 {{- else }}
     {{ print false }}

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -284,8 +284,16 @@ spec:
             periodSeconds: 5
             failureThreshold: 2
           {{- end }}
-        {{- with .Values.statefulset.securityContext }}
-          securityContext: {{- toYaml . | nindent 12 }}
+        {{- if eq (include "cockroachdb.securityContext.versionValidation" .) "true" }}
+        {{- if .Values.statefulset.securityContext.enabled }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+        {{- end }}
         {{- end }}
         {{- with .Values.statefulset.resources }}
           resources: {{- toYaml . | nindent 12 }}
@@ -342,8 +350,14 @@ spec:
           secret:
             secretName: {{ template "cockroachdb.fullname" . }}-log-config
       {{- end }}
-      {{- with .Values.securityContext }}
-      securityContext: {{- toYaml . | nindent 8 }}
+      {{- if eq (include "cockroachdb.securityContext.versionValidation" .) "true" }}
+      {{- if and .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsUser: 1000
+        runAsNonRoot: true
+      {{- end }}
       {{- end }}
 {{- if .Values.storage.persistentVolume.enabled }}
   volumeClaimTemplates:

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -284,6 +284,9 @@ spec:
             periodSeconds: 5
             failureThreshold: 2
           {{- end }}
+        {{- with .Values.statefulset.securityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+        {{- end }}
         {{- with .Values.statefulset.resources }}
           resources: {{- toYaml . | nindent 12 }}
         {{- end }}
@@ -338,6 +341,9 @@ spec:
         - name: log-config
           secret:
             secretName: {{ template "cockroachdb.fullname" . }}-log-config
+      {{- end }}
+      {{- with .Values.securityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- if .Values.storage.persistentVolume.enabled }}
   volumeClaimTemplates:

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -263,13 +263,7 @@ statefulset:
     # periodSeconds: 5
 
   securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    privileged: false
-    readOnlyRootFilesystem: true
-
+    enabled: true
 
 service:
   ports:
@@ -328,10 +322,7 @@ prometheus:
   enabled: true
 
 securityContext:
-  fsGroup: 1000
-  runAsGroup: 1000
-  runAsUser: 1000
-  runAsNonRoot: true
+  enabled: true
 
 # CockroachDB's Prometheus operator ServiceMonitor support
 serviceMonitor:

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -262,6 +262,15 @@ statefulset:
     # initialDelaySeconds: 30
     # periodSeconds: 5
 
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    privileged: false
+    readOnlyRootFilesystem: true
+
+
 service:
   ports:
     # You can set a different external and internal gRPC ports and their name.
@@ -317,6 +326,12 @@ ingress:
 
 prometheus:
   enabled: true
+
+securityContext:
+  fsGroup: 1000
+  runAsGroup: 1000
+  runAsUser: 1000
+  runAsNonRoot: true
 
 # CockroachDB's Prometheus operator ServiceMonitor support
 serviceMonitor:


### PR DESCRIPTION
The changes in this PR contain Security Context for node Statefulsets.

It covers -
container spec.
```securityContext:
  allowPrivilegeEscalation: false,
  capabilities:
    drop":
    - "ALL"
  privileged: false,
  readOnlyRootFilesystem: true```
PodSpec’s SecurityContext
```fsGroup: 1000
runAsGroup: 1000
runAsNonRoot:	true
runAsUser	1000```