### PR TITLE
release: advance CRDB version to v23.1.3

### DIFF
--- a/build/templates/README.md
+++ b/build/templates/README.md
@@ -284,9 +284,9 @@ Verify that no pod is deleted and then upgrade as normal. A new StatefulSet will
 
 ### See also
 
-For more information about upgrading a cluster to the latest major release of CockroachDB, see [Upgrade to CockroachDB v21.1](https://www.cockroachlabs.com/docs/stable/upgrade-cockroach-version.html).
+For more information about upgrading a cluster to the latest major release of CockroachDB, see [Upgrade to CockroachDB](https://www.cockroachlabs.com/docs/stable/upgrade-cockroach-version.html).
 
-Note that there are some backward-incompatible changes to SQL features between versions 20.2 and 21.1. For details, see the [CockroachDB v{{ .AppVersion }} release notes](https://www.cockroachlabs.com/docs/releases/v{{ .AppVersion }}.html#backward-incompatible-changes).
+Note that there are sometimes backward-incompatible changes to SQL features between major CockroachDB releases. For details, see the [Upgrade Policy](https://www.cockroachlabs.com/docs/cockroachcloud/upgrade-policy).
 
 ## Configuration
 

--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 11.0.1
-appVersion: 23.1.2
+version: 11.0.2
+appVersion: 23.1.3
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png
 sources:

--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -229,10 +229,10 @@ kubectl get pods \
 ```
 
 ```
-my-release-cockroachdb-0    cockroachdb/cockroach:v23.1.2
-my-release-cockroachdb-1    cockroachdb/cockroach:v23.1.2
-my-release-cockroachdb-2    cockroachdb/cockroach:v23.1.2
-my-release-cockroachdb-3    cockroachdb/cockroach:v23.1.2
+my-release-cockroachdb-0    cockroachdb/cockroach:v23.1.3
+my-release-cockroachdb-1    cockroachdb/cockroach:v23.1.3
+my-release-cockroachdb-2    cockroachdb/cockroach:v23.1.3
+my-release-cockroachdb-3    cockroachdb/cockroach:v23.1.3
 ```
 
 Resume normal operations. Once you are comfortable that the stability and performance of the cluster is what you'd expect post-upgrade, finalize the upgrade:
@@ -285,9 +285,9 @@ Verify that no pod is deleted and then upgrade as normal. A new StatefulSet will
 
 ### See also
 
-For more information about upgrading a cluster to the latest major release of CockroachDB, see [Upgrade to CockroachDB v21.1](https://www.cockroachlabs.com/docs/stable/upgrade-cockroach-version.html).
+For more information about upgrading a cluster to the latest major release of CockroachDB, see [Upgrade to CockroachDB](https://www.cockroachlabs.com/docs/stable/upgrade-cockroach-version.html).
 
-Note that there are some backward-incompatible changes to SQL features between versions 20.2 and 21.1. For details, see the [CockroachDB v23.1.2 release notes](https://www.cockroachlabs.com/docs/releases/v23.1.2.html#backward-incompatible-changes).
+Note that there are sometimes backward-incompatible changes to SQL features between major CockroachDB releases. For details, see the [Upgrade Policy](https://www.cockroachlabs.com/docs/cockroachcloud/upgrade-policy).
 
 ## Configuration
 
@@ -316,7 +316,7 @@ For details see the [`values.yaml`](values.yaml) file.
 | `conf.store.size`                                         | CockroachDB storage size                                        | `""`                                                  |
 | `conf.store.attrs`                                        | CockroachDB storage attributes                                  | `""`                                                  |
 | `image.repository`                                        | Container image name                                            | `cockroachdb/cockroach`                               |
-| `image.tag`                                               | Container image tag                                             | `v23.1.2`                                             |
+| `image.tag`                                               | Container image tag                                             | `v23.1.3`                                             |
 | `image.pullPolicy`                                        | Container pull policy                                           | `IfNotPresent`                                        |
 | `image.credentials`                                       | `registry`, `user` and `pass` credentials to pull private image | `{}`                                                  |
 | `statefulset.replicas`                                    | StatefulSet replicas number                                     | `3`                                                   |

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -1,7 +1,7 @@
 # Generated file, DO NOT EDIT. Source: build/templates/values.yaml
 image:
   repository: cockroachdb/cockroach
-  tag: v23.1.2
+  tag: v23.1.3
   pullPolicy: IfNotPresent
   credentials: {}
     # registry: docker.io


### PR DESCRIPTION
(Note that I manually edited out some references to v21.1 and fixed a URL that wasn't valid.)