### PR TITLE
e2e/operator: Create unique Firewall rules per vpc.

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   integration-tests-multi-region:
     runs-on: ubuntu-latest-4-core
+    timeout-minutes: 90
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -42,6 +43,7 @@ jobs:
         continue-on-error: false
   integration-tests-single-region:
     runs-on: ubuntu-latest-4-core
+    timeout-minutes: 90
     permissions:
       contents: read
       id-token: write

--- a/tests/e2e/operator/infra/common.go
+++ b/tests/e2e/operator/infra/common.go
@@ -8,13 +8,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-
-	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
-	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
 )
 
 // Provider types.

--- a/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
+++ b/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
@@ -90,8 +90,25 @@ func TestOperatorInMultiRegion(t *testing.T) {
 			}
 
 			// Run tests sequentially within a provider.
+			var testFailed bool
 			for name, method := range testCases {
+				// Skip remaining tests if a previous test failed to save time
+				if testFailed {
+					t.Logf("Skipping test %s due to previous test failure", name)
+					continue
+				}
+
 				t.Run(name, func(t *testing.T) {
+					// Add immediate cleanup trigger if this individual test fails
+					defer func() {
+						if t.Failed() {
+							testFailed = true
+							t.Logf("Test %s failed, triggering immediate infrastructure cleanup", name)
+							cloudProvider.TeardownInfra(t)
+							t.Logf("Infrastructure cleanup completed due to test failure")
+						}
+					}()
+
 					method(t)
 				})
 			}


### PR DESCRIPTION
GCP firewall rules are unique to project. This fix makes sure unique firewall rules are created per VPC to avoid conflict with other CI runs.