### PR TITLE
Add labels to init pod

### DIFF
--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -33,6 +33,9 @@ spec:
       {{- with .Values.init.labels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.labels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- with .Values.init.annotations }}
       annotations: {{- toYaml . | nindent 8 }}
     {{- end }}


### PR DESCRIPTION
Currently `.Values.labels` is added to the metadata of the init job itself, but not to `spec.template.metadata`. This is inconsistent to `.Values.init.labels` which are added in both locations. 

This pull request fixes that and adds `.Values.labels`  to `spec.template.metadata`.