### PR TITLE
[CRDB-44988] bugfix: fix cockroach start arguments

### DIFF
--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 14.0.6
+version: 14.0.7
 appVersion: 24.2.5
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -214,7 +214,7 @@ spec:
             {{- else }}
               --http-port={{ index .Values.service.ports.http.port | int64 }}
             {{- end }}
-            {{ if .Values.conf.port }}
+            {{- if .Values.conf.port }}
               --port={{ .Values.conf.port | int64 }}
             {{- else }}
               --port={{ .Values.service.ports.grpc.internal.port | int64 }}
@@ -256,7 +256,7 @@ spec:
           {{- end }}
           ports:
             - name: grpc
-              {{ if .Values.conf.port }}
+              {{- if .Values.conf.port }}
               containerPort: {{ .Values.conf.port | int64 }}
               {{- else }}
               containerPort: {{ .Values.service.ports.grpc.internal.port | int64 }}
@@ -349,7 +349,7 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end }}
-        {{ with .Values.statefulset.volumes }}
+        {{- with .Values.statefulset.volumes }}
           {{ toYaml . | nindent 8 }}
         {{- end }}
       {{- if .Values.tls.enabled }}


### PR DESCRIPTION
The cockroach start command was not accepting any arguments after --http-port due to whitespace getting introduced in the template. This PR chomps the whitespace to fix this bug.