### PR TITLE
Removes a newline in the securityContext helper

### DIFF
--- a/cockroachdb/templates/_helpers.tpl
+++ b/cockroachdb/templates/_helpers.tpl
@@ -274,7 +274,7 @@ Validate that if user enabled tls, then either self-signed certificates or certi
 {{- end -}}
 
 {{- define "cockroachdb.securityContext.versionValidation" }}
-{{/* Allow using `securityContext` for custom images. */}}
+{{- /* Allow using `securityContext` for custom images. */}}
 {{- if ne "cockroachdb/cockroach" .Values.image.repository -}}
     {{ print true }}
 {{- else -}}


### PR DESCRIPTION
The accidentally added newline lead to a always false if condition. "true" != "\r\ntrue" and therefor securityContext was never added.