### PR TITLE
introduce configurable resource limits for the copy-certs container

### DIFF
--- a/build/templates/values.yaml
+++ b/build/templates/values.yaml
@@ -432,6 +432,18 @@ tls:
     name: ""
   copyCerts:
     image: busybox
+    # The copy-certs container copies provided certificates. It finishes
+    # quickly and doesn't continue to consume resources in the Kubernetes
+    # cluster. Normally, you should leave this section commented out, but if your
+    # Kubernetes cluster uses Resource Quotas and requires all containers to specify
+    # resource requests or limits, you can set those here.
+    resources: { }
+      # requests:
+      #   cpu: "10m"
+      #   memory: "128Mi"
+      # limits:
+      #   cpu: "10m"
+      #   memory: "128Mi"
   certs:
     # Bring your own certs scenario. If provided, tls.init section will be ignored.
     provided: false

--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -68,6 +68,9 @@ spec:
               mountPath: /cockroach-certs/
             - name: certs-secret
               mountPath: /certs/
+      {{- with .Values.tls.copyCerts.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+      {{- end }}
     {{- end }}
     {{- with .Values.init.affinity }}
       affinity: {{- toYaml . | nindent 8 }}

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -71,6 +71,9 @@ spec:
               mountPath: /cockroach-certs/
             - name: certs-secret
               mountPath: /certs/
+        {{- with .Values.tls.copyCerts.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+        {{- end }}
       {{- end }}
     {{- end }}
     {{- if or .Values.statefulset.nodeAffinity .Values.statefulset.podAffinity .Values.statefulset.podAntiAffinity }}


### PR DESCRIPTION
Resources for copy-certs has to be configurable as OPA gatekeepers etc. will not only require resource limits for pods, but all containers