### PR TITLE
Ensure prior hook resources are deleted before running.

### DIFF
--- a/cockroachdb/templates/job-certSelfSigner.yaml
+++ b/cockroachdb/templates/job-certSelfSigner.yaml
@@ -9,7 +9,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "4"
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
   labels:
     helm.sh/chart: {{ template "cockroachdb.chart" . }}
     app.kubernetes.io/name: {{ template "cockroachdb.name" . }}

--- a/cockroachdb/templates/job-cleaner.yaml
+++ b/cockroachdb/templates/job-cleaner.yaml
@@ -8,7 +8,7 @@ metadata:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
     "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
   labels:
     helm.sh/chart: {{ template "cockroachdb.chart" . }}
     app.kubernetes.io/name: {{ template "cockroachdb.name" . }}

--- a/cockroachdb/templates/role-certSelfSigner.yaml
+++ b/cockroachdb/templates/role-certSelfSigner.yaml
@@ -9,7 +9,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "2"
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
   labels:
     helm.sh/chart: {{ template "cockroachdb.chart" . }}
     app.kubernetes.io/name: {{ template "cockroachdb.name" . }}

--- a/cockroachdb/templates/rolebinding-certSelfSigner.yaml
+++ b/cockroachdb/templates/rolebinding-certSelfSigner.yaml
@@ -9,7 +9,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "3"
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
   labels:
     helm.sh/chart: {{ template "cockroachdb.chart" . }}
     app.kubernetes.io/name: {{ template "cockroachdb.name" . }}

--- a/cockroachdb/templates/serviceaccount-certSelfSigner.yaml
+++ b/cockroachdb/templates/serviceaccount-certSelfSigner.yaml
@@ -10,7 +10,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
     {{- with .Values.tls.certs.selfSigner.svcAccountAnnotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
Configure all hooks with non-default hook deletion policies to include the "before-hook-creation" option. This ensures that hook resources from previous runs are cleaned up before running hooks, even if those resources weren't properly cleaned up previously.