### PR TITLE
Visus Sidecar config

### DIFF
--- a/build/templates/values.yaml
+++ b/build/templates/values.yaml
@@ -722,6 +722,18 @@ iap:
 godebug:
   disablethp: "1"
 
+# Visus exports additional Prometheus metrics derived from internal Cockroach DB sources (often SQL queries)
+visus:
+  enabled: false
+  image:
+    name: cockroachdb/visus
+    tag: v1.0.0
+    pullPolicy: IfNotPresent
+  bind_port: 8888
+  # Insecure is pretty normal here; it just applies to the Prometheus metrics exporter service
+  insecure: true
+  args: []
+
 # Use the CockroachDB Operator to manage the CockroachDB clusters.
 operator:
   enabled: false

--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 16.0.8
+version: 16.1.0
 appVersion: 25.1.6
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb/templates/_helpers.tpl
+++ b/cockroachdb/templates/_helpers.tpl
@@ -71,6 +71,19 @@ Return the appropriate apiVersion for NetworkPolicy.
 {{- end -}}
 
 {{/*
+Construct the PG_URL for this database node
+*/}}
+{{- define "cockroachdb.pg_url" -}}
+    {{- printf "postgres://root@localhost:%d/defaultdb?application_name=visus&" (.Values.service.ports.grpc.internal.port | int64) -}}
+    {{- if .Values.tls.enabled }}
+      {{- printf "sslmode=verify-full&ssrootcert=/cockroach/client/ca.crt&sslcert=/cockroach/client/client.root.crt&sslkey=/cockroach/client/client.root.key" }}
+    {{- else }}
+      {{- print "sslmode=disable" }}
+    {{- end }}
+{{- end -}}
+
+
+{{/*
 Return the appropriate apiVersion for StatefulSets
 */}}
 {{- define "cockroachdb.statefulset.apiVersion" -}}

--- a/cockroachdb/templates/networkpolicy.yaml
+++ b/cockroachdb/templates/networkpolicy.yaml
@@ -53,6 +53,9 @@ spec:
     # Allow connections to admin UI and for Prometheus.
     - ports:
         - port: http
