### PR TITLE
Remove blank lines from ServiceMonitor

### DIFF
--- a/cockroachdb/templates/serviceMonitor.yaml
+++ b/cockroachdb/templates/serviceMonitor.yaml
@@ -12,14 +12,14 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
   {{- if $serviceMonitor.labels }}
-    {{ toYaml $serviceMonitor.labels | nindent 4 }}
+    {{- toYaml $serviceMonitor.labels | nindent 4 }}
   {{- end }}
   {{- with .Values.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- if $serviceMonitor.annotations }}
   annotations:
-    {{ toYaml $serviceMonitor.annotations | nindent 4 }}
+    {{- toYaml $serviceMonitor.annotations | nindent 4 }}
   {{- end }}
 spec:
   selector:


### PR DESCRIPTION
The `ServiceMonitor` contains blank lines when adding custom labels and annotations:
```
# Source: cockroachdb/templates/serviceMonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: cockroachdb
  namespace: "crdb"
  labels:
    helm.sh/chart: cockroachdb-9.1.0
    app.kubernetes.io/name: cockroachdb
    app.kubernetes.io/instance: "my-instance"
    app.kubernetes.io/managed-by: "Helm"
                                                         <---- This line
    my-label: and-a-value-for-it
```

This PR should fix it.