### PR TITLE
fix: use the user.name attribute during init.provisioning to reference env variable secret

### DIFF
--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -169,7 +169,7 @@ spec:
                       {{- range $user := .Values.init.provisioning.users }}
                         CREATE USER IF NOT EXISTS {{ $user.name }} WITH
                         {{- if $user.password }}
-                          PASSWORD '${{ $user.password }}_PASSWORD'
+                          PASSWORD '${{ $user.name }}_PASSWORD'
                         {{- else }}
                           PASSWORD null
                         {{- end }}


### PR DESCRIPTION
This addresses https://github.com/cockroachdb/helm-charts/issues/509 to use the `user.name` instead of the `user.password` when provisioning the database user password.