### PR TITLE
[CRDB-48127] Helm(V2) E2E Tests.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,9 +25,9 @@ jobs:
         id: filter
         with:
           filters: |
-              certUtility: &certUtility
-              - 'pkg/**'
-              - 'cmd/**'
+            certUtility: &certUtility
+            - 'pkg/**'
+            - 'cmd/**'
 
   # pre job run golangci-lint
   go-lint:
@@ -53,6 +53,14 @@ jobs:
           version: v1.64
           working-directory: .
           args: --timeout=5m
+
+      - name: Clean up Docker resources
+        shell: bash
+        run: |
+          docker container prune -f
+          docker image prune -a -f
+          docker volume prune -f
+
 
   # pre job to run helm lint
   helm:
@@ -91,6 +99,15 @@ jobs:
       - name: Unit
         run: make test/units
 
+      - name: Clean up Docker resources
+        shell: bash
+        run: |
+          docker container prune -f
+          docker image prune -a -f
+          docker volume prune -f
+
+
+
   self-signer-tag-change:
     name: Tag Change
     runs-on: ubuntu-latest
@@ -117,7 +134,7 @@ jobs:
   # pre job to run helm e2e tests
   helm-install-e2e:
     name: Helm-E2E-Test
-    runs-on: ubuntu-latest-4-core
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -132,6 +149,14 @@ jobs:
 
       - name: Run E2E Test
         run: make test/e2e/install
+
+      - name: Clean up Docker resources
+        shell: bash
+        run: |
+          docker container prune -f
+          docker image prune -a -f
+          docker volume prune -f
+
 
   helm-rotate-cert-e2e:
     name: Helm-rotate-cert-Test
@@ -150,6 +175,65 @@ jobs:
 
       - name: Run E2E Test
         run: make test/e2e/rotate
+
+      - name: Clean up Docker resources
+        shell: bash
+        run: |
+          docker container prune -f
+          docker image prune -a -f
+          docker volume prune -f
+
+
+  helm-single-region-e2e:
+    name: Helm-single-region-Test
+    runs-on: ubuntu-latest-4-core
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.22
+
+      - name: Run E2E Test
+        run: make test/e2e/single-region
+
+      - name: Clean up Docker resources
+        shell: bash
+        run: |
+          docker container prune -f
+          docker image prune -a -f
+          docker volume prune -f
+
+
+  helm-multi-region-e2e:
+    name: Helm-multi-region-Test
+    runs-on: ubuntu-latest-4-core
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.22
+
+      - name: Run E2E Test
+        run: make test/e2e/multi-region
+
+      - name: Clean up Docker resources
+        shell: bash
+        run: |
+          docker container prune -f
+          docker image prune -a -f
+          docker volume prune -f
 
   lint-templates:
     name: Lint release templates

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ test/single-cluster/up: bin/k3d
 	 ./tests/k3d/dev-multi-cluster.sh up --name "$(K3D_CLUSTER)" --nodes $(MULTI_REGION_NODE_SIZE) --clusters 1
 
 test/multi-cluster/down: bin/k3d
-	./tests/k3d/dev-multi-cluster.sh down --name "$(K3D_CLUSTER)" --nodes $(MULTI_REGION_NODE_SIZE) --clusters $(REGIONS)
+	 ./tests/k3d/dev-multi-cluster.sh down --name "$(K3D_CLUSTER)" --nodes $(MULTI_REGION_NODE_SIZE) --clusters $(REGIONS)
 
 test/lint: bin/helm ## lint the helm chart
 	@build/lint.sh && bin/helm lint cockroachdb

--- a/tests/e2e/install/cockroachdb_helm_e2e_test.go
+++ b/tests/e2e/install/cockroachdb_helm_e2e_test.go
@@ -13,9 +13,6 @@ import (
 	"testing"
 	"time"
 
-	v1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/types"
-
 	"github.com/cockroachdb/cockroach-operator/pkg/kube"
 	"github.com/cockroachdb/helm-charts/pkg/security"
 	util "github.com/cockroachdb/helm-charts/pkg/utils"
@@ -25,6 +22,8 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/types"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,6 +35,7 @@ var (
 	releaseName      = "crdb-test"
 	customCASecret   = "custom-ca-secret"
 	helmChartPath, _ = filepath.Abs("../../../cockroachdb")
+	k3dClusterName   = "k3d-chart-testing-cluster"
 )
 
 const role = "crdb-test-cockroachdb-node-reader"
@@ -53,6 +53,7 @@ func TestCockroachDbHelmInstall(t *testing.T) {
 		NodeSecret:       fmt.Sprintf("%s-cockroachdb-node-secret", releaseName),
 		CaSecret:         fmt.Sprintf("%s-cockroachdb-ca-secret", releaseName),
 		IsCaUserProvided: false,
+		Context:          k3dClusterName,
 	}
 
 	k8s.CreateNamespace(t, kubectlOptions, namespaceName)
@@ -118,6 +119,7 @@ func TestCockroachDbHelmInstallWithCAProvided(t *testing.T) {
 		NodeSecret:       fmt.Sprintf("%s-cockroachdb-node-secret", releaseName),
 		CaSecret:         customCASecret,
 		IsCaUserProvided: true,
+		Context:          k3dClusterName,
 	}
 
 	cmd := shell.Command{
@@ -210,6 +212,7 @@ func TestCockroachDbHelmMigration(t *testing.T) {
 		NodeSecret:       fmt.Sprintf("%s-cockroachdb-node", releaseName),
 		CaSecret:         customCASecret,
 		IsCaUserProvided: false,
+		Context:          k3dClusterName,
 	}
 
 	certsDir, cleanup := util.CreateTempDir("certsDir")
@@ -362,6 +365,7 @@ func TestCockroachDbWithInsecureMode(t *testing.T) {
 		K8sClient:       k8sClient,
 		StatefulSetName: fmt.Sprintf("%s-cockroachdb", releaseName),
 		Namespace:       namespaceName,
+		Context:         k3dClusterName,
 	}
 
 	k8s.CreateNamespace(t, kubectlOptions, namespaceName)
@@ -457,6 +461,7 @@ spec:
 		NodeSecret:       "cockroachdb-node",
 		CaSecret:         "cockroachdb-ca",
 		IsCaUserProvided: false,
+		Context:          k3dClusterName,
 	}
 
 	// Setup the args. For this test, we will set the following input values:
@@ -529,6 +534,7 @@ func testWALFailoverExistingCluster(t *testing.T, additionalValues map[string]st
 		NodeSecret:       fmt.Sprintf("%s-cockroachdb-node-secret", releaseName),
 		CaSecret:         fmt.Sprintf("%s-cockroachdb-ca-secret", releaseName),
 		IsCaUserProvided: false,
+		Context:          k3dClusterName,
 	}
 
 	k8s.CreateNamespace(t, kubectlOptions, namespaceName)

