### PR TITLE
[CRDB-44987] lint: upgrade helmpack/chart-testing

### DIFF
--- a/build/lint.sh
+++ b/build/lint.sh
@@ -2,4 +2,4 @@
 
 set -euox pipefail
 
-build/tester.sh ct lint --config build/ct.yaml --all
+build/tester.sh ct lint --config build/ct.yaml --all --validate-maintainers=false

--- a/build/tester.sh
+++ b/build/tester.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image="quay.io/helmpack/chart-testing"
-version="v3.3.1"
+version="v3.11.0"
 
 if [ "${1-}" = "pull" ]; then
   docker pull "${image}:${version}"


### PR DESCRIPTION
The current version v3.3.1 of helmpack/chart-testing is 4 years old and comes bundled with older version of Helm wtih limited feature set. Upgrade to the latest v3.11.0 (7 months old).