### PR TITLE
Add custom fields to self signer jobs

### DIFF
--- a/build/templates/values.yaml
+++ b/build/templates/values.yaml
@@ -529,6 +529,9 @@ tls:
       nodeCertExpiryWindow: 168h
 
   selfSigner:
+    # Additional labels to apply to the Pod of this Job.
+    labels: {}
+
     # Additional annotations to apply to the Pod of this Job.
     annotations: {}
 

--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 11.2.4
+version: 11.2.5
 appVersion: 23.1.14
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb/templates/cronjob-ca-certSelfSigner.yaml
+++ b/cockroachdb/templates/cronjob-ca-certSelfSigner.yaml
@@ -20,8 +20,24 @@ spec:
     spec:
       backoffLimit: 1
       template:
+        metadata:
+        {{- with .Values.tls.selfSigner.annotations }}
+          annotations: {{- toYaml . | nindent 12 }}
+        {{- end }}
         spec:
           restartPolicy: Never
+        {{- if or .Values.tls.selfSigner.nodeAffinity }}
+          affinity:
+          {{- with .Values.tls.selfSigner.nodeAffinity }}
+            nodeAffinity: {{- toYaml . | nindent 14 }}
+          {{- end }}
+        {{- end }}
+          {{- with .Values.tls.selfSigner.nodeSelector }}
+          nodeSelector: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tls.selfSigner.tolerations }}
+          tolerations: {{- toYaml . | nindent 12 }}
+          {{- end }}
           containers:
           - name: cert-rotate-job
             image: "{{ .Values.tls.selfSigner.image.registry }}/{{ .Values.tls.selfSigner.image.repository }}:{{ .Values.tls.selfSigner.image.tag }}"

--- a/cockroachdb/templates/cronjob-ca-certSelfSigner.yaml
+++ b/cockroachdb/templates/cronjob-ca-certSelfSigner.yaml
@@ -21,6 +21,9 @@ spec:
       backoffLimit: 1
       template:
         metadata:
+        {{- with .Values.tls.selfSigner.labels }}
+          labels: {{- toYaml . | nindent 12 }}
+        {{- end }}
         {{- with .Values.tls.selfSigner.annotations }}
           annotations: {{- toYaml . | nindent 12 }}
         {{- end }}

--- a/cockroachdb/templates/cronjob-ca-certSelfSigner.yaml
+++ b/cockroachdb/templates/cronjob-ca-certSelfSigner.yaml
@@ -26,18 +26,15 @@ spec:
         {{- end }}
         spec:
           restartPolicy: Never
-        {{- if or .Values.tls.selfSigner.nodeAffinity }}
-          affinity:
-          {{- with .Values.tls.selfSigner.nodeAffinity }}
-            nodeAffinity: {{- toYaml . | nindent 14 }}
-          {{- end }}
+        {{- with .Values.tls.selfSigner.affinity }}
+          affinity: {{- toYaml . | nindent 12 }}
         {{- end }}
-          {{- with .Values.tls.selfSigner.nodeSelector }}
+        {{- with .Values.tls.selfSigner.nodeSelector }}
           nodeSelector: {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.tls.selfSigner.tolerations }}
+        {{- end }}
+        {{- with .Values.tls.selfSigner.tolerations }}
           tolerations: {{- toYaml . | nindent 12 }}
-          {{- end }}
+        {{- end }}
           containers:
           - name: cert-rotate-job
             image: "{{ .Values.tls.selfSigner.image.registry }}/{{ .Values.tls.selfSigner.image.repository }}:{{ .Values.tls.selfSigner.image.tag }}"

--- a/cockroachdb/templates/cronjob-client-node-certSelfSigner.yaml
+++ b/cockroachdb/templates/cronjob-client-node-certSelfSigner.yaml
@@ -19,8 +19,24 @@ spec:
     spec:
       backoffLimit: 1
       template:
+        metadata:
+        {{- with .Values.tls.selfSigner.annotations }}
+          annotations: {{- toYaml . | nindent 12 }}
+        {{- end }}
         spec:
           restartPolicy: Never
