### PR TITLE
needs-build job should not fail when tagChange is not true

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,8 @@ jobs:
           echo $output | grep "You have changed the tag of selfSigner utility"
           if [[ $? -eq 0 ]]; then
             echo ::set-output name=tagChange::true
+          else
+            echo ::set-output name=tagChange::false
           fi
 
 


### PR DESCRIPTION
Fixes #310 

Added tagChange value explicitly false in job so that the job doesn't fail because of the return value from previous grep command.