### PR TITLE
Fix provisioner not retrying on failure

### DIFF
--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -203,7 +203,7 @@ spec:
 
                   local exitCode="$?";
 
-                  if [[ "$exitCode" == "0" ]]
+                  if [[ "$exitCode" -eq "0" ]]
                     then break;
                   fi
 


### PR DESCRIPTION
When the provisioner fails to run, it is not retried and the Kubernetes job is marked as a success. Issue is just a typo in logic.