### PR TITLE
Cloud Operator support in helm chart for all the options of SHCM operator

### DIFF
--- a/build/templates/values.yaml
+++ b/build/templates/values.yaml
@@ -716,13 +716,14 @@ operator:
   enabled: true
   # Default values for the cluster chart.
   image:
-    repository: cockroachdb/cockroach
+    name: cockroachdb/cockroach:v24.3.1
     pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the cluster chart's appVersion.
-    tag: ""
+    pullSecret: ""
 
   nameOverride: ""
   fullnameOverride: ""
+
+  # tlsEnabled: true
 
   # A map of CRDB cluster settings.
   # See https://www.cockroachlabs.com/docs/stable/cluster-settings.html
@@ -740,6 +741,10 @@ operator:
       # stderr:
         # channels: [health, dev]
         # filter: INFO
+
+  # loggingConfigMapName define the config map which contains log configuration used to send the logs through the
+  # proper channels in the cockroachdb.
+  loggingConfigMapName: ""
 
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -821,6 +826,40 @@ operator:
   podLabels:
     app.kubernetes.io/component: cockroachdb
 
+  # PodAnnotations are the annotations that should be applied to the underlying CRDB pod
+  podAnnotations: {}
+
+  # Env is a list of environment variables to set in the container.
+  podEnvVariables: []
+  # - name: APP_NAME
+  #   value: "CRDB"
+  # - name: POD_NAME
+  #   valueFrom:
+  #     fieldRef:
+  #       fieldPath: metadata.name
+
+  # TopologySpreadConstraints will be used to construct the crdb pod's topology spread
+  # constraints.
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       foo: bar
+
   extras:
     # Add a container with dnsutils (nslookup, dig, ping, etc.) installed.
     dnsutils: false
+
+  # Flags specifies the flags that will be used for starting the cluster.
+  flags: {}
+
+  # Configure grpc, sql and http port for cockroachdb cluster
+  ports: {}
+  #  grpcPort: 26258
+  #  sqlPort: 26257
+  #  httpPort: 8080
+
+  # NodeSelector is the set of nodeSelector labels to apply to a node.
+  nodeSelector: {}

--- a/cockroachdb/templates/_helpers.tpl
+++ b/cockroachdb/templates/_helpers.tpl
@@ -370,3 +370,16 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ include "cockroachdb.clusterfullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+    It provides all external certificates are empty or not
+*/}}
+{{- define "externalCertificates.isEmpty" -}}
+  {{- $isEmpty := true }}
+  {{- range $key, $value := .Values.operator.certificates.externalCertificates }}
+    {{- if not (empty $value) }}
+      {{- $isEmpty = false }}
+    {{- end }}
+  {{- end }}
+  {{- print $isEmpty }}
+{{- end }}

--- a/cockroachdb/templates/crdb.yaml
+++ b/cockroachdb/templates/crdb.yaml
@@ -3,7 +3,7 @@
 apiVersion: crdb.cockroachlabs.com/v1alpha1
 kind: CrdbCluster
 metadata:
-  name: {{ template "cockroachdb.fullname" . }}
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cluster.labels" . | nindent 4 }}
@@ -14,6 +14,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.operator.tlsEnabled }}
+  tlsEnabled: {{ .Values.operator.tlsEnabled }}
+  {{- end }}
   {{- with .Values.operator.clusterSettings }}
   clusterSettings: {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -25,18 +28,33 @@ spec:
     - reconcile-beta
   template:
     spec:
-      image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+      image: "{{ .Values.operator.image.name }}"
       certificates:
         externalCertificates:
           {{- /* Note: defaults should match secrets and configmaps created by the self-signer job. */}}
-          clientCaConfigMapName: {{ .Values.operator.certificates.externalCertificates.clientCaConfigMapName | default (printf "%s-ca-secret-crt" (include "cockroachdb.fullname" .)) }}
-          nodeCaConfigMapName: {{ .Values.operator.certificates.externalCertificates.nodeCaConfigMapName | default (printf "%s-ca-secret-crt" (include "cockroachdb.fullname" .)) }}
-          httpSecretName: {{ .Values.operator.certificates.externalCertificates.httpSecretName | default (printf "%s-client-secret" (include "cockroachdb.fullname" .)) }}
-          nodeClientSecretName: {{ .Values.operator.certificates.externalCertificates.nodeClientSecretName | default (printf "%s-client-secret" (include "cockroachdb.fullname" .)) }}
-          nodeSecretName: {{ .Values.operator.certificates.externalCertificates.nodeSecretName | default (printf "%s-node-secret" (include "cockroachdb.fullname" .)) }}
-          rootSqlClientSecretName: {{ .Values.operator.certificates.externalCertificates.rootSqlClientSecretName | default (printf "%s-client-secret" (include "cockroachdb.fullname" .)) }}
+          {{- if (eq (include "externalCertificates.isEmpty" .) "true") }}
+            caConfigMapName: {{ printf "%s-ca-secret-crt" (include "cockroachdb.fullname" .) }}
+            nodeSecretName: {{ printf "%s-node-secret" (include "cockroachdb.fullname" .) }}
+            rootSqlClientSecretName: {{ printf "%s-client-secret" (include "cockroachdb.fullname" .) }}
+            nodeCaConfigMapName: {{ printf "%s-ca-secret-crt" (include "cockroachdb.fullname" .) }}
+            httpSecretName: {{ printf "%s-client-secret" (include "cockroachdb.fullname" .) }}
+            nodeClientSecretName: {{ printf "%s-client-secret" (include "cockroachdb.fullname" .) }}
+          {{- else }}
+          caConfigMapName: {{ .Values.operator.certificates.externalCertificates.clientCaConfigMapName }}
+          nodeSecretName: {{ .Values.operator.certificates.externalCertificates.nodeSecretName }}
+          rootSqlClientSecretName: {{ .Values.operator.certificates.externalCertificates.rootSqlClientSecretName }}
+          nodeCaConfigMapName: {{ .Values.operator.certificates.externalCertificates.nodeCaConfigMapName }}
+          httpSecretName: {{ .Values.operator.certificates.externalCertificates.httpSecretName }}
+          nodeClientSecretName: {{ .Values.operator.certificates.externalCertificates.nodeClientSecretName }}
+          {{- end }}
       {{- with .Values.operator.dataStore }}
       dataStore: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.ports }}
