### PR TITLE
cockroachdb: add crdbcluster options.

### DIFF
--- a/cockroachdb/templates/crdb.yaml
+++ b/cockroachdb/templates/crdb.yaml
@@ -23,6 +23,10 @@ spec:
   features:
     - reconcile
     - reconcile-beta
+  {{- with .Values.operator.flags }}
+  flags: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rollingRestartDelay: {{ .Values.operator.rollingRestartDelay }}
   template:
     spec:
       image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
@@ -37,6 +41,12 @@ spec:
           rootSqlClientSecretName: {{ .Values.operator.certificates.externalCertificates.rootSqlClientSecretName | default (printf "%s-client-secret" (include "cockroachdb.fullname" .)) }}
       {{- with .Values.operator.dataStore }}
       dataStore: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.env }}
+      env: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml . | nindent 8 }}
       {{- end }}
       podLabels:
         app.kubernetes.io/name: {{ template "cockroachdb.name" . }}

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -822,6 +822,25 @@ operator:
   podLabels:
     app.kubernetes.io/component: cockroachdb
 
+  # Flags passed to the cockroachdb container.
+  flags:
+    # Disable backup/restore to local disk by default.
+    --external-io-dir: disabled
+
+  # Environment variables set on cockroachdb pods.
+  env: []
+
+  # Delay between cockroachdb pod restarts. Wait 3m by default to avoid
+  # unavailability during restarts.
+  rollingRestartDelay: 3m0s
+
+  # Topology spread constraints set on cockroachdb pods. Spread cockroachdb
+  # pods across zones by default.
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: DoNotSchedule
+
   extras:
     # Add a container with dnsutils (nslookup, dig, ping, etc.) installed.
     dnsutils: false


### PR DESCRIPTION
Add options to the crdbcluster template that we set in cloud, along with sensible defaults.