### PR TITLE
Cert-manager node certificates should support customize dns domains

### DIFF
--- a/cockroachdb/templates/certificate.node.yaml
+++ b/cockroachdb/templates/certificate.node.yaml
@@ -36,6 +36,9 @@ spec:
     - {{ printf "*.%s" (include "cockroachdb.fullname" .) | quote }}
     - {{ printf "*.%s.%s" (include "cockroachdb.fullname" .) .Release.Namespace | quote }}
     - {{ printf "*.%s.%s.svc.%s" (include "cockroachdb.fullname" .) .Release.Namespace .Values.clusterDomain | quote }}
+    {{- range $domain := .Values.tls.certs.certManagerIssuer.additionalDNSNames  }}
+    - {{ $domain | quote }}
+    {{- end }}
   secretName: {{ .Values.tls.certs.nodeSecret }}
   issuerRef:
     name: {{ template "cockroachdb.fullname" . }}-ca-issuer

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -528,6 +528,9 @@ tls:
       nodeCertDuration: 8760h
       # Expiry window of node certificates means a window before actual expiry in which node certs should be rotated.
       nodeCertExpiryWindow: 168h
+      # Additional DNS names that will be included in the node certificates
+      additionalDNSNames: []
+      # - cockroachlabs.com
 
   selfSigner:
     # Additional annotations to apply to the Pod of this Job.


### PR DESCRIPTION
Cross cloud[region/zones/namespace] cockroachdb clusters, it might be multi helm chart release, cert-manager node certificates dnsNames has not supported customize domains yet.

It should be supported by using external FQDN.

For example. 

values-a.yaml
```yaml
tls:
  enabled: true
  certs:
    selfSigner:
      enabled: false
    certManager: true
statefulset:
  env: 
    - name: STATEFULSET_FQDN
      value: region-a.crdb.com
```

values-b.yaml
```yaml
tls:
  enabled: true
  certs:
    selfSigner:
      enabled: false
    certManager: true
statefulset:
  env: 
    - name: STATEFULSET_FQDN
      value: region-b.crdb.com
```

With overwrite `STATEFULSET_FQDN`,  region a/b would use external dns names, and certificates should be with customize dns domains.