+        {{- if or .Values.tls.selfSigner.nodeAffinity }}
+          affinity:
+          {{- with .Values.tls.selfSigner.nodeAffinity }}
+            nodeAffinity: {{- toYaml . | nindent 14 }}
+          {{- end }}
+        {{- end }}
+          {{- with .Values.tls.selfSigner.nodeSelector }}
+          nodeSelector: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tls.selfSigner.tolerations }}
+          tolerations: {{- toYaml . | nindent 12 }}
+          {{- end }}
           containers:
           - name: cert-rotate-job
             image: "{{ .Values.tls.selfSigner.image.registry }}/{{ .Values.tls.selfSigner.image.repository }}:{{ .Values.tls.selfSigner.image.tag }}"

--- a/cockroachdb/templates/cronjob-client-node-certSelfSigner.yaml
+++ b/cockroachdb/templates/cronjob-client-node-certSelfSigner.yaml
@@ -20,6 +20,9 @@ spec:
       backoffLimit: 1
       template:
         metadata:
+        {{- with .Values.tls.selfSigner.labels }}
+          labels: {{- toYaml . | nindent 12 }}
+        {{- end }}
         {{- with .Values.tls.selfSigner.annotations }}
           annotations: {{- toYaml . | nindent 12 }}
         {{- end }}

--- a/cockroachdb/templates/cronjob-client-node-certSelfSigner.yaml
+++ b/cockroachdb/templates/cronjob-client-node-certSelfSigner.yaml
@@ -25,18 +25,15 @@ spec:
         {{- end }}
         spec:
           restartPolicy: Never
-        {{- if or .Values.tls.selfSigner.nodeAffinity }}
-          affinity:
-          {{- with .Values.tls.selfSigner.nodeAffinity }}
-            nodeAffinity: {{- toYaml . | nindent 14 }}
-          {{- end }}
+        {{- with .Values.tls.selfSigner.affinity }}
+          affinity: {{- toYaml . | nindent 12 }}
         {{- end }}
-          {{- with .Values.tls.selfSigner.nodeSelector }}
+        {{- with .Values.tls.selfSigner.nodeSelector }}
           nodeSelector: {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.tls.selfSigner.tolerations }}
+        {{- end }}
+        {{- with .Values.tls.selfSigner.tolerations }}
           tolerations: {{- toYaml . | nindent 12 }}
-          {{- end }}
+        {{- end }}
           containers:
           - name: cert-rotate-job
             image: "{{ .Values.tls.selfSigner.image.registry }}/{{ .Values.tls.selfSigner.image.repository }}:{{ .Values.tls.selfSigner.image.tag }}"

