### PR TITLE
Add upgrade validation check to avoid accidental upgrades from statefulset based helm chart without migration.

### DIFF
--- a/cockroachdb-parent/charts/cockroachdb/templates/_helpers.tpl
+++ b/cockroachdb-parent/charts/cockroachdb/templates/_helpers.tpl
@@ -310,3 +310,15 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ include "cockroachdb.clusterfullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{- define "cockroachdb.isUpgradeAllowed" -}}
+{{- $stsName := include "cockroachdb.fullname" . -}}
+{{- $sts := lookup "apps/v1" "StatefulSet" .Release.Namespace $stsName -}}
+{{- if $sts -}}
+  {{- fail (print `You are attempting to upgrade from a StatefulSet-based CockroachDB Helm chart to the CockroachDB Enterprise Operator.
+Before proceeding, you must first migrate your existing CockroachDB cluster to one managed by the CockroachDB Enterprise Operator.
+
+👉 Learn more about the CockroachDB Enterprise Operator: cockroachdb-parent/charts/cockroachdb/README.md
+🔄 Follow the migration steps at scripts/migration/helm/README.md`) -}}
+{{- end -}}
+{{- end }}

--- a/cockroachdb-parent/charts/cockroachdb/templates/crdb.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/templates/crdb.yaml
@@ -1,4 +1,7 @@
 {{ template "cockroachdb.tlsValidation" . }}
+{{- if .Release.IsUpgrade -}}
+{{ template "cockroachdb.isUpgradeAllowed" . }}
+{{- end -}}
 apiVersion: crdb.cockroachlabs.com/v1alpha1
 kind: CrdbCluster
 metadata:

--- a/scripts/migration/helm/README.md
+++ b/scripts/migration/helm/README.md
@@ -92,6 +92,12 @@ To avoid this conflict, delete the existing PDB before applying the CrdbCluster 
 kubectl delete poddisruptionbudget $STS_NAME-budget
 ```
 
+Delete the StatefulSet that you previously scaled down to zero, as the Helm upgrade can proceed only if no StatefulSet is present.
+
+```
+kubectl delete statefulset $STS_NAME
+```
+
 Finally, apply the crdbcluster manifest using helm upgrade:
 
 ```


### PR DESCRIPTION
We are keeping the same name of the chart for Cockroach Enterprise Operator. We would be upgrading the version to much higher version to indicate that we have added a significant change how cockroachdb cluster is managed.

To avoid any accidental upgrades without migration, I have added this pre-upgrade check. It checks if there is existing statefulset present with the same name. If yes, then we print this message to user to migrate and doesn't allow upgrade to happen. 