### PR TITLE
[CRDB-51768] [CRDB-51638] Add localityMappings and remove join fields to/from crdb spec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [cockroachdb-parent-25.2.2-preview] - 2025-07-28
+### Added
+- `startFlags`, `podTemplate` fields for overriding CockroachDB start command and pod spec. 
+- `localityMappings` field to allow granular mapping of Kubernetes node label to CockroachDB node locality.
+
+### Changed
+- Removed the deprecated `flags` field; use `startFlags` instead.
+- Removed the `join` field; specify it using `startFlags`.
+
 ## [cockroachdb-17.0.0] - 2025-05-27
 ### Added
 - release: advance app version to v25.2.0

--- a/build/templates/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/build/templates/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -168,9 +168,6 @@ cockroachdb:
     clusterSettings: ~
     # timestamp captures the annotation timestamp used for rolling restarts.
     timestamp: "2021-10-18T00:00:00Z"
-    # join captures the list of comma-separated addresses for joining an existing cluster.
-    # Each item should be a resolvable FQDN (with port if needed).
-    join: ""
     # resources captures the resource requests and limits for CockroachDB pods.
     resources: ~
       # limits:
@@ -282,11 +279,6 @@ cockroachdb:
     # podLabels captures additional labels to apply to CockroachDB pods.
     podLabels:
       app.kubernetes.io/component: cockroachdb
-    # flags captures flags passed to the CockroachDB container.
-    # It is recommended to configure `startFlags` over `flags` for setting flags that are passed to the CockroachDB start command.
-    flags:
-      # Disables backup/restore to local disk by default.
-      --external-io-dir: disabled
     # startFlags specify the flags that will be used for starting the cluster.
     # Any flag defined in here will take precedence over the first-class
     # fields responsible for setting the same flags.
@@ -408,8 +400,33 @@ cockroachdb:
     #   topology.kubernetes.io/zone: us-central1-c
     #   example.datacenter.locality: dc2
     # the resulting locality flag will be: locality=region=us-central1,zone=us-central1-c,example.datacenter.locality=dc2.
-    # https://www.cockroachlabs.com/docs/v25.1/cockroach-start#locality
+    # It is recommended to configure `localityMappings` over `localityLabels` for locality flag computation that is passed to the CockroachDB start command.
     localityLabels: []
+    # localityMappings captures labels used to determine node locality.
+    # It is an ordered, comma-separated list of key/value pairs that which must be present as labels on the nodes.
+    # Each locality mapping captures the relationship between a node label and a locality label.
+    # For region and zone to be part of the locality, the labels (topology.kubernetes.io/region, topology.kubernetes.io/region) must be set on the nodes.
+    # For other labels, they must be set on the nodes and will be presented as key/value pairs to the node locality.
+    # Example:
+    # If localityMappings are provided as
+    # [
+    #   {nodeLabel: "topology.kubernetes.io/region", localityLabel: "region"},
+    #   {nodeLabel: "topology.kubernetes.io/zone", localityLabel: "zone"},
+    #   {nodeLabel: "example.datacenter.locality", localityLabel: "dc"}
+    # ]
+    # and the node labels are:
+    # topology.kubernetes.io/region: us-central1
+    # topology.kubernetes.io/zone: us-central1-c
+    # example.datacenter.locality: dc2
+    # the resulting locality flag will be: locality=region=us-central1,zone=us-central1-c,dc=dc2.
+    # https://www.cockroachlabs.com/docs/v25.1/cockroach-start#locality
+    localityMappings: []
+      # - nodeLabel: "topology.kubernetes.io/region"
+      #   localityLabel: "region"
+      # - nodeLabel: "topology.kubernetes.io/zone"
+      #   localityLabel: "zone"
+      # - nodeLabel: "example.datacenter.locality"
+      #   localityLabel: "dc"
     # loggingConfigMapName defines the ConfigMap which contains log configuration used to send the logs through the
     # proper channels within CockroachDB.
     # The value of the ConfigMap should be specified under the key logs.yaml.