--- a/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
+++ b/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
@@ -1,0 +1,403 @@
+package multiRegion
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/testutil"
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type multiRegion struct {
+	operator.OperatorUseCases
+	operator.Region
+}
+
+func newMultiRegion() *multiRegion {
+	return &multiRegion{}
+}
+func TestOperatorInMultiRegion(t *testing.T) {
+	r := newMultiRegion()
+	r.Region = operator.Region{
+		IsMultiRegion: true,
+		NodeCount:     3,
+		ReusingInfra:  false,
+	}
+	r.Clients = make(map[string]client.Client)
+	r.Namespace = make(map[string]string)
+	t.Run("TestHelmInstall", r.TestHelmInstall)
+	t.Run("TestHelmUpgrade", r.TestHelmUpgrade)
+	t.Run("TestClusterRollingRestart", r.TestClusterRollingRestart)
+	t.Run("TestKillingCockroachNode", r.TestKillingCockroachNode)
+	t.Run("TestClusterScaleUp", r.TestClusterScaleUp)
+}
+
+// TestHelmInstall will install Operator and CockroachDB charts in multiple regions,
+// and verifies if CockroachDB has formed multi-region cluster.
+func (r *multiRegion) TestHelmInstall(t *testing.T) {
+	var corednsClusterOptions = make(map[string]coredns.CoreDNSClusterOption)
+
+	// Set up multi-region k3d infra.
+	r.SetUpInfra(t, corednsClusterOptions)
+
+	var clusters = operator.Clusters[:len(r.Clients)]
+
+	// Creating random namespace for each region.
+	for _, cluster := range clusters {
+		r.Namespace[cluster] = fmt.Sprintf("%s-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
+	}
+
+	// Cleanup resources.
+	defer r.CleanupResources(t)
+
+	// Create CA certificate.
+	err := r.CreateCACertificate(t)
+	require.NoError(t, err)
+
+	defer r.CleanUpCACertificate(t)
+
+	// Apply operator, CockroachDB charts on each cluster.
+	for i, cluster := range clusters {
+		r.InstallCharts(t, cluster, i)
+	}
+
+	// Get current context name.
+	_, rawConfig := r.GetCurrentContext(t)
+
+	// Validate CockroachDB functionality in each cluster.
+	for _, cluster := range clusters {
+		if _, ok := rawConfig.Contexts[cluster]; !ok {
+			t.Fatal()
+		}
+		rawConfig.CurrentContext = cluster
+		// Validate CockroachDB cluster.
+		r.ValidateCRDB(t, cluster)
+	}
+	// Validate Multi-region setup.
+	r.ValidateMultiRegionSetup(t)
+}
+
+// TestHelmUpgrade will upgrade the existing charts in multiple regions,
+// and verifies the CockroachDB health in multi-region.
+func (r *multiRegion) TestHelmUpgrade(t *testing.T) {
+	var corednsClusterOptions = make(map[string]coredns.CoreDNSClusterOption)
+
+	// Set up multi-region k3d infra.
+	r.SetUpInfra(t, corednsClusterOptions)
+
+	var clusters = operator.Clusters[:len(r.Clients)]
+
+	// Creating random namespace for each region.
+	for _, cluster := range clusters {
+		r.Namespace[cluster] = fmt.Sprintf("%s-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
+	}
+
+	// Cleanup resources.
+	defer r.CleanupResources(t)
+
+	// Create CA certificate.
+	err := r.CreateCACertificate(t)
+	require.NoError(t, err)
+
+	defer r.CleanUpCACertificate(t)
+
+	// Apply operator, CockroachDB charts on each cluster.
+	for i, cluster := range clusters {
+		r.InstallCharts(t, cluster, i)
+	}
+
+	// Get current context name.
+	kubeConfig, rawConfig := r.GetCurrentContext(t)
+
+	// Validate CockroachDB functionality in each cluster.
+	for _, cluster := range clusters {
+		if _, ok := rawConfig.Contexts[cluster]; !ok {
+			t.Fatal()
+		}
+		rawConfig.CurrentContext = cluster
+		// Validate CockroachDB cluster.
+		r.ValidateCRDB(t, cluster)
+	}
+
+	// Get helm chart paths.
+	helmChartPath, _, err := operator.HelmChartPaths()
+	require.NoError(t, err)
+	for _, cluster := range clusters {
+		kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+		options := &helm.Options{
+			KubectlOptions: kubectlOptions,
+			ExtraArgs: map[string][]string{
+				"upgrade": {"--reuse-values", "--set", fmt.Sprintf("operator.resources.requests.cpu=%s", "100m")},
+			},
+		}
+		// Apply Helm upgrade with updated values.
+		helm.Upgrade(t, options, helmChartPath, operator.ReleaseName)
+
+		// Get the initial timestamp of the pods before the upgrade.
+		pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+			LabelSelector: operator.LabelSelector,
+		})
+
+		// Capture the creation timestamp of the last pod.
+		initialTimestamp := pods[0].CreationTimestamp.Time
+
+		// Verify if the pods are restarted after helm upgrade.
+		err = r.VerifyHelmUpgrade(t, initialTimestamp, kubectlOptions)
+		require.NoError(t, err)
+
+		crdbCluster := testutil.CockroachCluster{
+			DesiredNodes: r.NodeCount,
+		}
+		testutil.RequireCRDBClusterToBeReadyEventuallyTimeout(t, kubectlOptions, crdbCluster, 600*time.Second)
+		pods = k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+			LabelSelector: operator.LabelSelector,
+		})
+		for _, pod := range pods {
+			require.Equal(t, resource.MustParse("100m"), pod.Spec.Containers[0].Resources.Requests["cpu"])
+		}
+		r.ValidateCRDB(t, cluster)
+	}
+	r.ValidateMultiRegionSetup(t)
+}
+
+// TestClusterRollingRestart will do a rolling restart by updating
+// timestamp of each cockroachdb pod in multi region through helm upgrade and verifies the same.
+func (r *multiRegion) TestClusterRollingRestart(t *testing.T) {
+	var corednsClusterOptions = make(map[string]coredns.CoreDNSClusterOption)
+
+	// Set up multi-region k3d infra.
+	r.SetUpInfra(t, corednsClusterOptions)
+
+	var clusters = operator.Clusters[:len(r.Clients)]
+
+	// Creating random namespace for each region.
+	for _, cluster := range clusters {
+		r.Namespace[cluster] = fmt.Sprintf("%s-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
+	}
+
+	// Cleanup resources.
+	defer r.CleanupResources(t)
+
+	// Create CA certificate.
+	err := r.CreateCACertificate(t)
+	require.NoError(t, err)
+
+	defer r.CleanUpCACertificate(t)
+
+	// Apply operator, CockroachDB charts on each cluster.
+	for i, cluster := range clusters {
+		r.InstallCharts(t, cluster, i)
+	}
+
+	// Get current context name.
+	kubeConfig, rawConfig := r.GetCurrentContext(t)
+
+	// Validate CockroachDB functionality in each cluster.
+	for _, cluster := range clusters {
+		if _, ok := rawConfig.Contexts[cluster]; !ok {
+			t.Fatal()
+		}
+		rawConfig.CurrentContext = cluster
+		r.ValidateCRDB(t, cluster)
+	}
+
+	// Get helm chart paths.
+	helmChartPath, _, err := operator.HelmChartPaths()
+	require.NoError(t, err)
+
+	// Modify the timestamp value and apply helm upgrade.
+	var upgradeTime time.Time
+	for _, cluster := range clusters {
+		// Helm upgrade with timestamp annotation.
+		kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+		upgradeTime = time.Now().UTC()
+
+		options := &helm.Options{
+			KubectlOptions: kubectlOptions,
+			ExtraArgs: map[string][]string{
+				"upgrade": {"--reuse-values", "--set", fmt.Sprintf("timestamp=%s", upgradeTime.Format(time.RFC3339))},
+			},
+		}
+		helm.Upgrade(t, options, helmChartPath, operator.ReleaseName)
+
+		// Get the initial timestamp of the pods before the upgrade.
+		pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+			LabelSelector: operator.LabelSelector,
+		})
+		if len(pods) == 0 {
+			require.Fail(t, "No initial pods found for deployment")
+		}
+
+		// Capture the creation timestamp of the last pod.
+		initialTimestamp := pods[2].CreationTimestamp.Time
+
+		// Verify if the pods are restarted after helm upgrade.
+		err = r.VerifyHelmUpgrade(t, initialTimestamp, kubectlOptions)
+		require.NoError(t, err)
+
+		crdbCluster := testutil.CockroachCluster{
+			DesiredNodes: r.NodeCount,
+		}
+		testutil.RequireCRDBClusterToBeReadyEventuallyTimeout(t, kubectlOptions, crdbCluster, 600*time.Second)
+		pods = k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+			LabelSelector: operator.LabelSelector,
+		})
+		// Verify that each pod's creation timestamp is after the upgradeTime.
+		for _, pod := range pods {
+			require.False(t, pod.CreationTimestamp.Time.Before(upgradeTime), fmt.Errorf("pod %s was not restarted before %v", pod.Name, upgradeTime))
+		}
+	}
+	r.ValidateMultiRegionSetup(t)
+}
+
+// TestKillingCockroachNode will manually kill one cockroachdb node to verify
+// if the reconciliation is working as expected in multi region and verifies the same.
+func (r *multiRegion) TestKillingCockroachNode(t *testing.T) {
+	var corednsClusterOptions = make(map[string]coredns.CoreDNSClusterOption)
+
+	// Set up multi-region k3d infra.
+	r.SetUpInfra(t, corednsClusterOptions)
+
+	var clusters = operator.Clusters[:len(r.Clients)]
+
+	// Creating random namespace for each region.
+	for _, cluster := range clusters {
+		r.Namespace[cluster] = fmt.Sprintf("%s-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
+	}
+
+	// Cleanup resources.
+	defer r.CleanupResources(t)
+
+	// Create CA certificate.
+	err := r.CreateCACertificate(t)
+	require.NoError(t, err)
+
+	defer r.CleanUpCACertificate(t)
+
+	// Apply operator, CockroachDB charts on each cluster.
+	for i, cluster := range clusters {
+		r.InstallCharts(t, cluster, i)
+	}
+
+	// Get current context name.
+	kubeConfig, rawConfig := r.GetCurrentContext(t)
+
+	// Validate CockroachDB functionality in each cluster.
+	for _, cluster := range clusters {
+		if _, ok := rawConfig.Contexts[cluster]; !ok {
+			t.Fatal()
+		}
+		rawConfig.CurrentContext = cluster
+		r.ValidateCRDB(t, cluster)
+	}
+
+	// Kill a pod in each cluster and verify the reconciliation
+	for _, cluster := range clusters {
+		kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+		pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+			LabelSelector: operator.LabelSelector,
+		})
+
+		// Kill a node in the cluster.
+		err := k8s.RunKubectlE(t, kubectlOptions, "delete", "pod", pods[0].Name)
+		require.NoError(t, err)
+
+		// Wait till the reconciliation is done and all the pods are up and running.
+		crdbCluster := testutil.CockroachCluster{
+			DesiredNodes: r.NodeCount,
+		}
+		testutil.RequireCRDBClusterToBeReadyEventuallyTimeout(t, kubectlOptions, crdbCluster, 600*time.Second)
+		// Validate CockroachDB cluster.
+		if _, ok := rawConfig.Contexts[cluster]; !ok {
+			t.Fatal()
+		}
+		rawConfig.CurrentContext = cluster
+		r.ValidateCRDB(t, cluster)
+	}
+	r.ValidateMultiRegionSetup(t)
+}
+
+// TestClusterScaleUp will scale the CockroachDB nodes in multiple regions
+// and verifies the CockroachDB cluster health and replicas in each region.
+func (r *multiRegion) TestClusterScaleUp(t *testing.T) {
+	var corednsClusterOptions = make(map[string]coredns.CoreDNSClusterOption)
+
+	// Set up multi-region k3d infra.
+	r.SetUpInfra(t, corednsClusterOptions)
+
+	var clusters = operator.Clusters[:len(r.Clients)]
+
+	// Creating random namespace for each region.
+	for _, cluster := range clusters {
+		r.Namespace[cluster] = fmt.Sprintf("%s-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
+	}
+
+	// Cleanup resources.
+	defer r.CleanupResources(t)
+
+	// Create CA certificate.
+	err := r.CreateCACertificate(t)
+	require.NoError(t, err)
+
+	defer r.CleanUpCACertificate(t)
+
+	// Apply Operator, CockroachDB charts on each cluster.
+	for i, cluster := range clusters {
+		r.InstallCharts(t, cluster, i)
+	}
+
+	// Get current context name.
+	kubeConfig, rawConfig := r.GetCurrentContext(t)
+
+	// Validate CockroachDB functionality in each cluster.
+	for _, cluster := range clusters {
+		if _, ok := rawConfig.Contexts[cluster]; !ok {
+			t.Fatal()
+		}
+		rawConfig.CurrentContext = cluster
+
+		r.ValidateCRDB(t, cluster)
+	}
+	// Get helm chart paths.
+	helmChartPath, _, err := operator.HelmChartPaths()
+	require.NoError(t, err)
+
+	// Modify the nodes in each region and apply helm upgrade.
+	for i, cluster := range clusters {
+		kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+		r.NodeCount = 4
+		options := &helm.Options{
+			KubectlOptions: kubectlOptions,
+			SetJsonValues: map[string]string{
+				"operator.regions": operator.MustMarshalJSON(r.OperatorRegions(i, r.NodeCount)),
+			},
+			ExtraArgs: map[string][]string{
+				"upgrade": {"--reuse-values", "--wait"},
+			},
+		}
+		// Apply Helm upgrade with updated values.
+		helm.Upgrade(t, options, helmChartPath, operator.ReleaseName)
+
+		crdbCluster := testutil.CockroachCluster{
+			DesiredNodes: r.NodeCount,
+		}
+		testutil.RequireCRDBClusterToBeReadyEventuallyTimeout(t, kubectlOptions, crdbCluster, 600*time.Second)
+		pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+			LabelSelector: operator.LabelSelector,
+		})
+		require.True(t, len(pods) == 4)
+		// Validate CockroachDB cluster.
+		r.ValidateCRDB(t, cluster)
+	}
+	r.ValidateMultiRegionSetup(t)
+}