+        {{- if .Values.visus.enabled }}
+        - port: visus-http
+        {{- end }}
     {{- with .Values.networkPolicy.ingress.http }}
       from: {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/cockroachdb/templates/service.visus.yaml
+++ b/cockroachdb/templates/service.visus.yaml
@@ -1,0 +1,50 @@
+# This service only exists to create DNS entries for each pod in
+# the StatefulSet such that they can resolve each other's IP addresses.
+# It does not create a load-balanced ClusterIP and should not be used directly
+# by clients in most circumstances.
+{{- if .Values.visus.enabled }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: "{{ template "cockroachdb.fullname" . }}-visus"
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    helm.sh/chart: {{ template "cockroachdb.chart" . }}
+    app.kubernetes.io/name: "{{ template "cockroachdb.name" . }}-visus"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+  {{- with .Values.service.discovery.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+    # Use this annotation in addition to the actual field below because the
+    # annotation will stop being respected soon, but the field is broken in
+    # some versions of Kubernetes:
+    # https://github.com/kubernetes/kubernetes/issues/58662
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    # Enable automatic monitoring of all instances when Prometheus is running
+    # in the cluster.
+    prometheus.io/scrape: "true"
+    prometheus.io/path: _status/vars
+    prometheus.io/port: {{ .Values.visus.bind_port | quote }}
+  {{- with .Values.service.discovery.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  clusterIP: None
+  ports:
+    {{- if .Values.visus.enabled }}
+    - name: visus-http
+      port: {{ .Values.visus.bind_port | int64 }}
+      targetPort: visus-http
+    {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ template "cockroachdb.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  {{- with .Values.statefulset.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/cockroachdb/templates/serviceMonitor.yaml
+++ b/cockroachdb/templates/serviceMonitor.yaml
@@ -51,4 +51,17 @@ spec:
     {{- if .Values.serviceMonitor.tlsConfig }}
     tlsConfig: {{ toYaml .Values.serviceMonitor.tlsConfig | nindent 6 }}
     {{- end }}
+  {{- if .Values.visus.enabled }}
+  - port: visus-http
+    path: /_status/vars
+    {{- if $serviceMonitor.interval }}
+    interval: {{ $serviceMonitor.interval }}
+    {{- end }}
+    {{- if $serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ $serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    {{- if and not .Values.visus.insecure .Values.serviceMonitor.tlsConfig }}
+    tlsConfig: {{ toYaml .Values.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -49,8 +49,8 @@ spec:
         - name: {{ template "cockroachdb.fullname" . }}.db.registry
     {{- end }}
       serviceAccountName: {{ template "cockroachdb.serviceAccount.name" . }}
-      {{- if .Values.tls.enabled }}
       initContainers:
+        {{- if .Values.tls.enabled }}
         - name: copy-certs
           image: {{ .Values.tls.copyCerts.image | quote }}
           imagePullPolicy: {{ .Values.tls.selfSigner.image.pullPolicy | quote }}
@@ -80,6 +80,49 @@ spec:
         {{- with .Values.tls.copyCerts.resources }}
           resources: {{- toYaml . | nindent 12 }}
         {{- end }}
+        {{- end }}
+        {{/* Sidecar support is since k8s 1.29, which is beyond the k8s support horizon */}}
+        {{- if .Values.visus.enabled  }}
+        - name: visus
+          image: "{{ .Values.visus.image.name }}:{{ .Values.visus.image.tag }}"
+          imagePullPolicy: {{ .Values.visus.image.pullPolicy | quote }}
+          # This is a sidecar
+          restartPolicy: Always
+          command:
+            - visus
+            - start
+            - --url
+            - {{ template "cockroachdb.pg_url" $ }}
+            - --visus-metrics
+            - --bind-addr
+            - localhost:{{ .Values.visus.bind_port }}
+            {{- if .Values.visus.insecure }}
+            - --insecure
+            {{- else }}
+            - --bind-cert
+            - /cockroach/node/node.crt
+            - --bind-key
+            - /cockroach/node/node.key
+            - --ca-cert
+            - /cockroach/node/ca.crt
+            {{- end }}
+            {{- range $ic := .Values.visus.args }}
+            - {{- toYaml $ic | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: visus-http
+              containerPort: {{ .Values.visus.bind_port | int64 }}
+              protocol: TCP
+          volumeMounts:
+            {{- if .Values.tls.enabled }}
+            - name: certs
+              mountPath: /cockroach-certs/
+            - name: certs-secret
+              mountPath: /cockroach/node/
+            - name: client-secret
+              mountPath: /cockroach/client
+            {{- end }}
+        {{- end }}
         {{- range $ic := .Values.statefulset.initContainers }}
         - {{- toYaml $ic | nindent 10 }}
           {{ with $.Values.statefulset.volumeMounts}}
@@ -87,7 +130,6 @@ spec:
           {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- end }}
-      {{- end }}
     {{- if or .Values.statefulset.nodeAffinity .Values.statefulset.podAffinity .Values.statefulset.podAntiAffinity }}
       affinity:
       {{- with .Values.statefulset.nodeAffinity }}
@@ -433,6 +475,33 @@ spec:
             defaultMode: 256
           {{- end }}
           {{- end }}
+        {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager .Values.tls.certs.selfSigner.enabled }}
+        - name: client-secret
+        {{- if or .Values.tls.certs.tlsSecret .Values.tls.certs.certManager .Values.tls.certs.selfSigner.enabled }}
+          projected:
+            sources:
+            - secret:
+                {{- if .Values.tls.certs.selfSigner.enabled }}
+                name: {{ template "cockroachdb.fullname" . }}-client-secret
+                {{ else }}
+                name: {{ .Values.tls.certs.clientRootSecret }}
+                {{ end -}}
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                  mode: 0400
+                - key: tls.crt
+                  path: client.root.crt
+                  mode: 0400
+                - key: tls.key
+                  path: client.root.key
+                  mode: 0400
+        {{- else }}
+          secret:
+            secretName: {{ .Values.tls.certs.clientRootSecret }}
+            defaultMode: 0400
+        {{- end }}
+        {{- end }}
       {{- end }}
       {{- range .Values.statefulset.secretMounts }}
         - name: {{ printf "secret-%s" . | quote }}

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -723,6 +723,18 @@ iap:
 godebug:
   disablethp: "1"
 
+# Visus exports additional Prometheus metrics derived from internal Cockroach DB sources (often SQL queries)
+visus:
+  enabled: false
+  image:
+    name: cockroachdb/visus
+    tag: v1.0.0
+    pullPolicy: IfNotPresent
+  bind_port: 8888
+  # Insecure is pretty normal here; it just applies to the Prometheus metrics exporter service
+  insecure: true
+  args: []
+
 # Use the CockroachDB Operator to manage the CockroachDB clusters.
 operator:
   enabled: false

--- a/tests/e2e/migrate/helm_chart_to_cockroach_enterprise_operator_test.go
+++ b/tests/e2e/migrate/helm_chart_to_cockroach_enterprise_operator_test.go
@@ -130,7 +130,7 @@ func (h *HelmChartToOperator) TestDefaultMigration(t *testing.T) {
 	require.Contains(t, err.Error(), "You are attempting to upgrade from a StatefulSet-based CockroachDB Helm chart to the CockroachDB Enterprise Operator.")
 
 	t.Log("Delete the StatefulSet as helm upgrade can proceed only if no StatefulSet is present")
-	k8s.RunKubectl(t, kubectlOptions, "delete", "statefulset", stsName)
+	k8s.RunKubectl(t, kubectlOptions, "delete", "statefulset", h.CrdbCluster.StatefulSetName)
 
 	helm.Upgrade(t, &helm.Options{
 		KubectlOptions: kubectlOptions,


### PR DESCRIPTION
First-class support for Visus as a CRDB Sidecar in the Helm chart.

Visus will start before the DB, and be restarted if it fails. K8s won't wait for visus to terminate, since the restartPolicy is set.

Also includes a separate headless Service def so the Prometheus scraper can address each node directly. Visus is not exposed outside the cluster. 