### PR TITLE
Add pod security policy

### DIFF
--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 11.1.7
+version: 11.2.0
 appVersion: 23.1.10
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb/templates/job-certSelfSigner.yaml
+++ b/cockroachdb/templates/job-certSelfSigner.yaml
@@ -30,6 +30,8 @@ spec:
     spec:
     {{- if and .Values.tls.certs.selfSigner.securityContext.enabled }}
       securityContext:
+        seccompProfile:
+          type: "RuntimeDefault"
         runAsGroup: 1000
         runAsUser: 1000
         fsGroup: 1000
@@ -71,5 +73,11 @@ spec:
             value: {{ .Release.Namespace | quote }}
           - name: CLUSTER_DOMAIN
             value: {{ .Values.clusterDomain}}
+        {{- if and .Values.tls.certs.selfSigner.securityContext.enabled }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:  
+              drop: ["ALL"]
+        {{- end }}
       serviceAccountName: {{ template "selfcerts.fullname" . }}
 {{- end}}

--- a/cockroachdb/templates/job-cleaner.yaml
+++ b/cockroachdb/templates/job-cleaner.yaml
@@ -27,6 +27,8 @@ spec:
     spec:
     {{- if and .Values.tls.certs.selfSigner.securityContext.enabled }}
       securityContext:
+        seccompProfile:
+          type: "RuntimeDefault"
         runAsGroup: 1000
         runAsUser: 1000
         fsGroup: 1000
@@ -43,5 +45,11 @@ spec:
           env:
           - name: STATEFULSET_NAME
             value: {{ template "cockroachdb.fullname" . }}
+        {{- if and .Values.tls.certs.selfSigner.securityContext.enabled }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:  
+              drop: ["ALL"]
+        {{- end }}
       serviceAccountName: {{ template "rotatecerts.fullname" . }}
 {{- end}}

--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -40,6 +40,8 @@ spec:
     {{- if eq (include "cockroachdb.securityContext.versionValidation" .) "true" }}
     {{- if and .Values.init.securityContext.enabled }}
       securityContext:
+        seccompProfile:
+          type: "RuntimeDefault"
         runAsGroup: 1000
         runAsUser: 1000
         fsGroup: 1000
@@ -72,6 +74,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+        {{- if and .Values.init.securityContext.enabled }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:  
+              drop: ["ALL"]
+        {{- end }}
           volumeMounts:
             - name: client-certs
               mountPath: /cockroach-certs/
@@ -246,6 +254,12 @@ spec:
         {{- end }}
         {{- with .Values.init.resources }}
           resources: {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- if and .Values.init.securityContext.enabled }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:  
+              drop: ["ALL"]
         {{- end }}
     {{- if .Values.tls.enabled }}
       volumes:

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -65,6 +65,17 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+        {{- if .Values.statefulset.securityContext.enabled }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: "RuntimeDefault"
+        {{- end }}
           volumeMounts:
             - name: certs
               mountPath: /cockroach-certs/

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -73,8 +73,6 @@ spec:
                 - ALL
             privileged: false
             readOnlyRootFilesystem: true
-            seccompProfile:
-              type: "RuntimeDefault"
         {{- end }}
           volumeMounts:
             - name: certs
@@ -367,6 +365,8 @@ spec:
       {{- if eq (include "cockroachdb.securityContext.versionValidation" .) "true" }}
       {{- if and .Values.securityContext.enabled }}
       securityContext:
+        seccompProfile:
+          type: "RuntimeDefault"
         fsGroup: 1000
         runAsGroup: 1000
         runAsUser: 1000

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -303,8 +303,6 @@ spec:
                 - ALL
             privileged: false
             readOnlyRootFilesystem: true
-            seccompProfile:
-              type: "RuntimeDefault"
         {{- end }}
         {{- end }}
         {{- with .Values.statefulset.resources }}

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -294,6 +294,8 @@ spec:
                 - ALL
             privileged: false
             readOnlyRootFilesystem: true
+            seccompProfile:
+              type: "RuntimeDefault"
         {{- end }}
         {{- end }}
         {{- with .Values.statefulset.resources }}


### PR DESCRIPTION
This adds pod security policy and `seccompProfile`. I was unable to get the Helm chart to install locally to verify that these changes work when tls is enabled and the self signer is enabled, this seems to be the default configuration based on values. Whenever I attempt to do this I always get errors that the serviceaccount, roles, and rolebinding already exist due to how the annotations are being set manually. I'm not familiar enough with this chart to know if we should change those to include the release-name so that a subsequent run does not try to recreate them.

If I could get this to work locally I believe I will also need to resources in the jobs `job-certSelfSigner` and `job-cleaner` as we require setting resource limits/requests everywhere.