### PR TITLE
Move template calls out of networkPolicy.ingress.grpc scope

### DIFF
--- a/cockroachdb/templates/networkpolicy.yaml
+++ b/cockroachdb/templates/networkpolicy.yaml
@@ -23,10 +23,11 @@ spec:
   ingress:
     - ports:
         - port: grpc
-    {{- with .Values.networkPolicy.ingress.grpc }}
       from:
+      {{- with .Values.networkPolicy.ingress.grpc }}
         # Allow connections via custom rules.
         {{- toYaml . | nindent 8 }}
+      {{- end }}
         # Allow client connection via pre-considered label.
         - podSelector:
             matchLabels:
@@ -49,7 +50,6 @@ spec:
               {{- toYaml . | nindent 14 }}
             {{- end }}
       {{- end }}
-    {{- end }}
     # Allow connections to admin UI and for Prometheus.
     - ports:
         - port: http


### PR DESCRIPTION
as stated in https://github.com/cockroachdb/helm-charts/issues/24 it's not possible to use networkPolicies with custom grpc rules.
PR https://github.com/cockroachdb/helm-charts/pull/297 seems to be stale and the proposed solution renders strangely for the default of grpc (empty array).

This PR renders
```yaml
networkPolicy:
  enabled: true
  ingress:
    grpc:
    - podSelector:
        matchLabels:
          app.kubernetes.io/instance: foo
```
into 

```yaml
[...]
  ingress:
    - ports:
        - port: grpc
      from:
        # Allow connections via custom rules.
        - podSelector:
            matchLabels:
              app.kubernetes.io/instance: foo
        # Allow client connection via pre-considered label.
        - podSelector:
            matchLabels:
[...]
```

and 

```yaml
networkPolicy:
  enabled: true
# leave grpc as empty array
```
into

```yaml
[...]
  ingress:
    - ports:
        - port: grpc
      from:
        # Allow client connection via pre-considered label.
        - podSelector:
            matchLabels:
[...]
```