### PR TITLE
Feat: self signer resource quotas

### DIFF
--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 12.0.4
+version: 12.0.5
 appVersion: 23.2.4
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb/templates/cronjob-ca-certSelfSigner.yaml
+++ b/cockroachdb/templates/cronjob-ca-certSelfSigner.yaml
@@ -42,5 +42,9 @@ spec:
             - name: CLUSTER_DOMAIN
               value: {{ .Values.clusterDomain}}
           serviceAccountName: {{ template "rotatecerts.fullname" . }}
+      {{- with .Values.tls.selfSigner.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+      {{- end }}
+
   {{- end }}
 {{- end }}

--- a/cockroachdb/templates/cronjob-client-node-certSelfSigner.yaml
+++ b/cockroachdb/templates/cronjob-client-node-certSelfSigner.yaml
@@ -49,5 +49,8 @@ spec:
               value: {{ .Release.Namespace }}
             - name: CLUSTER_DOMAIN
               value: {{ .Values.clusterDomain}}
+        {{- with .Values.tls.selfSigner.resources }}
+            resources: {{- toYaml . | nindent 14 }}
+        {{- end }}
           serviceAccountName: {{ template "rotatecerts.fullname" . }}
   {{- end}}

--- a/cockroachdb/templates/job-certSelfSigner.yaml
+++ b/cockroachdb/templates/job-certSelfSigner.yaml
@@ -73,6 +73,9 @@ spec:
             value: {{ .Release.Namespace | quote }}
           - name: CLUSTER_DOMAIN
             value: {{ .Values.clusterDomain}}
+        {{- with .Values.tls.selfSigner.resources }}
+            resources: {{- toYaml . | nindent 14 }}
+        {{- end }}
         {{- if and .Values.tls.certs.selfSigner.securityContext.enabled }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/cockroachdb/templates/job-certSelfSigner.yaml
+++ b/cockroachdb/templates/job-certSelfSigner.yaml
@@ -73,9 +73,9 @@ spec:
             value: {{ .Release.Namespace | quote }}
           - name: CLUSTER_DOMAIN
             value: {{ .Values.clusterDomain}}
-        {{- with .Values.tls.selfSigner.resources }}
-            resources: {{- toYaml . | nindent 14 }}
-        {{- end }}
+      {{- with .Values.tls.selfSigner.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+      {{- end }}
         {{- if and .Values.tls.certs.selfSigner.securityContext.enabled }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/cockroachdb/templates/job-cleaner.yaml
+++ b/cockroachdb/templates/job-cleaner.yaml
@@ -45,6 +45,9 @@ spec:
           env:
           - name: STATEFULSET_NAME
             value: {{ template "cockroachdb.fullname" . }}
+        {{- with .Values.tls.selfSigner.resources }}
+            resources: {{- toYaml . | nindent 14 }}
+        {{- end }}
         {{- if and .Values.tls.certs.selfSigner.securityContext.enabled }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -555,6 +555,17 @@ tls:
       # username: john_doe
       # password: changeme
 
+    # Uncomment the following resources definitions or pass them from
+    # command line to control the CPU and memory resources allocated
+    # by Pods of this StatefulSet.
+    resources: {}
+      # limits:
+      #   cpu: 100m
+      #   memory: 512Mi
+      # requests:
+      #   cpu: 100m
+      #   memory: 512Mi
+
 networkPolicy:
   enabled: false
 


### PR DESCRIPTION
Adds the possibility to define resource quotas for `selfSigner` related jobs. Required to deploy chart to environments, which strictly enforce quotas being set on pods.