### PR TITLE
Fix password parsing in init job

### DIFF
--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -169,7 +169,7 @@ spec:
                       {{- range $user := .Values.init.provisioning.users }}
                         CREATE USER IF NOT EXISTS {{ $user.name }} WITH
                         {{- if $user.password }}
-                          PASSWORD '${{ $user.name }}_PASSWORD'
+                          PASSWORD '${{ $user.password }}_PASSWORD'
                         {{- else }}
                           PASSWORD null
                         {{- end }}

--- a/tests/template/cockroachdb_helm_template_test.go
+++ b/tests/template/cockroachdb_helm_template_test.go
@@ -807,7 +807,7 @@ func TestHelmDatabaseProvisioning(t *testing.T) {
 					"before-hook-creation",
 					true,
 					true,
-					"CREATE USER IF NOT EXISTS testUser WITH PASSWORD '$testUser_PASSWORD' CREATEROLE;",
+					"CREATE USER IF NOT EXISTS testUser WITH PASSWORD '$testPassword_PASSWORD' CREATEROLE;",
 				},
 				struct {
 					exists          bool

--- a/tests/template/cockroachdb_helm_template_test.go
+++ b/tests/template/cockroachdb_helm_template_test.go
@@ -902,7 +902,7 @@ func TestHelmDatabaseProvisioning(t *testing.T) {
 					"before-hook-creation",
 					true,
 					true,
-					"CREATE USER IF NOT EXISTS testUser WITH PASSWORD '$testUser_PASSWORD';" +
+					"CREATE USER IF NOT EXISTS testUser WITH PASSWORD '$testPassword_PASSWORD';" +
 						"CREATE DATABASE IF NOT EXISTS testDatabase;" +
 						"GRANT ALL ON DATABASE testDatabase TO testUser;",
 				},


### PR DESCRIPTION
Caught this bug when deploying locally on minikube. The password getting set was the user name instead of the actual password being passed in.