--- a/tests/e2e/operator/region.go
+++ b/tests/e2e/operator/region.go
@@ -1,0 +1,641 @@
+package operator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/helm-charts/tests/e2e/calico"
+	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
+	"github.com/cockroachdb/helm-charts/tests/testutil"
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+const (
+	CloudProvider = "k3d"
+	TestDBName    = "testdb"
+	Namespace     = "test-cockroach"
+	LabelSelector = "app=cockroachdb"
+)
+
+var (
+	RegionCodes   = []string{"us-east1", "us-east2"}
+	Clusters      = []string{"k3d-chart-testing-cluster-0", "k3d-chart-testing-cluster-1"}
+	CustomDomains = map[string]string{
+		"k3d-chart-testing-cluster-0": "cluster1.local",
+		"k3d-chart-testing-cluster-1": "cluster2.local",
+	}
+
+	operatorReleaseName = "cockroachdb-operator"
+	customCASecret      = "cockroachdb-ca-secret"
+	ReleaseName         = "cockroachdb"
+)
+
+type operator interface {
+	setUpInfra(t *testing.T, corednsClusterOptions map[string]coredns.CoreDNSClusterOption) map[string]client.Client
+	installCharts(t *testing.T, cluster string, index int)
+	validateCRDB(t *testing.T, cluster string, clients map[string]client.Client)
+}
+
+// OperatorUseCases defines use cases for the CockroachDB cluster.
+type OperatorUseCases interface {
+	TestHelmInstall(t *testing.T)
+	TestHelmUpgrade(t *testing.T)
+	TestClusterScaleUp(t *testing.T)
+	TestClusterRollingRestart(t *testing.T)
+	TestKillingCockroachNode(t *testing.T)
+}
+
+type Region struct {
+	IsMultiRegion bool
+	// NodeCount is the desired CockroachDB nodes in the region.
+	NodeCount int
+	// Namespace stores mapping between cluster name and namespace.
+	Namespace    map[string]string
+	ReusingInfra bool
+	// Clients store the k8s client for each cluster
+	// needed for performing k8s operations on k8s objects.
+	Clients map[string]client.Client
+	operator
+}
+
+// SetUpInfra Creates K3d clusters, deploy calico CNI, deploy coredns in each cluster.
+func (r *Region) SetUpInfra(t *testing.T, corednsClusterOptions map[string]coredns.CoreDNSClusterOption) {
+
+	// If using existing infra return clients.
+	if r.ReusingInfra {
+		return
+	}
+
+	var clients = make(map[string]client.Client)
+	// Get current context name.
+	kubeConfig, rawConfig := r.GetCurrentContext(t)
+
+	for i, cluster := range Clusters {
+		if _, ok := rawConfig.Contexts[cluster]; !ok {
+			// Create cluster using shell command.
+			err := createK3DCluster(t)
+			require.NoError(t, err)
+		}
+
+		cfg, err := config.GetConfigWithContext(cluster)
+		require.NoError(t, err)
+		k8sClient, err := client.New(cfg, client.Options{})
+		require.NoError(t, err)
+		clients[cluster] = k8sClient
+
+		// Add the apiextensions scheme to the client's scheme.
+		_ = apiextv1.AddToScheme(k8sClient.Scheme())
+
+		kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, "kube-system")
+
+		// Install Calico.
+		calico.RegisterCalicoGVK(k8sClient.Scheme())
+		objects := calico.K3DCalicoCNI(calico.K3dClusterBGPConfig{
+			AddressAllocation: i,
+		})
+
+		for _, obj := range objects {
+			err = k8sClient.Create(context.Background(), obj)
+			require.NoError(t, err)
+		}
+
+		// Create or update CoreDNS deployment.
+		deployment := coredns.CoreDNSDeployment(2)
+		// Apply deployment.
+		deploymentYaml := coredns.ToYAML(t, deployment)
+		err = k8s.KubectlApplyFromStringE(t, kubectlOptions, deploymentYaml)
+		require.NoError(t, err)
+
+		// Wait for deployment to be ready.
+		_, err = retry.DoWithRetryE(t, "waiting for coredns deployment",
+			30, 10*time.Second,
+			func() (string, error) {
+				return k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+					"wait", "--for=condition=Available", "deployment/coredns")
+			})
+		require.NoError(t, err)
+
+		// Create CoreDNS service.
+		service := coredns.CoreDNSService()
+		serviceYaml := coredns.ToYAML(t, service)
+		// Apply service.
+		err = k8s.KubectlApplyFromStringE(t, kubectlOptions, serviceYaml)
+		require.NoError(t, err)
+
+		// Now get the DNS IPs.
+		var ips []string
+		_, err = retry.DoWithRetryE(t, "waiting for CoreDNS service IPs",
+			30, 10*time.Second,
+			func() (string, error) {
+				svc, err := k8s.GetServiceE(t, kubectlOptions, "crl-core-dns")
+				if err != nil {
+					return "", err
+				}
+
+				if len(svc.Status.LoadBalancer.Ingress) == 0 {
+					return "", fmt.Errorf("waiting for load balancer ingress")
+				}
+
+				// Collect IPs from ingress.
+				for _, ingress := range svc.Status.LoadBalancer.Ingress {
+					if ingress.IP != "" {
+						time.Sleep(5 * time.Second)
+						ips = append(ips, ingress.IP)
+					} else if ingress.Hostname != "" {
+						// If hostname is provided instead of IP, resolve it
+						resolvedIPs, err := net.LookupHost(ingress.Hostname)
+						if err != nil {
+							return "", fmt.Errorf("failed to resolve hostname %s: %v", ingress.Hostname, err)
+						}
+						ips = append(ips, resolvedIPs...)
+					}
+				}
+				return "", nil
+			})
+
+		require.NoError(t, err)
+
+		corednsClusterOptions[CustomDomains[cluster]] = coredns.CoreDNSClusterOption{
+			IPs:       ips,
+			Namespace: r.Namespace[cluster],
+			Domain:    CustomDomains[cluster],
+		}
+		if !r.IsMultiRegion {
+			break
+		}
+	}
+
+	// Update Coredns config.
+	for _, cluster := range Clusters {
+		// Create or update CoreDNS configmap.
+		kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, "kube-system")
+		cm := coredns.CoreDNSConfigMap(CustomDomains[cluster], corednsClusterOptions)
+
+		// Apply the updated ConfigMap to Kubernetes.
+		cmYaml := coredns.ToYAML(t, cm)
+		err := k8s.KubectlApplyFromStringE(t, kubectlOptions, cmYaml)
+		require.NoError(t, err)
+
+		// restart coredns pods.
+		err = k8s.RunKubectlE(t, kubectlOptions, "rollout", "restart", "deployment", "coredns")
+		require.NoError(t, err)
+		if !r.IsMultiRegion {
+			r.Clients = clients
+			r.ReusingInfra = true
+			return
+		}
+	}
+	r.Clients = clients
+	r.ReusingInfra = true
+
+	netConfig := calico.K3dCalicoBGPPeeringOptions{
+		ClusterConfig: map[string]calico.K3dClusterBGPConfig{},
+	}
+
+	// Update network config for each region.
+	for i, region := range RegionCodes {
+		rawConfig.CurrentContext = Clusters[i]
+		kubectlOptions := k8s.NewKubectlOptions(Clusters[i], kubeConfig, "kube-system")
+		err := r.setupNetworking(t, context.TODO(), region, netConfig, kubectlOptions, i)
+		if err != nil {
+			t.Error(err)
+		}
+	}
+
+	objectsByRegion := calico.K3dCalicoBGPPeeringObjects(netConfig)
+	// Apply all the objects for each region on to the cluster.
+	for i, region := range RegionCodes {
+		ctl := clients[Clusters[i]]
+		for _, obj := range objectsByRegion[region] {
+			err := ctl.Create(context.Background(), obj)
+			require.NoError(t, err)
+		}
+	}
+}
+
+// setupNetworking ensures there is cross-k3d-cluster network connectivity and
+// service discovery.
+func (r *Region) setupNetworking(t *testing.T, ctx context.Context, region string, netConfig calico.K3dCalicoBGPPeeringOptions, options *k8s.KubectlOptions, clusterId int) error {
+	// Mark the master nodes as our bgp edge. These nodes will act as our bgp
+	// peers.
+	clusterConfig := netConfig.ClusterConfig[region]
+	clusterConfig.AddressAllocation = clusterId
+
+	ctl := r.Clients[options.ContextName]
+
+	// Get master nodes.
+	var nodes []corev1.Node
+	nodes, err := k8s.GetNodesByFilterE(t, options, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", "node-role.kubernetes.io/master", "true"),
+	})
+	if err != nil {
+		return errors.Wrapf(err, "list nodes in %s", region)
+	}
+
+	// Patch server nodes with new annotation.
+	for _, node := range nodes {
+		patch := []byte(`{"metadata": {"annotations": {"projectcalico.org/labels": "{\"edge\":\"true\"}"}}}`)
+		if err := ctl.Patch(ctx, &node, client.RawPatch(types.StrategicMergePatchType, patch)); err != nil {
+			return errors.Wrapf(err, "annotate node for calico edge")
+		}
+
+		time.Sleep(15 * time.Second)
+
+		for _, nodeAddress := range node.Status.Addresses {
+			if nodeAddress.Type == corev1.NodeInternalIP {
+				clusterConfig.PeeringNodes = append(clusterConfig.PeeringNodes, nodeAddress.Address)
+			}
+		}
+	}
+	netConfig.ClusterConfig[region] = clusterConfig
+	return nil
+}
+
+// InstallCharts Installs both Operator and CockroachDB charts by providing custom CA secret
+// which is generated through cockroach binary, It also
+// verifies whether relevant services are up and running.
+func (r *Region) InstallCharts(t *testing.T, cluster string, index int) {
+	// Get current context name.
+	kubeConfig, rawConfig := r.GetCurrentContext(t)
+
+	// Get helm chart paths.
+	helmChartPath, operatorChartPath, err := HelmChartPaths()
+	require.NoError(t, err)
+
+	// Verify if cluster exists in the contexts.
+	if _, ok := rawConfig.Contexts[cluster]; !ok {
+		t.Fatal()
+	}
+	rawConfig.CurrentContext = cluster
+
+	// Setup kubectl options for this cluster.
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+
+	// Create namespace.
+	k8s.CreateNamespace(t, kubectlOptions, r.Namespace[cluster])
+
+	// create CA Secret.
+	err = k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", customCASecret, "--from-file=ca.crt",
+		"--from-file=ca.key")
+	require.NoError(t, err)
+
+	// Setup kubectl options for this cluster.
+	kubectlOptions = k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+	extraArgs := map[string][]string{
+		"install": {
+			"--wait",
+			"--debug",
+		},
+	}
+	operatorOpts := &helm.Options{
+		KubectlOptions: kubectlOptions,
+		ExtraArgs:      extraArgs,
+	}
+
+	// Install Operator on the cluster.
+	helm.Install(t, operatorOpts, operatorChartPath, operatorReleaseName)
+
+	// Wait for operator and webhook service to be available with endpoints.
+	k8s.WaitUntilServiceAvailable(t, kubectlOptions, "cockroach-operator", 30, 2*time.Second)
+	k8s.WaitUntilServiceAvailable(t, kubectlOptions, "cockroach-webhook-service", 30, 2*time.Second)
+
+	// Wait for crd to be installed.
+	_, _ = retry.DoWithRetryE(t, "wait-for-crd", 60, time.Second*5, func() (string, error) {
+		return k8s.RunKubectlAndGetOutputE(t, operatorOpts.KubectlOptions, "get", "crd", "crdbclusters.crdb.cockroachlabs.com")
+	})
+
+	// Helm install cockroach CR with operator region config.
+	crdbOptions := &helm.Options{
+		KubectlOptions: kubectlOptions,
+		SetValues: patchHelmValues(map[string]string{
+			"clusterDomain":                   CustomDomains[cluster],
+			"operator.enabled":                "true",
+			"operator.rollingRestartDelay":    "30s",
+			"tls.certs.selfSigner.caProvided": "true",
+			"tls.certs.selfSigner.caSecret":   customCASecret,
+			"operator.dataStore.volumeClaimTemplate.spec.resources.requests.storage": "1Gi",
+		}),
+		SetJsonValues: map[string]string{
+			"operator.regions": MustMarshalJSON(r.OperatorRegions(index, r.NodeCount)),
+		},
+		ExtraArgs: extraArgs,
+	}
+
+	helm.Install(t, crdbOptions, helmChartPath, ReleaseName)
+
+	serviceName := "cockroachdb-public"
+	k8s.WaitUntilServiceAvailable(t, kubectlOptions, serviceName, 30, 5*time.Second)
+}
+
+// ValidateCRDB validates the CockroachDB cluster by performing basic operations on db.
+func (r *Region) ValidateCRDB(t *testing.T, cluster string) {
+	cfg, err := config.GetConfigWithContext(cluster)
+	require.NoError(t, err)
+	// Get current context name.
+	kubeConfig, rawConfig := r.GetCurrentContext(t)
+	rawConfig.CurrentContext = cluster
+	// Setup kubectl options for this cluster.
+	namespaceName := r.Namespace[cluster]
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, namespaceName)
+	crdbCluster := testutil.CockroachCluster{
+		Cfg:              cfg,
+		K8sClient:        r.Clients[cluster],
+		StatefulSetName:  "cockroachdb",
+		Namespace:        namespaceName,
+		ClientSecret:     "cockroachdb-client-secret",
+		NodeSecret:       "cockroachdb-node-secret",
+		CaSecret:         customCASecret,
+		IsCaUserProvided: true,
+		DesiredNodes:     r.NodeCount,
+		Context:          cluster,
+	}
+
+	testutil.RequireCertificatesToBeValid(t, crdbCluster)
+	testutil.RequireCRDBClusterToBeReadyEventuallyTimeout(t, kubectlOptions, crdbCluster, 900*time.Second)
+
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: LabelSelector,
+	})
+	require.True(t, len(pods) > 0)
+	podName := fmt.Sprintf("%s.cockroachdb.%s", pods[0].Name, r.Namespace[cluster])
+	testutil.RequireCRDBClusterToFunction(t, crdbCluster, false, podName)
+	testutil.RequireCRDBDatabaseToFunction(t, crdbCluster, TestDBName, podName)
+}
+
+// VerifyHelmUpgrade waits till all the pods are restarted after the
+// helm upgrade is completed, it verifies with initialTimestamp which is the timestamp
+// of the pods before recreation and returns the pod name.
+func (r *Region) VerifyHelmUpgrade(t *testing.T, initialTimestamp time.Time, kubectlOptions *k8s.KubectlOptions) error {
+	// Wait for the pods to be recreated with a new timestamp after the upgrade.
+	_, err := retry.DoWithRetryE(t, "waiting for pods to be recreated with new timestamp",
+		60, 10*time.Second,
+		func() (string, error) {
+			// List the pods for the deployment.
+			pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+				LabelSelector: LabelSelector,
+			})
+
+			// Check if any pods exist.
+			if len(pods) == 0 {
+				return "", fmt.Errorf("no pods found for deployment")
+			}
+
+			// Check if any pod has a creation timestamp greater than the initial timestamp.
+			// We are actually waiting for all pods to complete helm upgrade,
+			// as just verifying one pod and cleaning up the resources will cause issues,
+			// Since helm delete is happening while pods are still in upgrade process.
+			for _, pod := range pods {
+				if !pod.CreationTimestamp.Time.After(initialTimestamp) {
+					return "", fmt.Errorf("pod %s has not been recreated with a new timestamp yet", pod.Name)
+				}
+			}
+			return "", nil
+		})
+	return err
+}
+
+// ValidateMultiRegionSetup validates the multi-region setup.
+func (r *Region) ValidateMultiRegionSetup(t *testing.T) {
+	// Validate multi-region setup.
+	for _, cluster := range Clusters {
+		// Get current context name.
+		kubeConfig, rawConfig := r.GetCurrentContext(t)
+		rawConfig.CurrentContext = cluster
+		kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+
+		pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+			LabelSelector: LabelSelector,
+		})
+		require.NotEmpty(t, pods)
+
+		// Execute SQL query to verify regions.
+		stdout, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+			"exec", pods[0].Name, "-c", "cockroachdb", "--",
+			"/cockroach/cockroach", "sql", "--certs-dir=/cockroach/cockroach-certs",
+			"-e", "SHOW REGIONS FROM CLUSTER")
+		require.NoError(t, err)
+
+		// Verify regions output.
+		expectedRegions := []string{
+			"k3d-us-east1",
+			"k3d-us-east2",
+		}
+		for _, clusterRegion := range expectedRegions {
+			require.Contains(t, stdout, clusterRegion)
+		}
+
+		// Execute node status command and verify node properties.
+		nodeStatus, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+			"exec", pods[0].Name, "-c", "cockroachdb", "--",
+			"/cockroach/cockroach", "node", "status", "--format=json", "--certs-dir=/cockroach/cockroach-certs")
+		require.NoError(t, err)
+
+		var nodes []struct {
+			Address     string `json:"address"`
+			Build       string `json:"build"`
+			ID          string `json:"id"`
+			IsAvailable string `json:"is_available"`
+			IsLive      string `json:"is_live"`
+			Locality    string `json:"locality"`
+			SQLAddress  string `json:"sql_address"`
+			StartedAt   string `json:"started_at"`
+			UpdatedAt   string `json:"updated_at"`
+		}
+		err = json.Unmarshal([]byte(nodeStatus), &nodes)
+		require.NoError(t, err)
+
+		// Count nodes per region.
+		nodesPerRegion := make(map[string]int)
+		for _, node := range nodes {
+			// Extract region from locality.
+			for _, part := range strings.Split(node.Locality, ",") {
+				if strings.HasPrefix(part, "region=") {
+					region := strings.TrimPrefix(part, "region=")
+					nodesPerRegion[region]++
+				}
+			}
+			// Verify node is available and live.
+			require.Equal(t, "true", node.IsAvailable, "Node %s is not available", node.ID)
+			require.Equal(t, "true", node.IsLive, "Node %s is not live", node.ID)
+		}
+
+		// Verify node count per region matches desired nodes.
+		for _, region := range expectedRegions {
+			require.Equal(t, r.NodeCount, nodesPerRegion[region],
+				"Region %s has %d nodes, expected %d",
+				region, nodesPerRegion[region], r.NodeCount)
+		}
+	}
+}
+
+// CreateCACertificate creates CA cert and key at the same path.
+func (r *Region) CreateCACertificate(t *testing.T) error {
+	// Create CA secret in all regions.
+	cmd := shell.Command{
+		Command:    "cockroach",
+		Args:       []string{"cert", "create-ca", "--certs-dir=.", "--ca-key=ca.key"},
+		WorkingDir: ".",
+		Env:        nil,
+		Logger:     nil,
+	}
+
+	certOutput, err := shell.RunCommandAndGetOutputE(t, cmd)
+	t.Log(certOutput)
+	return err
+}
+
+func (r *Region) CleanUpCACertificate(t *testing.T) {
+	cmd := shell.Command{
+		Command:    "rm",
+		Args:       []string{"-rf", "ca.crt", "ca.key"},
+		WorkingDir: ".",
+	}
+
+	shell.RunCommand(t, cmd)
+}
+
+// GetCurrentContext gets current cluster context from KubeConfig.
+func (r *Region) GetCurrentContext(t *testing.T) (string, api.Config) {
+	kubeConfig, err := k8s.GetKubeConfigPathE(t)
+	require.NoError(t, err)
+
+	config := k8s.LoadConfigFromPath(kubeConfig)
+	rawConfig, err := config.RawConfig()
+	require.NoError(t, err)
+	return kubeConfig, rawConfig
+}
+
+// CleanupResources will clean the resources installed by Operator, CockroachDB charts and deletes the namespace.
+// Any failure in doing so might cause issues in other tests as some of the
+// cluster resources are tied to the namespace.
+func (r *Region) CleanupResources(t *testing.T) {
+	for cluster, namespace := range r.Namespace {
+		kubectlOptions := k8s.NewKubectlOptions(cluster, "", namespace)
+
+		extraArgs := map[string][]string{
+			"delete": {
+				"--wait",
+				"--debug",
+			},
+		}
+		helmOptions := &helm.Options{
+			KubectlOptions: kubectlOptions,
+			ExtraArgs:      extraArgs,
+		}
+		err := helm.DeleteE(t, helmOptions, ReleaseName, true)
+		require.NoError(t, err)
+		err = helm.DeleteE(t, helmOptions, operatorReleaseName, true)
+		require.NoError(t, err)
+		k8s.DeleteNamespace(t, kubectlOptions, namespace)
+	}
+}
+
+// OperatorRegions returns the regions config based on the index
+// which is referring to cluster index.
+func (r *Region) OperatorRegions(index int, nodes int) []map[string]interface{} {
+	return r.createOperatorRegions(index, nodes, CustomDomains, Clusters, RegionCodes)
+}
+
+func HelmChartPaths() (string, string, error) {
+	helmChartPath, err := filepath.Abs("../../../../cockroachdb")
+	if err != nil {
+		return "", "", err
+	}
+
+	operatorChartPath, err := filepath.Abs("../../../../operator")
+	if err != nil {
+		return "", "", err
+	}
+
+	return helmChartPath, operatorChartPath, nil
+}
+
+// createK3DCluster creates a new k3d cluster
+// by calling the make command which will create
+// single k3d cluster.
+func createK3DCluster(t *testing.T) error {
+	cmd := shell.Command{
+		Command: "make",
+		Args: []string{
+			"test/single-cluster/up",
+		},
+		WorkingDir: "../../../..",
+	}
+
+	output, err := shell.RunCommandAndGetOutputE(t, cmd)
+	if err != nil {
+		return fmt.Errorf("failed to create cluster: %v\nOutput: %s", err, output)
+	}
+	return nil
+}
+
+// createOperatorRegions returns the appropriate regions config
+// required while installing CockroachDb charts.
+func (r *Region) createOperatorRegions(index int, nodes int, customDomains map[string]string, clusters []string, regionCodes []string) []map[string]interface{} {
+	regions := make([]map[string]interface{}, 0, len(regionCodes))
+
+	for i, code := range regionCodes {
+		if i > index {
+			break
+		}
+
+		region := map[string]interface{}{
+			"code":          code,
+			"cloudProvider": CloudProvider,
+			"nodes":         nodes,
+			"namespace":     r.Namespace[clusters[i]],
+		}
+
+		if len(clusters) > i && clusters[i] != "" {
+			if domain, ok := customDomains[clusters[i]]; ok {
+				region["domain"] = domain
+			}
+		}
+
+		regions = append(regions, region)
+	}
+
+	return regions
+}
+
+func MustMarshalJSON(value interface{}) string {
+	bytes, err := json.Marshal(value)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to marshal JSON: %v", err))
+	}
+	return string(bytes)
+}
+
+func patchHelmValues(inputValues map[string]string) map[string]string {
+	if inputValues == nil {
+		inputValues = make(map[string]string)
+	}
+
+	overrides := map[string]string{
+		"storage.persistentVolume.size": "1Gi",
+	}
+
+	for k, v := range overrides {
+		inputValues[k] = v
+	}
+
+	return inputValues
+}

