### PR TITLE
Fix early exit in changetag check

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,9 +26,7 @@ jobs:
       - name: Check Tag Change
         id: changetag
         run: |
-          output=$(./build/self-signer-utility.sh)
-          echo $output | grep "You have changed the tag of selfSigner utility"
-          if [[ $? -eq 0 ]]; then
+          if ./build/self-signer-utility.sh | grep -q "You have changed the tag of selfSigner utility"; then
             echo ::set-output name=tagChange::true
           else
             echo ::set-output name=tagChange::false


### PR DESCRIPTION
Previously, the `changetag` step tried to run some commands that can return non zero and fail the step before the `if` check.

This PR simplifies the `if` statement to evaluate the exit code of the check.