### PR TITLE
Fix pdb api version for k8s 1.21+

### DIFF
--- a/cockroachdb/templates/poddisruptionbudget.yaml
+++ b/cockroachdb/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 kind: PodDisruptionBudget
-{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
+{{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version) }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1


### PR DESCRIPTION
Current if condition is wrong and chart is not installable for k8s 1.25+ because of policy/v1beta1 selection

- [ ] Fix https://github.com/cockroachdb/helm-charts/issues/270