### PR TITLE
[CRDB-44993] pvc: support persistent volume for logs

### DIFF
--- a/build/templates/values.yaml
+++ b/build/templates/values.yaml
@@ -69,14 +69,35 @@ conf:
   log:
     enabled: false
     # https://www.cockroachlabs.com/docs/v21.1/configure-logs
-    config: {}
+    config:
       # file-defaults:
-      #   dir: /custom/dir/path/
+      #   dir: /cockroach/cockroach-logs
       # fluent-defaults:
       #   format: json-fluent
       # sinks:
       #   stderr:
       #     channels: [DEV]
+    persistentVolume:
+      # If enabled, then a PersistentVolumeClaim will be created and
+      # used to store CockroachDB's logs.
+      enabled: false
+      # CockroachDB's logs volume mount path. This gets prepended with
+      # `/cockroach/` in the stateful set. The `conf.log.config` should have
+      # `file-defaults.dir` to specify the log path and should reference the
+      # mounted volume.
+      path: cockroach-logs
+      size: 10Gi
+      # If defined, then `storageClassName: <storageClass>`.
+      # If set to "-", then `storageClassName: ""`, which disables dynamic
+      # provisioning.
+      # If undefined or empty (default), then no `storageClassName` spec is
+      # set, so the default provisioner will be chosen (gp2 on AWS, standard
+      # on GKE, AWS & OpenStack).
+      storageClass: ""
+      # Additional labels to apply to the created PersistentVolumeClaims.
+      labels: {}
+      # Additional annotations to apply to the created PersistentVolumeClaims.
+      annotations: {}
 
   # Logs at or above this threshold to STDERR. Ignored when "log" is enabled
   logtostderr: INFO

--- a/cockroachdb/templates/_helpers.tpl
+++ b/cockroachdb/templates/_helpers.tpl
@@ -289,3 +289,17 @@ Validate that if user enabled tls, then either self-signed certificates or certi
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Validate the log configuration.
+*/}}
+{{- define "cockroachdb.conf.log.validation" -}}
+{{- if and (not .Values.conf.log.enabled) .Values.conf.log.persistentVolume.enabled -}}
+    {{ fail "Persistent volume for logs can only be enabled if logging is enabled" }}
+{{- end -}}
+{{- if and .Values.conf.log.persistentVolume.enabled (dig "file-defaults" "dir" "" .Values.conf.log.config) -}}
+{{- if not (hasPrefix (printf "/cockroach/%s" .Values.conf.log.persistentVolume.path) (dig "file-defaults" "dir" "" .Values.conf.log.config)) }}
+    {{ fail "Log configuration should use the persistent volume if enabled" }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{ template "cockroachdb.conf.log.validation" . }}
 kind: StatefulSet
 apiVersion: {{ template "cockroachdb.statefulset.apiVersion" . }}
 metadata:
@@ -290,7 +291,11 @@ spec:
               mountPath: /cockroach/log-config
               readOnly: true
           {{- end }}
-          {{ with .Values.statefulset.volumeMounts }}
+          {{- if .Values.conf.log.persistentVolume.enabled }}
+            - name: logsdir
+              mountPath: /cockroach/{{ .Values.conf.log.persistentVolume.path }}/
+          {{- end }}
+          {{- with .Values.statefulset.volumeMounts }}
             {{ toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.statefulset.customStartupProbe }}
@@ -393,6 +398,15 @@ spec:
           secret:
             secretName: {{ template "cockroachdb.fullname" . }}-log-config
       {{- end }}
+      {{- if .Values.conf.log.enabled }}
+        - name: logsdir
+        {{- if .Values.conf.log.persistentVolume.enabled }}
+          persistentVolumeClaim:
+            claimName: logsdir
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+      {{- end }}
       {{- if eq (include "cockroachdb.securityContext.versionValidation" .) "true" }}
       {{- if and .Values.securityContext.enabled }}
       securityContext:
@@ -404,8 +418,9 @@ spec:
         runAsNonRoot: true
       {{- end }}
       {{- end }}
-{{- if .Values.storage.persistentVolume.enabled }}
+{{- if or .Values.storage.persistentVolume.enabled .Values.conf.log.persistentVolume.enabled }}
   volumeClaimTemplates:
+  {{- if .Values.storage.persistentVolume.enabled }}
     - metadata:
         name: datadir
         labels:
@@ -432,4 +447,33 @@ spec:
         resources:
           requests:
             storage: {{ .Values.storage.persistentVolume.size | quote }}
+  {{- end }}
+  {{- if .Values.conf.log.persistentVolume.enabled }}
+    - metadata:
+        name: logsdir
+        labels:
+          app.kubernetes.io/name: {{ template "cockroachdb.name" . }}
+          app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        {{- with .Values.conf.log.persistentVolume.labels }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.labels }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.conf.log.persistentVolume.annotations }}
+        annotations: {{- toYaml . | nindent 10 }}
+      {{- end }}
+      spec:
+        accessModes: ["ReadWriteOnce"]
+      {{- if .Values.conf.log.persistentVolume.storageClass }}
+      {{- if (eq "-" .Values.conf.log.persistentVolume.storageClass) }}
+        storageClassName: ""
+      {{- else }}
+        storageClassName: {{ .Values.conf.log.persistentVolume.storageClass | quote}}
+      {{- end }}
+      {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.conf.log.persistentVolume.size | quote }}
+  {{- end }}
 {{- end }}

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -70,14 +70,35 @@ conf:
   log:
     enabled: false
     # https://www.cockroachlabs.com/docs/v21.1/configure-logs
-    config: {}
+    config:
       # file-defaults:
-      #   dir: /custom/dir/path/
+      #   dir: /cockroach/cockroach-logs
       # fluent-defaults:
       #   format: json-fluent
       # sinks:
       #   stderr:
       #     channels: [DEV]
+    persistentVolume:
+      # If enabled, then a PersistentVolumeClaim will be created and
+      # used to store CockroachDB's logs.
+      enabled: false
+      # CockroachDB's logs volume mount path. This gets prepended with
+      # `/cockroach/` in the stateful set. The `conf.log.config` should have
+      # `file-defaults.dir` to specify the log path and should reference the
+      # mounted volume.
+      path: cockroach-logs
+      size: 10Gi
+      # If defined, then `storageClassName: <storageClass>`.
+      # If set to "-", then `storageClassName: ""`, which disables dynamic
+      # provisioning.
+      # If undefined or empty (default), then no `storageClassName` spec is
+      # set, so the default provisioner will be chosen (gp2 on AWS, standard
+      # on GKE, AWS & OpenStack).
+      storageClass: ""
+      # Additional labels to apply to the created PersistentVolumeClaims.
+      labels: {}
+      # Additional annotations to apply to the created PersistentVolumeClaims.
+      annotations: {}
 
   # Logs at or above this threshold to STDERR. Ignored when "log" is enabled
   logtostderr: INFO


### PR DESCRIPTION
This is a recommended practice in Production as it helps minimize disk stalls on the data store volumes.