### PR TITLE
Update terminationGracePeriodSeconds to 300 seconds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ test/cluster: bin/kind ## start a local kind cluster for testing
 
 test/e2e/%: PKG=$*
 test/e2e/%: bin/cockroach bin/kubectl bin/helm build/self-signer test/publish-images-to-kind ## run e2e tests for package (e.g. install or rotate)
-	@PATH="$(PWD)/bin:${PATH}" go test -v ./tests/e2e/$(PKG)/...
+	@PATH="$(PWD)/bin:${PATH}" go test -timeout 30m -v ./tests/e2e/$(PKG)/...
 
 test/lint: bin/helm ## lint the helm chart
 	@build/lint.sh && bin/helm lint cockroachdb

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Kick off the upgrade process by changing the new Docker image, where `$new_versi
 ```shell
 helm upgrade my-release cockroachdb/cockroachdb \
 --set image.tag=$new_version \
---reuse-values
+--reuse-values --timeout=20m
 ```
 
 Kubernetes will carry out a safe [rolling upgrade](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets) of your CockroachDB nodes one-by-one. Monitor the cluster's pods until all have been successfully restarted:
@@ -174,7 +174,7 @@ User can move from old kubernetes signing certificates by performing following s
 Run the upgrade command with upgrade strategy set as "onDelete" which only upgrades the pods when deleted by the user.
 
 ```shell
-helm upgrade crdb-test cockroachdb --set statefulset.updateStrategy.type="OnDelete"
+helm upgrade crdb-test cockroachdb --set statefulset.updateStrategy.type="OnDelete" --timeout=20m
 ```
 
 While monitor all the pods, once the init-job is created, you can delete all the cockroachdb pods with following command:

--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -49,7 +49,7 @@ spec:
     {{- end }}
     {{- end }}
       restartPolicy: OnFailure
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 300
     {{- if or .Values.image.credentials (and .Values.tls.enabled .Values.tls.selfSigner.image.credentials (not .Values.tls.certs.provided) (not .Values.tls.certs.certManager)) }}
       imagePullSecrets:
       {{- if .Values.image.credentials }}

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -148,7 +148,7 @@ spec:
     {{- end }}
       # No pre-stop hook is required, a SIGTERM plus some time is all that's
       # needed for graceful shutdown of a node.
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 300
       containers:
         - name: db
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/examples/client-secure.yaml
+++ b/examples/client-secure.yaml
@@ -31,7 +31,7 @@ spec:
     command:
     - sleep
     - "2147483648" # 2^31
-  terminationGracePeriodSeconds: 0
+  terminationGracePeriodSeconds: 300
   volumes:
   - name: client-certs
     projected:

--- a/tests/e2e/install/cockroachdb_helm_e2e_test.go
+++ b/tests/e2e/install/cockroachdb_helm_e2e_test.go
@@ -315,6 +315,11 @@ func TestCockroachDbHelmMigration(t *testing.T) {
 			"storage.persistentVolume.size":   "1Gi",
 			"statefulset.updateStrategy.type": "OnDelete",
 		},
+		ExtraArgs: map[string][]string{
+			"upgrade": []string{
+				"--timeout=20m",
+			},
+		},
 	}
 
 	// Upgrade the cockroachdb helm chart and checks installation should succeed.


### PR DESCRIPTION
We've extended the terminationGracePeriodSeconds to 300 seconds for the CockroachDB StatefulSet, allowing up to 300 seconds for termination of the pod. Consequently, we need to adjust the Helm upgrade timeout accordingly for a standard 3-node CockroachDB cluster.