@@ -419,26 +436,26 @@ cockroachdb:
       # disablethp determines whether Transparent Huge Pages are disabled.
       # By default, disables THP, which can cause memory inefficiency for CockroachDB.
       disablethp: "1"
-      # podTemplate is an optional pod specification that overrides the default pod specification configured by the operator.
-      # If specified, podTemplate is merged with the default pod specification, with settings in podTemplate taking precedence.
-      # This can be used to add or update containers, volumes, and other settings of the CockroachDB pod.
-      podTemplate: {}
-        # # metadata captures the pod metadata for CockroachDB pods.
-        # metadata: {}
-        # # spec captures the pod specification for CockroachDB pods.
-        # spec:
-        #   # initContainers captures the list of init containers for CockroachDB pods.
-        #   initContainers:
-        #     - name : cockroachdb-init
-        #       image: us-docker.pkg.dev/cockroach-cloud-images/data-plane/init-container@sha256:c3e4ba851802a429c7f76c639a64b9152d206cebb31162c1760f05e98f7c4254
-        #   # containers captures the list of containers for CockroachDB pods.
-        #   containers:
-        #     - name: cockroachdb
-        #       image: cockroachdb/cockroach:v25.2.2
-        #     - name: cert-reloader
-        #       image: us-docker.pkg.dev/cockroach-cloud-images/data-plane/inotifywait:87edf086db32734c7fa083a62d1055d664900840
-        #   # imagePullSecrets captures the secrets for fetching images from private registries.
-        #   imagePullSecrets: []
+    # podTemplate is an optional pod specification that overrides the default pod specification configured by the operator.
+    # If specified, podTemplate is merged with the default pod specification, with settings in podTemplate taking precedence.
+    # This can be used to add or update containers, volumes, and other settings of the CockroachDB pod.
+    podTemplate: {}
+      # # metadata captures the pod metadata for CockroachDB pods.
+      # metadata: {}
+      # # spec captures the pod specification for CockroachDB pods.
+      # spec:
+      #   # initContainers captures the list of init containers for CockroachDB pods.
+      #   initContainers:
+      #     - name : cockroachdb-init
+      #       image: us-docker.pkg.dev/cockroach-cloud-images/data-plane/init-container@sha256:c3e4ba851802a429c7f76c639a64b9152d206cebb31162c1760f05e98f7c4254
+      #   # containers captures the list of containers for CockroachDB pods.
+      #   containers:
+      #     - name: cockroachdb
+      #       image: cockroachdb/cockroach:v25.2.2
+      #     - name: cert-reloader
+      #       image: us-docker.pkg.dev/cockroach-cloud-images/data-plane/inotifywait:87edf086db32734c7fa083a62d1055d664900840
+      #   # imagePullSecrets captures the secrets for fetching images from private registries.
+      #   imagePullSecrets: []
 k8s:
   # nameOverride overrides the name of the chart. If not set, the chart name will be used.
   # For example, if the chart name is "cockroachdb" and nameOverride is set to "crdb",

--- a/cockroachdb-parent/Chart.lock
+++ b/cockroachdb-parent/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: operator
   repository: file://charts/operator
-  version: 25.2.2-preview+1
+  version: 25.2.2-preview+2
 - name: cockroachdb
   repository: file://charts/cockroachdb
-  version: 25.2.2-preview+1
-digest: sha256:9f1bb739f03dbc1abb9bfd04fcf43e01f065230c8ebfc8ec4fde6fd17084c2be
-generated: "2025-07-15T18:45:12.388963+05:30"
+  version: 25.2.2-preview+2
+digest: sha256:38a6c54411a81631dceaaf9525c307fe8fbd449da0d75bde2afd9a8e9c40b95d
+generated: "2025-07-26T14:54:13.807804+05:30"

--- a/cockroachdb-parent/Chart.yaml
+++ b/cockroachdb-parent/Chart.yaml
@@ -3,14 +3,14 @@ apiVersion: v2
 name: cockroachdb-parent
 description: A parent Helm chart for CockroachDB and its operator using helm-spray
 type: application