--- a/cockroachdb/templates/job-certSelfSigner.yaml
+++ b/cockroachdb/templates/job-certSelfSigner.yaml
@@ -24,6 +24,9 @@ spec:
         app.kubernetes.io/name: {{ template "cockroachdb.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+      {{- with .Values.tls.selfSigner.labels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- with .Values.tls.selfSigner.annotations }}
       annotations: {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -73,7 +76,7 @@ spec:
         {{- if and .Values.tls.certs.selfSigner.securityContext.enabled }}
           securityContext:
             allowPrivilegeEscalation: false
-            capabilities:  
+            capabilities:
               drop: ["ALL"]
         {{- end }}
       serviceAccountName: {{ template "selfcerts.fullname" . }}

--- a/cockroachdb/templates/job-certSelfSigner.yaml
+++ b/cockroachdb/templates/job-certSelfSigner.yaml
@@ -38,18 +38,15 @@ spec:
         runAsNonRoot: true
     {{- end }}
       restartPolicy: Never
-    {{- if or .Values.tls.selfSigner.nodeAffinity }}
-      affinity:
-      {{- with .Values.tls.selfSigner.nodeAffinity }}
-        nodeAffinity: {{- toYaml . | nindent 10 }}
-      {{- end }}
+    {{- with .Values.tls.selfSigner.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
     {{- end }}
-      {{- with .Values.tls.selfSigner.nodeSelector }}
+    {{- with .Values.tls.selfSigner.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.tls.selfSigner.tolerations }}
+    {{- end }}
+    {{- with .Values.tls.selfSigner.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
-      {{- end }}
+    {{- end }}
       containers:
         - name: cert-generate-job
           image: "{{ .Values.tls.selfSigner.image.registry }}/{{ .Values.tls.selfSigner.image.repository }}:{{ .Values.tls.selfSigner.image.tag }}"

--- a/cockroachdb/templates/job-cleaner.yaml
+++ b/cockroachdb/templates/job-cleaner.yaml
@@ -24,6 +24,9 @@ spec:
         app.kubernetes.io/name: {{ template "cockroachdb.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    {{- with .Values.tls.selfSigner.annotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+    {{- end }}
     spec:
     {{- if and .Values.tls.certs.selfSigner.securityContext.enabled }}
       securityContext:
@@ -35,6 +38,18 @@ spec:
         runAsNonRoot: true
     {{- end }}
       restartPolicy: Never
+    {{- if or .Values.tls.selfSigner.nodeAffinity }}
+      affinity:
+      {{- with .Values.tls.selfSigner.nodeAffinity }}
+        nodeAffinity: {{- toYaml . | nindent 10 }}
+      {{- end }}
+    {{- end }}
+      {{- with .Values.tls.selfSigner.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tls.selfSigner.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: cleaner
           image: "{{ .Values.tls.selfSigner.image.registry }}/{{ .Values.tls.selfSigner.image.repository }}:{{ .Values.tls.selfSigner.image.tag }}"
@@ -48,7 +63,7 @@ spec:
         {{- if and .Values.tls.certs.selfSigner.securityContext.enabled }}
           securityContext:
             allowPrivilegeEscalation: false
-            capabilities:  
+            capabilities:
               drop: ["ALL"]
         {{- end }}
       serviceAccountName: {{ template "rotatecerts.fullname" . }}

--- a/cockroachdb/templates/job-cleaner.yaml
+++ b/cockroachdb/templates/job-cleaner.yaml
@@ -24,6 +24,9 @@ spec:
         app.kubernetes.io/name: {{ template "cockroachdb.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+      {{- with .Values.tls.selfSigner.labels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- with .Values.tls.selfSigner.annotations }}
       annotations: {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/cockroachdb/templates/job-cleaner.yaml
+++ b/cockroachdb/templates/job-cleaner.yaml
@@ -38,18 +38,15 @@ spec:
         runAsNonRoot: true
     {{- end }}
       restartPolicy: Never
-    {{- if or .Values.tls.selfSigner.nodeAffinity }}
-      affinity:
-      {{- with .Values.tls.selfSigner.nodeAffinity }}
-        nodeAffinity: {{- toYaml . | nindent 10 }}
-      {{- end }}
+    {{- with .Values.tls.selfSigner.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
     {{- end }}
-      {{- with .Values.tls.selfSigner.nodeSelector }}
+    {{- with .Values.tls.selfSigner.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.tls.selfSigner.tolerations }}
+    {{- end }}
+    {{- with .Values.tls.selfSigner.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
-      {{- end }}
+    {{- end }}
       containers:
         - name: cleaner
           image: "{{ .Values.tls.selfSigner.image.registry }}/{{ .Values.tls.selfSigner.image.repository }}:{{ .Values.tls.selfSigner.image.tag }}"

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -530,6 +530,9 @@ tls:
       nodeCertExpiryWindow: 168h
 
   selfSigner:
+    # Additional labels to apply to the Pod of this Job.
+    labels: {}
+
     # Additional annotations to apply to the Pod of this Job.
     annotations: {}
 


### PR DESCRIPTION
Currently annotations, affinity, node selector and tolerations are only applied to self signer init job. It would be better if those are also applied to rotate cronjobs and clean-up job.
My use case is to disable Istio sidecar injection to the clean-up job.