+      ports: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.flags }}
+      flags: {{- toYaml . | nindent 8 }}
       {{- end }}
       podLabels:
         app.kubernetes.io/name: {{ template "cockroachdb.name" . }}
@@ -44,12 +62,28 @@ spec:
         {{- with .Values.operator.podLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- with .Values.operator.podAnnotations }}
+      podAnnotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.podEnvVariables }}
+      env: {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.operator.resources }}
       resourceRequirements: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.operator.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ .Values.operator.rbac.serviceAccountName | default (include "cockroachdb.serviceAccount.name" .) }}
+      {{- if .Values.operator.loggingConfigMapName }}
+      loggingConfigMapName: {{ .Values.operator.loggingConfigMapName }}
+      {{- else }}
       {{- if .Values.operator.loggingConf }}
       loggingConfigMapName: {{ .Release.Name }}-logging
+      {{- end }}
       {{- end }}
   # All properties below are solely to pass validation. They aren't used by the
   # betaclusterctrl controller so the values don't matter so long as they're

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -717,13 +717,14 @@ operator:
   enabled: true
   # Default values for the cluster chart.
   image:
-    repository: cockroachdb/cockroach
+    name: cockroachdb/cockroach:v24.3.1
     pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the cluster chart's appVersion.
-    tag: ""
+    pullSecret: ""
 
   nameOverride: ""
   fullnameOverride: ""
+
+  # tlsEnabled: true
 
   # A map of CRDB cluster settings.
   # See https://www.cockroachlabs.com/docs/stable/cluster-settings.html
@@ -741,6 +742,10 @@ operator:
       # stderr:
         # channels: [health, dev]
         # filter: INFO
+
+  # loggingConfigMapName define the config map which contains log configuration used to send the logs through the
+  # proper channels in the cockroachdb.
+  loggingConfigMapName: ""
 
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -822,6 +827,40 @@ operator:
   podLabels:
     app.kubernetes.io/component: cockroachdb
 
+  # PodAnnotations are the annotations that should be applied to the underlying CRDB pod
+  podAnnotations: {}
+
+  # Env is a list of environment variables to set in the container.
+  podEnvVariables: []
+  # - name: APP_NAME
+  #   value: "CRDB"
+  # - name: POD_NAME
+  #   valueFrom:
+  #     fieldRef:
+  #       fieldPath: metadata.name
+
+  # TopologySpreadConstraints will be used to construct the crdb pod's topology spread
+  # constraints.
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       foo: bar
+
   extras:
     # Add a container with dnsutils (nslookup, dig, ping, etc.) installed.
     dnsutils: false
+
+  # Flags specifies the flags that will be used for starting the cluster.
+  flags: {}
+
+  # Configure grpc, sql and http port for cockroachdb cluster
+  ports: {}
+  #  grpcPort: 26258
+  #  sqlPort: 26257
+  #  httpPort: 8080
+
+  # NodeSelector is the set of nodeSelector labels to apply to a node.
+  nodeSelector: {}


### PR DESCRIPTION
- Added support for adding various fields for cockroach cloud operator.
- Added migration tooling which actually reads from the custom resource yaml and converts it into the values.yaml file to be installed as helm chart.