-version: 25.2.2-preview+1
+version: 25.2.2-preview+2
 appVersion: 25.2.2
 dependencies:
   - name: operator
-    version: 25.2.2-preview+1
+    version: 25.2.2-preview+2
     condition: operator.enabled
     repository: "file://charts/operator"
   - name: cockroachdb
-    version: 25.2.2-preview+1
+    version: 25.2.2-preview+2
     condition: cockroachdb.enabled
     repository: "file://charts/cockroachdb"

--- a/cockroachdb-parent/charts/cockroachdb/Chart.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 25.2.2-preview+1
+version: 25.2.2-preview+2
 appVersion: 25.2.2
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb-parent/charts/cockroachdb/templates/crdb.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/templates/crdb.yaml
@@ -32,9 +32,6 @@ spec:
   template:
     spec:
       image: "{{ .Values.cockroachdb.crdbCluster.image.name }}"
-      {{- if .Values.cockroachdb.crdbCluster.join }}
-      join: {{ .Values.cockroachdb.crdbCluster.join }}
-      {{- end }}
       certificates:
         {{- if .Values.cockroachdb.tls.enabled }}
         {{- if .Values.cockroachdb.tls.externalCertificates.enabled }}
@@ -91,6 +88,9 @@ spec:
       {{- with .Values.cockroachdb.crdbCluster.localityLabels }}
       localityLabels: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.cockroachdb.crdbCluster.localityMappings }}
+      localityMappings: {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.cockroachdb.crdbCluster.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -115,9 +115,6 @@ spec:
       {{- end }}
       {{- if .Values.cockroachdb.crdbCluster.service.ports.http.port }}
       httpPort: {{ .Values.cockroachdb.crdbCluster.service.ports.http.port }}
-      {{- end }}
-      {{- with .Values.cockroachdb.crdbCluster.flags }}
-      flags: {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.cockroachdb.crdbCluster.startFlags }}
       startFlags: {{- toYaml . | nindent 8 }}

--- a/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -169,9 +169,6 @@ cockroachdb:
     clusterSettings: ~
     # timestamp captures the annotation timestamp used for rolling restarts.
     timestamp: "2021-10-18T00:00:00Z"
-    # join captures the list of comma-separated addresses for joining an existing cluster.
-    # Each item should be a resolvable FQDN (with port if needed).
-    join: ""
     # resources captures the resource requests and limits for CockroachDB pods.
     resources: ~
       # limits:
@@ -283,11 +280,6 @@ cockroachdb:
     # podLabels captures additional labels to apply to CockroachDB pods.
     podLabels:
       app.kubernetes.io/component: cockroachdb
-    # flags captures flags passed to the CockroachDB container.
-    # It is recommended to configure `startFlags` over `flags` for setting flags that are passed to the CockroachDB start command.
-    flags:
-      # Disables backup/restore to local disk by default.
-      --external-io-dir: disabled
     # startFlags specify the flags that will be used for starting the cluster.
     # Any flag defined in here will take precedence over the first-class
     # fields responsible for setting the same flags.
@@ -409,8 +401,33 @@ cockroachdb:
     #   topology.kubernetes.io/zone: us-central1-c
     #   example.datacenter.locality: dc2
     # the resulting locality flag will be: locality=region=us-central1,zone=us-central1-c,example.datacenter.locality=dc2.
-    # https://www.cockroachlabs.com/docs/v25.1/cockroach-start#locality
+    # It is recommended to configure `localityMappings` over `localityLabels` for locality flag computation that is passed to the CockroachDB start command.
     localityLabels: []
