### PR TITLE
fix: Make init-job run as hook only on install

### DIFF
--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -19,12 +19,17 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   annotations:
-    helm.sh/hook: post-install,post-upgrade
+    {{- if not .Release.IsInstall }}
+    helm.sh/hook: post-upgrade
     helm.sh/hook-delete-policy: before-hook-creation
+    {{- end }}
     {{- with .Values.init.jobAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Release.IsInstall }}
+  ttlSecondsAfterFinished: 0
+  {{- end }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
There are multiple issues stating the init-job is not run as expected

This is because there is a deadlock with the CRDB-StatfulSet requiring the init-job to run, which is only ran by Helm when the StatefulSet is considered ready

The optional use of the --wait of `helm install` is causing differing observations

This PR attempts to fix the problem by using the Job as plain Job instead of hook when the Chart is initially installed