### PR TITLE
Fix: target port as sql for port 26257

### DIFF
--- a/build/templates/values.yaml
+++ b/build/templates/values.yaml
@@ -860,7 +860,7 @@ operator:
           # CockroachDB's port to listen to inter-communications and client connections.
           port: 26257
           # If using Istio set it to `cockroach`.
-          name: grpc-internal
+          name: sql
       http:
         # CockroachDB's port to listen to HTTP requests.
         port: 8080

--- a/cockroachdb/templates/service.public.yaml
+++ b/cockroachdb/templates/service.public.yaml
@@ -50,7 +50,7 @@ spec:
   {{- if ne ($ports.grpc.internal.port | int64) ($ports.grpc.external.port | int64) }}
     - name: {{ $ports.grpc.internal.name | quote }}
       port: {{ $ports.grpc.internal.port | int64 }}
-      targetPort: grpc
+      targetPort: sql
   {{- end }}
     # The secondary port serves the UI as well as health and debug endpoints.
     - name: {{ $ports.http.name | quote }}

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -861,7 +861,7 @@ operator:
           # CockroachDB's port to listen to inter-communications and client connections.
           port: 26257
           # If using Istio set it to `cockroach`.
-          name: grpc-internal
+          name: sql
       http:
         # CockroachDB's port to listen to HTTP requests.
         port: 8080


### PR DESCRIPTION
This PR fixes the target port as `sql` for 26257 for `cockroach-service` as it should match with port exposed by pods.