+    # localityMappings captures labels used to determine node locality.
+    # It is an ordered, comma-separated list of key/value pairs that which must be present as labels on the nodes.
+    # Each locality mapping captures the relationship between a node label and a locality label.
+    # For region and zone to be part of the locality, the labels (topology.kubernetes.io/region, topology.kubernetes.io/region) must be set on the nodes.
+    # For other labels, they must be set on the nodes and will be presented as key/value pairs to the node locality.
+    # Example:
+    # If localityMappings are provided as
+    # [
+    #   {nodeLabel: "topology.kubernetes.io/region", localityLabel: "region"},
+    #   {nodeLabel: "topology.kubernetes.io/zone", localityLabel: "zone"},
+    #   {nodeLabel: "example.datacenter.locality", localityLabel: "dc"}
+    # ]
+    # and the node labels are:
+    # topology.kubernetes.io/region: us-central1
+    # topology.kubernetes.io/zone: us-central1-c
+    # example.datacenter.locality: dc2
+    # the resulting locality flag will be: locality=region=us-central1,zone=us-central1-c,dc=dc2.
+    # https://www.cockroachlabs.com/docs/v25.1/cockroach-start#locality
+    localityMappings: []
+      # - nodeLabel: "topology.kubernetes.io/region"
+      #   localityLabel: "region"
+      # - nodeLabel: "topology.kubernetes.io/zone"
+      #   localityLabel: "zone"
+      # - nodeLabel: "example.datacenter.locality"
+      #   localityLabel: "dc"
     # loggingConfigMapName defines the ConfigMap which contains log configuration used to send the logs through the
     # proper channels within CockroachDB.
     # The value of the ConfigMap should be specified under the key logs.yaml.
@@ -420,26 +437,26 @@ cockroachdb:
       # disablethp determines whether Transparent Huge Pages are disabled.
       # By default, disables THP, which can cause memory inefficiency for CockroachDB.
       disablethp: "1"
-      # podTemplate is an optional pod specification that overrides the default pod specification configured by the operator.
-      # If specified, podTemplate is merged with the default pod specification, with settings in podTemplate taking precedence.
-      # This can be used to add or update containers, volumes, and other settings of the CockroachDB pod.
-      podTemplate: {}
-        # # metadata captures the pod metadata for CockroachDB pods.
-        # metadata: {}
-        # # spec captures the pod specification for CockroachDB pods.
-        # spec:
-        #   # initContainers captures the list of init containers for CockroachDB pods.
-        #   initContainers:
-        #     - name : cockroachdb-init
-        #       image: us-docker.pkg.dev/cockroach-cloud-images/data-plane/init-container@sha256:c3e4ba851802a429c7f76c639a64b9152d206cebb31162c1760f05e98f7c4254
-        #   # containers captures the list of containers for CockroachDB pods.
-        #   containers:
-        #     - name: cockroachdb
-        #       image: cockroachdb/cockroach:v25.2.2
-        #     - name: cert-reloader
-        #       image: us-docker.pkg.dev/cockroach-cloud-images/data-plane/inotifywait:87edf086db32734c7fa083a62d1055d664900840
-        #   # imagePullSecrets captures the secrets for fetching images from private registries.
-        #   imagePullSecrets: []
+    # podTemplate is an optional pod specification that overrides the default pod specification configured by the operator.
+    # If specified, podTemplate is merged with the default pod specification, with settings in podTemplate taking precedence.
+    # This can be used to add or update containers, volumes, and other settings of the CockroachDB pod.
+    podTemplate: {}
+      # # metadata captures the pod metadata for CockroachDB pods.
+      # metadata: {}
+      # # spec captures the pod specification for CockroachDB pods.
+      # spec:
+      #   # initContainers captures the list of init containers for CockroachDB pods.
+      #   initContainers:
+      #     - name : cockroachdb-init
+      #       image: us-docker.pkg.dev/cockroach-cloud-images/data-plane/init-container@sha256:c3e4ba851802a429c7f76c639a64b9152d206cebb31162c1760f05e98f7c4254
+      #   # containers captures the list of containers for CockroachDB pods.
+      #   containers:
+      #     - name: cockroachdb
+      #       image: cockroachdb/cockroach:v25.2.2
+      #     - name: cert-reloader
+      #       image: us-docker.pkg.dev/cockroach-cloud-images/data-plane/inotifywait:87edf086db32734c7fa083a62d1055d664900840
+      #   # imagePullSecrets captures the secrets for fetching images from private registries.
+      #   imagePullSecrets: []
 k8s:
   # nameOverride overrides the name of the chart. If not set, the chart name will be used.
   # For example, if the chart name is "cockroachdb" and nameOverride is set to "crdb",

