### PR TITLE
Fix cert manager to use custom CA issuer provided by user

### DIFF
--- a/cockroachdb/templates/certificate.client.yaml
+++ b/cockroachdb/templates/certificate.client.yaml
@@ -28,7 +28,13 @@ spec:
       - Cockroach
   secretName: {{ .Values.tls.certs.clientRootSecret }}
   issuerRef:
+  {{- if .Values.tls.certs.certManagerIssuer.isSelfSignedIssuer }}
     name: {{ template "cockroachdb.fullname" . }}-ca-issuer
     kind: Issuer
     group: cert-manager.io
+  {{- else }}
+    name: {{ .Values.tls.certs.certManagerIssuer.name }}
+    kind: {{ .Values.tls.certs.certManagerIssuer.kind }}
+    group: {{ .Values.tls.certs.certManagerIssuer.group }}
+  {{- end }}
 {{- end }}

--- a/cockroachdb/templates/certificate.node.yaml
+++ b/cockroachdb/templates/certificate.node.yaml
@@ -38,7 +38,13 @@ spec:
     - {{ printf "*.%s.%s.svc.%s" (include "cockroachdb.fullname" .) .Release.Namespace .Values.clusterDomain | quote }}
   secretName: {{ .Values.tls.certs.nodeSecret }}
   issuerRef:
+  {{- if .Values.tls.certs.certManagerIssuer.isSelfSignedIssuer }}
     name: {{ template "cockroachdb.fullname" . }}-ca-issuer
     kind: Issuer
     group: cert-manager.io
+  {{- else }}
+    name: {{ .Values.tls.certs.certManagerIssuer.name }}
+    kind: {{ .Values.tls.certs.certManagerIssuer.kind }}
+    group: {{ .Values.tls.certs.certManagerIssuer.group }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes: #355 

It allows user to provide a CA issuer to generate client and node certificates.