### PR TITLE
Update terminationGracePeriodSeconds to 300 seconds

### DIFF
--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -49,7 +49,7 @@ spec:
     {{- end }}
     {{- end }}
       restartPolicy: OnFailure
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 300
     {{- if or .Values.image.credentials (and .Values.tls.enabled .Values.tls.selfSigner.image.credentials (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager)) }}
       imagePullSecrets:
       {{- if .Values.image.credentials }}

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -148,7 +148,7 @@ spec:
     {{- end }}
       # No pre-stop hook is required, a SIGTERM plus some time is all that's
       # needed for graceful shutdown of a node.
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 300
       containers:
         - name: db
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/examples/client-secure.yaml
+++ b/examples/client-secure.yaml
@@ -31,7 +31,7 @@ spec:
     command:
     - sleep
     - "2147483648" # 2^31
-  terminationGracePeriodSeconds: 0
+  terminationGracePeriodSeconds: 300
   volumes:
   - name: client-certs
     projected:


### PR DESCRIPTION
A value of 0 is strongly recommended against in the Kubernetes docs (https://github.com/kubernetes/website/pull/1731/files#diff-da05a631829c13713cb0f46fc58f809d75db6d624c62a292fc787faf441e612cR38). The CockroachDB public operator uses a value of 300 seconds (https://github.com/cockroachdb/cockroach-operator/blob/master/pkg/resource/statefulset.go#L52).