### PR TITLE
cockroachdb-parent/operator: Update operator ClusterRole permissions

### DIFF
--- a/cockroachdb-parent/charts/operator/templates/operator.yaml
+++ b/cockroachdb-parent/charts/operator/templates/operator.yaml
@@ -336,6 +336,12 @@ rules:
   - apiGroups:
       - crdb.cockroachlabs.com
     resources:
+      - crdbclusters/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - crdb.cockroachlabs.com
+    resources:
       - crdbnodes
     verbs:
       - create
@@ -352,6 +358,12 @@ rules:
     verbs:
       - get
       - patch
+      - update
+  - apiGroups:
+      - crdb.cockroachlabs.com
+    resources:
+      - crdbnodes/finalizers
+    verbs:
       - update
   - apiGroups:
       - crdb.cockroachlabs.com


### PR DESCRIPTION
- This PR addresses the CRDB deployments fix happening on OpenShift cluster.
- We still need to set `cockroachdb.tls.selfSigner.securityContext.enabled: false` for self-signer to run as openShift has stricter default securityPolicies.
- For CRDB pods to run, we either need to modify the ID's(userId,groupId, fsgroup etc;) used to be in the  allowed range or 
   grant access to serviceAccount access to a less restrictive SCC, such as **anyuid**.
   `oc adm policy add-scc-to-user anyuid -z <your-pod-serviceaccount-name> -n <your-pod-namespace>`.