### PR TITLE
test: fix flaky test due to timeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,7 @@ jobs:
   # pre job to run helm e2e tests
   helm-install-e2e:
     name: Helm-E2E-Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-core
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3


### PR DESCRIPTION
The e2e test times out probably due to a lot of PVs getting provisioned and running out of space.

This PR restricts the PV sizes across all tests to 1Gi (as opposed to the default 100Gi). It also now uses the ubuntu-latest-4-core runner (with higher storage) for the e2e tests.