--- a/cockroachdb-parent/charts/operator/Chart.yaml
+++ b/cockroachdb-parent/charts/operator/Chart.yaml
@@ -4,4 +4,4 @@ name: operator
 description: A Helm chart for managing the CockroachDB operator.
 type: application
 appVersion: 25.2.2
-version: 25.2.2-preview+1
+version: 25.2.2-preview+2

--- a/pkg/migrate/build-manifests.go
+++ b/pkg/migrate/build-manifests.go
@@ -104,7 +104,7 @@ func (m *Manifest) FromPublicOperator() error {
 			return errors.Newf("pod %s isn't scheduled to a node", podName)
 		}
 
-		nodeSpec := buildNodeSpecFromOperator(publicCluster, sts, pod.Spec.NodeName, input.joinCmd, input.flags)
+		nodeSpec := buildNodeSpecFromOperator(publicCluster, sts, pod.Spec.NodeName, input.startFlags)
 		crdbNode := v1alpha1.CrdbNode{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "CrdbNode",
@@ -131,7 +131,7 @@ func (m *Manifest) FromPublicOperator() error {
 		}
 	}
 
-	helmValues := buildHelmValuesFromOperator(publicCluster, sts, m.cloudProvider, m.cloudRegion, m.namespace, input.joinCmd, input.flags)
+	helmValues := buildHelmValuesFromOperator(publicCluster, sts, m.cloudProvider, m.cloudRegion, m.namespace, input.startFlags)
 
 	if err := yamlToDisk(filepath.Join(m.outputDir, "values.yaml"), []any{helmValues}); err != nil {
 		return errors.Wrap(err, "writing helm values to disk")

--- a/pkg/migrate/testdata/helm/allInput/crdbnode-0.yaml.golden
+++ b/pkg/migrate/testdata/helm/allInput/crdbnode-0.yaml.golden
@@ -55,15 +55,9 @@ spec:
       fieldRef:
         apiVersion: v1
         fieldPath: status.hostIP
-  flags:
-    --advertise-host: $(hostname).${STATEFULSET_FQDN}
-    --cache: 25%
-    --certs-dir: /cockroach/cockroach-certs/
-    --max-sql-memory: 25%
   grpcPort: 26258
   httpPort: 8080
   image: cockroachdb/cockroach:v25.1.5
-  join: ${STATEFULSET_NAME}-0.${STATEFULSET_FQDN}:26257,${STATEFULSET_NAME}-1.${STATEFULSET_FQDN}:26257,${STATEFULSET_NAME}-2.${STATEFULSET_FQDN}:26257
   localityLabels:
   - country
   - region
@@ -87,6 +81,14 @@ spec:
   serviceAccountName: cockroachdb
   sideCars: {}
   sqlPort: 26257
+  startFlags:
+    omit: null
+    upsert:
+    - --join=${STATEFULSET_NAME}-0.${STATEFULSET_FQDN}:26257,${STATEFULSET_NAME}-1.${STATEFULSET_FQDN}:26257,${STATEFULSET_NAME}-2.${STATEFULSET_FQDN}:26257
+    - --advertise-host=$(hostname).${STATEFULSET_FQDN}
+    - --certs-dir=/cockroach/cockroach-certs/
+    - --cache=25%
+    - --max-sql-memory=25%
   terminationGracePeriod: 5m0s
   tolerations:
   - effect: NoSchedule

--- a/pkg/migrate/testdata/helm/allInput/crdbnode-1.yaml.golden
+++ b/pkg/migrate/testdata/helm/allInput/crdbnode-1.yaml.golden
@@ -55,15 +55,9 @@ spec:
       fieldRef:
         apiVersion: v1
         fieldPath: status.hostIP
-  flags:
-    --advertise-host: $(hostname).${STATEFULSET_FQDN}
-    --cache: 25%
-    --certs-dir: /cockroach/cockroach-certs/
-    --max-sql-memory: 25%
   grpcPort: 26258
   httpPort: 8080
   image: cockroachdb/cockroach:v25.1.5
-  join: ${STATEFULSET_NAME}-0.${STATEFULSET_FQDN}:26257,${STATEFULSET_NAME}-1.${STATEFULSET_FQDN}:26257,${STATEFULSET_NAME}-2.${STATEFULSET_FQDN}:26257
   localityLabels:
   - country
   - region
@@ -87,6 +81,14 @@ spec:
   serviceAccountName: cockroachdb
   sideCars: {}
   sqlPort: 26257
+  startFlags:
+    omit: null
+    upsert:
+    - --join=${STATEFULSET_NAME}-0.${STATEFULSET_FQDN}:26257,${STATEFULSET_NAME}-1.${STATEFULSET_FQDN}:26257,${STATEFULSET_NAME}-2.${STATEFULSET_FQDN}:26257
+    - --advertise-host=$(hostname).${STATEFULSET_FQDN}
+    - --certs-dir=/cockroach/cockroach-certs/
+    - --cache=25%
+    - --max-sql-memory=25%
   terminationGracePeriod: 5m0s
   tolerations:
   - effect: NoSchedule

--- a/pkg/migrate/testdata/helm/allInput/crdbnode-2.yaml.golden
+++ b/pkg/migrate/testdata/helm/allInput/crdbnode-2.yaml.golden
@@ -55,15 +55,9 @@ spec:
       fieldRef:
         apiVersion: v1
         fieldPath: status.hostIP
-  flags:
-    --advertise-host: $(hostname).${STATEFULSET_FQDN}
-    --cache: 25%
-    --certs-dir: /cockroach/cockroach-certs/
-    --max-sql-memory: 25%
   grpcPort: 26258
   httpPort: 8080
   image: cockroachdb/cockroach:v25.1.5
-  join: ${STATEFULSET_NAME}-0.${STATEFULSET_FQDN}:26257,${STATEFULSET_NAME}-1.${STATEFULSET_FQDN}:26257,${STATEFULSET_NAME}-2.${STATEFULSET_FQDN}:26257
   localityLabels:
   - country
   - region
@@ -87,6 +81,14 @@ spec:
   serviceAccountName: cockroachdb
   sideCars: {}
   sqlPort: 26257
+  startFlags:
+    omit: null
+    upsert:
+    - --join=${STATEFULSET_NAME}-0.${STATEFULSET_FQDN}:26257,${STATEFULSET_NAME}-1.${STATEFULSET_FQDN}:26257,${STATEFULSET_NAME}-2.${STATEFULSET_FQDN}:26257
+    - --advertise-host=$(hostname).${STATEFULSET_FQDN}
+    - --certs-dir=/cockroach/cockroach-certs/
+    - --cache=25%
+    - --max-sql-memory=25%
   terminationGracePeriod: 5m0s
   tolerations:
   - effect: NoSchedule

--- a/pkg/migrate/testdata/helm/allInput/values.yaml.golden
+++ b/pkg/migrate/testdata/helm/allInput/values.yaml.golden
@@ -31,14 +31,8 @@ cockroachdb:
       value: kubernetes-helm
     - name: GODEBUG
       value: disablethp=1
-    flags:
-      --advertise-host: $(hostname).${STATEFULSET_FQDN}
-      --cache: 25%
-      --certs-dir: /cockroach/cockroach-certs/
-      --max-sql-memory: 25%
     image:
       name: cockroachdb/cockroach:v25.1.5
-    join: ${STATEFULSET_NAME}-0.${STATEFULSET_FQDN}:26257,${STATEFULSET_NAME}-1.${STATEFULSET_FQDN}:26257,${STATEFULSET_NAME}-2.${STATEFULSET_FQDN}:26257
     localityLabels:
     - country
     - region
@@ -72,6 +66,14 @@ cockroachdb:
           port: 8080
         sql:
           port: 26257
+    startFlags:
+      omit: null
+      upsert:
+      - --join=${STATEFULSET_NAME}-0.${STATEFULSET_FQDN}:26257,${STATEFULSET_NAME}-1.${STATEFULSET_FQDN}:26257,${STATEFULSET_NAME}-2.${STATEFULSET_FQDN}:26257
+      - --advertise-host=$(hostname).${STATEFULSET_FQDN}
+      - --certs-dir=/cockroach/cockroach-certs/
+      - --cache=25%
+      - --max-sql-memory=25%
     terminationGracePeriod: 300s
     tolerations:
     - effect: NoSchedule

--- a/pkg/migrate/testdata/operator/allInput/crdbnode-0.yaml.golden
+++ b/pkg/migrate/testdata/operator/allInput/crdbnode-0.yaml.golden
@@ -65,17 +65,9 @@ spec:
       fieldRef:
         apiVersion: v1
         fieldPath: status.hostIP
-  flags:
-    --advertise-host: $(POD_NAME).cockroachdb.default
-    --cache: 30%
-    --certs-dir: /cockroach/cockroach-certs/
-    --listen-addr: :26258
-    --max-sql-memory: 30%
-    --sql-addr: :26257
   grpcPort: 26258
   httpPort: 8080
   image: cockroachdb/cockroach:v25.1.5
-  join: cockroachdb-0.cockroachdb.default:26258,cockroachdb-1.cockroachdb.default:26258,cockroachdb-2.cockroachdb.default:26258
   loggingConfigMapName: cockroachdb-log-config
   nodeName: node0
   nodeSelector:
@@ -97,6 +89,16 @@ spec:
   serviceAccountName: cockroachdb
   sideCars: {}
   sqlPort: 26257
+  startFlags:
+    omit: null
+    upsert:
+    - --advertise-host=$(POD_NAME).cockroachdb.default
+    - --certs-dir=/cockroach/cockroach-certs/
+    - --sql-addr=:26257
+    - --listen-addr=:26258
+    - --cache=30%
+    - --max-sql-memory=30%
+    - --join=cockroachdb-0.cockroachdb.default:26258,cockroachdb-1.cockroachdb.default:26258,cockroachdb-2.cockroachdb.default:26258
   terminationGracePeriod: 5m0s
   tolerations:
   - effect: NoSchedule

--- a/pkg/migrate/testdata/operator/allInput/crdbnode-1.yaml.golden
+++ b/pkg/migrate/testdata/operator/allInput/crdbnode-1.yaml.golden
@@ -65,17 +65,9 @@ spec:
       fieldRef:
         apiVersion: v1
         fieldPath: status.hostIP
-  flags:
-    --advertise-host: $(POD_NAME).cockroachdb.default
-    --cache: 30%
-    --certs-dir: /cockroach/cockroach-certs/
-    --listen-addr: :26258
-    --max-sql-memory: 30%
-    --sql-addr: :26257
   grpcPort: 26258
   httpPort: 8080
   image: cockroachdb/cockroach:v25.1.5
-  join: cockroachdb-0.cockroachdb.default:26258,cockroachdb-1.cockroachdb.default:26258,cockroachdb-2.cockroachdb.default:26258
   loggingConfigMapName: cockroachdb-log-config
   nodeName: node1
   nodeSelector:
@@ -97,6 +89,16 @@ spec:
   serviceAccountName: cockroachdb
   sideCars: {}
   sqlPort: 26257
+  startFlags:
+    omit: null
+    upsert:
+    - --advertise-host=$(POD_NAME).cockroachdb.default
+    - --certs-dir=/cockroach/cockroach-certs/
+    - --sql-addr=:26257
+    - --listen-addr=:26258
+    - --cache=30%
+    - --max-sql-memory=30%
+    - --join=cockroachdb-0.cockroachdb.default:26258,cockroachdb-1.cockroachdb.default:26258,cockroachdb-2.cockroachdb.default:26258
   terminationGracePeriod: 5m0s
   tolerations:
   - effect: NoSchedule

--- a/pkg/migrate/testdata/operator/allInput/crdbnode-2.yaml.golden
+++ b/pkg/migrate/testdata/operator/allInput/crdbnode-2.yaml.golden
@@ -65,17 +65,9 @@ spec:
       fieldRef:
         apiVersion: v1
         fieldPath: status.hostIP
-  flags:
-    --advertise-host: $(POD_NAME).cockroachdb.default
-    --cache: 30%
-    --certs-dir: /cockroach/cockroach-certs/
-    --listen-addr: :26258
-    --max-sql-memory: 30%
-    --sql-addr: :26257
   grpcPort: 26258
   httpPort: 8080
   image: cockroachdb/cockroach:v25.1.5
-  join: cockroachdb-0.cockroachdb.default:26258,cockroachdb-1.cockroachdb.default:26258,cockroachdb-2.cockroachdb.default:26258
   loggingConfigMapName: cockroachdb-log-config
   nodeName: node2
   nodeSelector:
@@ -97,6 +89,16 @@ spec:
   serviceAccountName: cockroachdb
   sideCars: {}
   sqlPort: 26257
+  startFlags:
+    omit: null
+    upsert:
+    - --advertise-host=$(POD_NAME).cockroachdb.default
+    - --certs-dir=/cockroach/cockroach-certs/
+    - --sql-addr=:26257
+    - --listen-addr=:26258
+    - --cache=30%
+    - --max-sql-memory=30%
+    - --join=cockroachdb-0.cockroachdb.default:26258,cockroachdb-1.cockroachdb.default:26258,cockroachdb-2.cockroachdb.default:26258
   terminationGracePeriod: 5m0s
   tolerations:
   - effect: NoSchedule

--- a/pkg/migrate/testdata/operator/allInput/values.yaml.golden
+++ b/pkg/migrate/testdata/operator/allInput/values.yaml.golden
@@ -42,16 +42,8 @@ cockroachdb:
           resource: limits.memory
     - name: MY_ENV_VAR
       value: kubernetes-helm
-    flags:
-      --advertise-host: $(POD_NAME).cockroachdb.default
-      --cache: 30%
-      --certs-dir: /cockroach/cockroach-certs/
-      --listen-addr: :26258
-      --max-sql-memory: 30%
-      --sql-addr: :26257
     image:
       name: cockroachdb/cockroach:v25.1.5
-    join: cockroachdb-0.cockroachdb.default:26258,cockroachdb-1.cockroachdb.default:26258,cockroachdb-2.cockroachdb.default:26258
     loggingConfigMapName: cockroachdb-log-config
     nodeSelector:
       cloud.google.com/gke-nodepool: default-pool
@@ -83,6 +75,16 @@ cockroachdb:
           port: 8080
         sql:
           port: 26257
+    startFlags:
+      omit: null
+      upsert:
+      - --advertise-host=$(POD_NAME).cockroachdb.default
+      - --certs-dir=/cockroach/cockroach-certs/
+      - --sql-addr=:26257
+      - --listen-addr=:26258
+      - --cache=30%
+      - --max-sql-memory=30%
+      - --join=cockroachdb-0.cockroachdb.default:26258,cockroachdb-1.cockroachdb.default:26258,cockroachdb-2.cockroachdb.default:26258
     terminationGracePeriod: 300s
     tolerations:
     - effect: NoSchedule


### PR DESCRIPTION
- `localityMappings` gives flexibility to configure `nodeLabel` and `localityLabel`.
- `localityLabels` is deprecated and localityMappings is the recommended way to configure
    for computing locality dynamically for each node.
- `join` needs to be passed via `startFlags`.
-  Bumped helm version and updated `CHANGELOG`.