### PR TITLE
fix default resource names.

### DIFF
--- a/cockroachdb/templates/crdb.yaml
+++ b/cockroachdb/templates/crdb.yaml
@@ -3,7 +3,7 @@
 apiVersion: crdb.cockroachlabs.com/v1alpha1
 kind: CrdbCluster
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "cockroachdb.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cluster.labels" . | nindent 4 }}
@@ -28,12 +28,13 @@ spec:
       image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
       certificates:
         externalCertificates:
-          clientCaConfigMapName: {{ .Values.operator.certificates.externalCertificates.clientCaConfigMapName | default (printf "%s-ca-secret-crt" $.Release.Name) }}
-          nodeCaConfigMapName: {{ .Values.operator.certificates.externalCertificates.nodeCaConfigMapName | default (printf "%s-ca-secret-crt" $.Release.Name) }}
-          httpSecretName: {{ .Values.operator.certificates.externalCertificates.httpSecretName | default (printf "%s-client-secret" $.Release.Name) }}
-          nodeClientSecretName: {{ .Values.operator.certificates.externalCertificates.nodeClientSecretName | default (printf "%s-client-secret" $.Release.Name) }}
-          nodeSecretName: {{ .Values.operator.certificates.externalCertificates.nodeSecretName | default (printf "%s-node-secret" $.Release.Name) }}
-          rootSqlClientSecretName: {{ .Values.operator.certificates.externalCertificates.rootSqlClientSecretName | default (printf "%s-client-secret" $.Release.Name) }}
+          {{- /* Note: defaults should match secrets and configmaps created by the self-signer job. */}}
+          clientCaConfigMapName: {{ .Values.operator.certificates.externalCertificates.clientCaConfigMapName | default (printf "%s-ca-secret-crt" (include "cockroachdb.fullname" .)) }}
+          nodeCaConfigMapName: {{ .Values.operator.certificates.externalCertificates.nodeCaConfigMapName | default (printf "%s-ca-secret-crt" (include "cockroachdb.fullname" .)) }}
+          httpSecretName: {{ .Values.operator.certificates.externalCertificates.httpSecretName | default (printf "%s-client-secret" (include "cockroachdb.fullname" .)) }}
+          nodeClientSecretName: {{ .Values.operator.certificates.externalCertificates.nodeClientSecretName | default (printf "%s-client-secret" (include "cockroachdb.fullname" .)) }}
+          nodeSecretName: {{ .Values.operator.certificates.externalCertificates.nodeSecretName | default (printf "%s-node-secret" (include "cockroachdb.fullname" .)) }}
+          rootSqlClientSecretName: {{ .Values.operator.certificates.externalCertificates.rootSqlClientSecretName | default (printf "%s-client-secret" (include "cockroachdb.fullname" .)) }}
       {{- with .Values.operator.dataStore }}
       dataStore: {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -46,7 +47,7 @@ spec:
       {{- with .Values.operator.resources }}
       resourceRequirements: {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ default .Release.Name .Values.operator.rbac.serviceAccountName }}
+      serviceAccountName: {{ .Values.operator.rbac.serviceAccountName | default (include "cockroachdb.serviceAccount.name" .) }}
       {{- if .Values.operator.loggingConf }}
       loggingConfigMapName: {{ .Release.Name }}-logging
       {{- end }}


### PR DESCRIPTION
The default names of service accounts, secrets, and configmaps currently don't match the defaults in the crdbcluster template. This patch updates the crdbcluster defaults such that creating a new cluster works without overrides.