### PR TITLE
Upgrade Bazel version in .bazelversion file

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,1 +1,1 @@
-cockroachdb/6.2.1
+cockroachdb/7.6.0


### PR DESCRIPTION
One of the mirrors for the rules_go repository doesn't contain the files anymore and the current version of Bazel wouldn't retry downloading from the next mirror.
Upgrading to a newer version of Bazel fixes this issue.