### PR TITLE
User provided CA cert handeling in configmap.

### DIFF
--- a/cmd/self-signer/root.go
+++ b/cmd/self-signer/root.go
@@ -100,6 +100,7 @@ func getInitialConfig(caDuration, caExpiry, nodeDuration, nodeExpiry, clientDura
 	}
 
 	if !clientOnly {
+		// STATEFULSET_NAME is derived from {{ template "cockroachdb.fullname" . }} in helm chart.
 		stsName, exists := os.LookupEnv("STATEFULSET_NAME")
 		if !exists {
 			return genCert, errors.New("Required STATEFULSET_NAME env not found")

--- a/pkg/generator/generate_cert.go
+++ b/pkg/generator/generate_cert.go
@@ -581,7 +581,7 @@ func (rc *GenerateCert) LoadCASecret(ctx context.Context, namespace string) erro
 	// If we are using the operator to manage secrets then we need to store the CA cert in a
 	// ConfigMap.
 	if rc.CaSecret != "" && rc.OperatorManaged {
-		cm := resource.CreateConfigMap(namespace, rc.CaSecret, secret.CA(),
+		cm := resource.CreateConfigMap(namespace, rc.getCASecretName(), secret.CA(),
 			resource.NewKubeResource(ctx, rc.client, namespace, kube.DefaultPersister))
 		if err = cm.Update(); err != nil {
 			return errors.Wrap(err, "failed to update CA cert in ConfigMap")


### PR DESCRIPTION
User provided CA secret should be copied into configmap named after release name so that the configmap could be passed to external certificates.