### PR TITLE
Add the release namespace in cluster scope resources

### DIFF
--- a/cockroachdb/templates/_helpers.tpl
+++ b/cockroachdb/templates/_helpers.tpl
@@ -24,6 +24,24 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Create a default fully qualified app name for cluster scope resource.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name with release namespace appended at the end.
+*/}}
+{{- define "cockroachdb.clusterfullname" -}}
+{{- if .Values.fullnameOverride -}}
+    {{- printf "%s-%s" .Values.fullnameOverride .Release.Namespace | trunc 56 | trimSuffix "-" -}}
+{{- else -}}
+    {{- $name := default .Chart.Name .Values.nameOverride -}}
+    {{- if contains $name .Release.Name -}}
+        {{- printf "%s-%s" .Release.Name .Release.Namespace | trunc 56 | trimSuffix "-" -}}
+    {{- else -}}
+        {{- printf "%s-%s-%s" .Release.Name $name .Release.Namespace | trunc 56 | trimSuffix "-" -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "cockroachdb.chart" -}}

--- a/cockroachdb/templates/clusterrole.yaml
+++ b/cockroachdb/templates/clusterrole.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "cockroachdb.fullname" . }}
+  name: {{ template "cockroachdb.clusterfullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     helm.sh/chart: {{ template "cockroachdb.chart" . }}

--- a/cockroachdb/templates/clusterrolebinding.yaml
+++ b/cockroachdb/templates/clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ template "cockroachdb.fullname" . }}
+  name: {{ template "cockroachdb.clusterfullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     helm.sh/chart: {{ template "cockroachdb.chart" . }}
@@ -15,7 +15,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "cockroachdb.fullname" . }}
+  name: {{ template "cockroachdb.clusterfullname" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "cockroachdb.tls.serviceAccount.name" . }}


### PR DESCRIPTION
Fixes #300 #283 

Added namespace name in cluster scope resources so that the name doesn't conflict when the same release name is used.