--- a/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
+++ b/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
@@ -1,0 +1,340 @@
+package singleRegion
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/testutil"
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type singleRegion struct {
+	operator.OperatorUseCases
+	operator.Region
+}
+
+func newSingleRegion() *singleRegion {
+	return &singleRegion{}
+}
+func TestOperatorInSingleRegion(t *testing.T) {
+	r := newSingleRegion()
+	r.Region = operator.Region{
+		IsMultiRegion: false,
+		NodeCount:     3,
+		ReusingInfra:  false,
+	}
+	r.Clients = make(map[string]client.Client)
+	r.Namespace = make(map[string]string)
+	t.Run("TestHelmInstall", r.TestHelmInstall)
+	t.Run("TestHelmUpgrade", r.TestHelmUpgrade)
+	t.Run("TestClusterRollingRestart", r.TestClusterRollingRestart)
+	t.Run("TestKillingCockroachNode", r.TestKillingCockroachNode)
+	t.Run("TestClusterScaleUp", r.TestClusterScaleUp)
+}
+
+// TestHelmInstall will install Operator and CockroachDB charts
+// and verifies if CockroachDB service is up and running.
+func (r *singleRegion) TestHelmInstall(t *testing.T) {
+	var corednsClusterOptions = make(map[string]coredns.CoreDNSClusterOption)
+	cluster := operator.Clusters[0]
+	r.Namespace[cluster] = fmt.Sprintf("%s-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
+
+	// Cleanup resources.
+	defer r.CleanupResources(t)
+
+	// Create CA certificate.
+	err := r.CreateCACertificate(t)
+	require.NoError(t, err)
+
+	defer r.CleanUpCACertificate(t)
+
+	// Setup Single region k3d infra.
+	r.SetUpInfra(t, corednsClusterOptions)
+
+	// Install Operator and CockroachDB charts.
+	r.InstallCharts(t, cluster, 0)
+
+	// Get current context name.
+	_, rawConfig := r.GetCurrentContext(t)
+
+	if _, ok := rawConfig.Contexts[cluster]; !ok {
+		t.Fatal()
+	}
+	rawConfig.CurrentContext = cluster
+	r.ValidateCRDB(t, cluster)
+}
+
+// TestHelmUpgrade will upgrade the existing charts in a single region
+// and verifies the CockroachDB health.
+func (r *singleRegion) TestHelmUpgrade(t *testing.T) {
+	var corednsClusterOptions = make(map[string]coredns.CoreDNSClusterOption)
+	cluster := operator.Clusters[0]
+	r.Namespace[cluster] = fmt.Sprintf("%s-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
+
+	// Cleanup resources.
+	defer r.CleanupResources(t)
+
+	// Create CA certificate.
+	err := r.CreateCACertificate(t)
+	require.NoError(t, err)
+
+	defer r.CleanUpCACertificate(t)
+
+	// Setup Single region k3d infra.
+	r.SetUpInfra(t, corednsClusterOptions)
+
+	// Install Operator and CockroachDB charts.
+	r.InstallCharts(t, cluster, 0)
+
+	// Get current context name.
+	kubeConfig, rawConfig := r.GetCurrentContext(t)
+
+	if _, ok := rawConfig.Contexts[cluster]; !ok {
+		t.Fatal()
+	}
+	rawConfig.CurrentContext = cluster
+
+	// Validate CockroachDB cluster.
+	r.ValidateCRDB(t, cluster)
+
+	// Get helm chart paths.
+	helmChartPath, _, err := operator.HelmChartPaths()
+	require.NoError(t, err)
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+	options := &helm.Options{
+		KubectlOptions: kubectlOptions,
+		ExtraArgs: map[string][]string{
+			"upgrade": {"--reuse-values", "--set", fmt.Sprintf("operator.resources.requests.cpu=%s", "100m")},
+		},
+	}
+	// Apply Helm upgrade with updated values.
+	helm.Upgrade(t, options, helmChartPath, operator.ReleaseName)
+
+	// Get the initial timestamp of the pods before the upgrade.
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+
+	// Capture the creation timestamp of the last pod.
+	initialTimestamp := pods[0].CreationTimestamp.Time
+
+	// Verify if the pods are restarted after helm upgrade.
+	err = r.VerifyHelmUpgrade(t, initialTimestamp, kubectlOptions)
+	require.NoError(t, err)
+
+	crdbCluster := testutil.CockroachCluster{
+		DesiredNodes: r.NodeCount,
+	}
+	testutil.RequireCRDBClusterToBeReadyEventuallyTimeout(t, kubectlOptions, crdbCluster, 600*time.Second)
+	pods = k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	for _, pod := range pods {
+		require.Equal(t, resource.MustParse("100m"), pod.Spec.Containers[0].Resources.Requests["cpu"])
+	}
+	r.ValidateCRDB(t, cluster)
+}
+
+// TestClusterRollingRestart will do a rolling restart by updating
+// timestamp of each cockroachdb pod in single region through helm upgrade and verifies the same.
+func (r *singleRegion) TestClusterRollingRestart(t *testing.T) {
+	var corednsClusterOptions = make(map[string]coredns.CoreDNSClusterOption)
+	cluster := operator.Clusters[0]
+	r.Namespace[cluster] = fmt.Sprintf("%s-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
+
+	// Cleanup resources.
+	defer r.CleanupResources(t)
+
+	// Create CA certificate.
+	err := r.CreateCACertificate(t)
+	require.NoError(t, err)
+
+	defer r.CleanUpCACertificate(t)
+
+	//Setup Single region k3d infra.
+	r.SetUpInfra(t, corednsClusterOptions)
+
+	// Install Operator and CRDB charts.
+	r.InstallCharts(t, cluster, 0)
+
+	// Get current context name.
+	kubeConfig, rawConfig := r.GetCurrentContext(t)
+
+	if _, ok := rawConfig.Contexts[cluster]; !ok {
+		t.Fatal()
+	}
+	rawConfig.CurrentContext = cluster
+
+	// Validate CockroachDB cluster.
+	r.ValidateCRDB(t, cluster)
+
+	// Get helm chart paths.
+	helmChartPath, _, err := operator.HelmChartPaths()
+	require.NoError(t, err)
+
+	var upgradeTime time.Time
+
+	// Helm upgrade with timestamp annotation.
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+	upgradeTime = time.Now().UTC()
+
+	options := &helm.Options{
+		KubectlOptions: kubectlOptions,
+		ExtraArgs: map[string][]string{
+			"upgrade": {"--reuse-values", "--set", fmt.Sprintf("timestamp=%s", upgradeTime.Format(time.RFC3339))},
+		},
+	}
+	helm.Upgrade(t, options, helmChartPath, operator.ReleaseName)
+
+	// Get the initial timestamp of the pods before the upgrade.
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	if len(pods) == 0 {
+		require.Fail(t, "No initial pods found for deployment")
+	}
+
+	// Capture the creation timestamp of the last pod.
+	initialTimestamp := pods[2].CreationTimestamp.Time
+
+	// Verify if the pods are restarted after helm upgrade.
+	err = r.VerifyHelmUpgrade(t, initialTimestamp, kubectlOptions)
+	require.NoError(t, err)
+
+	crdbCluster := testutil.CockroachCluster{
+		DesiredNodes: r.NodeCount,
+	}
+	testutil.RequireCRDBClusterToBeReadyEventuallyTimeout(t, kubectlOptions, crdbCluster, 600*time.Second)
+	pods = k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	// Verify that each pod's creation timestamp is after the upgradeTime.
+	for _, pod := range pods {
+		require.False(t, pod.CreationTimestamp.Time.Before(upgradeTime), fmt.Errorf("pod %s was not restarted before %v", pod.Name, upgradeTime))
+	}
+	r.ValidateCRDB(t, cluster)
+}
+
+// TestKillingCockroachNode will manually kill one cockroachdb node to verify
+// if the reconciliation is working as expected in single region and verifies the same.
+func (r *singleRegion) TestKillingCockroachNode(t *testing.T) {
+	var corednsClusterOptions = make(map[string]coredns.CoreDNSClusterOption)
+	cluster := operator.Clusters[0]
+	r.Namespace[cluster] = fmt.Sprintf("%s-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
+
+	// Cleanup resources.
+	defer r.CleanupResources(t)
+
+	//Setup Single region k3d infra.
+	r.SetUpInfra(t, corednsClusterOptions)
+
+	// Create CA certificate.
+	err := r.CreateCACertificate(t)
+	require.NoError(t, err)
+
+	defer r.CleanUpCACertificate(t)
+
+	// Install Operator and CRDB charts.
+	r.InstallCharts(t, cluster, 0)
+
+	// Get current context name.
+	kubeConfig, rawConfig := r.GetCurrentContext(t)
+
+	// Validate CockroachDB cluster.
+	if _, ok := rawConfig.Contexts[cluster]; !ok {
+		t.Fatal()
+	}
+	rawConfig.CurrentContext = cluster
+
+	// Validate CockroachDB cluster.
+	r.ValidateCRDB(t, cluster)
+
+	// List the pods.
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+
+	// Kill a node in the cluster.
+	err = k8s.RunKubectlE(t, kubectlOptions, "delete", "pod", pods[0].Name)
+	require.NoError(t, err)
+
+	// Wait till the reconciliation is done and all the pods are up and running.
+	crdbCluster := testutil.CockroachCluster{
+		DesiredNodes: r.NodeCount,
+	}
+	testutil.RequireCRDBClusterToBeReadyEventuallyTimeout(t, kubectlOptions, crdbCluster, 600*time.Second)
+
+	if _, ok := rawConfig.Contexts[cluster]; !ok {
+		t.Fatal()
+	}
+	rawConfig.CurrentContext = cluster
+
+	// Validate CockroachDB cluster.
+	r.ValidateCRDB(t, cluster)
+}
+
+// TestClusterScaleUp will scale the CockroachDB nodes in the existing region
+// and verifies the CockroachDB cluster health and replicas.
+func (r *singleRegion) TestClusterScaleUp(t *testing.T) {
+	var corednsClusterOptions = make(map[string]coredns.CoreDNSClusterOption)
+	cluster := operator.Clusters[0]
+	r.Namespace[cluster] = fmt.Sprintf("%s-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
+
+	// Cleanup resources.
+	defer r.CleanupResources(t)
+
+	//Setup Single region k3d infra.
+	r.SetUpInfra(t, corednsClusterOptions)
+
+	// Create CA certificate.
+	err := r.CreateCACertificate(t)
+	require.NoError(t, err)
+
+	defer r.CleanUpCACertificate(t)
+
+	// Install Operator and CockroachDB charts.
+	r.InstallCharts(t, cluster, 0)
+
+	// Get current context name.
+	kubeConfig, rawConfig := r.GetCurrentContext(t)
+	if _, ok := rawConfig.Contexts[cluster]; !ok {
+		t.Fatal()
+	}
+	rawConfig.CurrentContext = cluster
+
+	// Validate CockroachDB cluster.
+	r.ValidateCRDB(t, cluster)
+
+	// Get helm chart paths.
+	helmChartPath, _, err := operator.HelmChartPaths()
+	require.NoError(t, err)
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+	r.NodeCount = 4
+	options := &helm.Options{
+		KubectlOptions: kubectlOptions,
+		SetJsonValues: map[string]string{
+			"operator.regions": operator.MustMarshalJSON(r.OperatorRegions(0, r.NodeCount)),
+		},
+		ExtraArgs: map[string][]string{
+			"upgrade": {"--reuse-values", "--wait"},
+		},
+	}
+	helm.Upgrade(t, options, helmChartPath, operator.ReleaseName)
+
+	crdbCluster := testutil.CockroachCluster{
+		DesiredNodes: r.NodeCount,
+	}
+	testutil.RequireCRDBClusterToBeReadyEventuallyTimeout(t, kubectlOptions, crdbCluster, 600*time.Second)
+	r.ValidateCRDB(t, cluster)
+}

--- a/tests/k3d/dev-cluster.sh
+++ b/tests/k3d/dev-cluster.sh
@@ -26,7 +26,7 @@ REQUIRED_IMAGES=(
     "quay.io/jetstack/cert-manager-webhook:v1.11.0"
     "quay.io/jetstack/cert-manager-controller:v1.11.0"
     "quay.io/jetstack/cert-manager-ctl:v1.11.0"
-    "cockroachdb/cockroach:v25.1.0"
+    "cockroachdb/cockroach:v25.1.2"
     "${REGISTRY}/${REPOSITORY}:$(bin/yq '.tls.selfSigner.image.tag' ./cockroachdb/values.yaml)"
 )
 

--- a/tests/k3d/dev-multi-cluster.sh
+++ b/tests/k3d/dev-multi-cluster.sh
@@ -20,7 +20,6 @@ CLUSTER_CIDRS=(10.0.0.0/17 10.1.0.0/17 10.2.0.0/17)
 
 # Binary paths
 K3D_PATH="./bin/k3d"
-CILIUM_PATH="./bin/cilium"  # Path to Cilium binary
 
 # Registry configuration
 REGISTRY="gcr.io"
@@ -35,7 +34,11 @@ REQUIRED_IMAGES=(
     "quay.io/jetstack/cert-manager-controller:v1.11.0"
     "quay.io/jetstack/cert-manager-ctl:v1.11.0"
     "coredns/coredns:1.9.2"
-    "cockroachdb/cockroach:v25.1.0"
+    "$(bin/yq '.operator.image.name' ./cockroachdb/values.yaml)"
+    "us.gcr.io/cockroach-cloud-images/inotifywait:20200513"
+    "bash:latest"
+    "busybox"
+    "us-docker.pkg.dev/cockroach-cloud-images/data-plane/init-container:f21cb0727676a48d0000bc3f32108ce59d51c3e7"
     "${REGISTRY}/${REPOSITORY}:$(bin/yq '.tls.selfSigner.image.tag' ./cockroachdb/values.yaml)"
 )
 


### PR DESCRIPTION
- Added e2e tests under `e2e/operator/` for single and multi region use cases.
- It covers all the use cases we tested out manually from product brief.
- Update ci workflow to include single region and multi region e2e jobs with relevant machine.

Previous PR's - [#480]

JIRA - [CRDB-48127]

Parent - [CRDB-43233]