### PR TITLE
[CC-33024] Remove the deprecated fields of CockroachDB operator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,7 +164,7 @@ jobs:
 
   helm-rotate-cert-e2e:
     name: Helm-rotate-cert-Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-core
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -48,7 +48,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: multi-region-test-results
+          name: multi-region-test-results-${{ matrix.provider }}
           path: |
             test_output.log
             test_output.json
@@ -167,7 +167,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: single-region-test-results
+          name: single-region-test-results-${{ matrix.provider }}
           path: |
             test_output.log
             test_output.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [cockroachdb-parent-25.3.4-preview+1] 2025-11-25
+### Added
+- Added WAL failover custom path support in CockroachDB operator.
+- Added virtual cluster support in CockroachDB operator.
+- Added `--enable-k8s-node-controller` flag in CockroachDB operator to handle K8s node decommission feature.
+### Breaking Changes
+- Removed the following deprecated fields in favor of the corresponding podTemplate fields:
+  - cockroachdb.crdbcluster.resources
+  - cockroachdb.crdbcluster.podLabels
+  - cockroachdb.crdbcluster.env
+  - cockroachdb.crdbcluster.topologySpreadConstraints
+  - cockroachdb.crdbcluster.podAnnotations
+  - cockroachdb.crdbcluster.nodeSelector
+  - cockroachdb.crdbcluster.affinity
+  - cockroachdb.crdbcluster.tolerations
+
 ## [cockroachdb-parent-25.3.0-preview] - 2025-08-26
 ### Added
 - `loggingConfigVars` field for supporting multiple environment configuration variables in the `loggingConfigMap`.

--- a/build/templates/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/build/templates/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -168,14 +168,6 @@ cockroachdb:
     clusterSettings: ~
     # timestamp captures the annotation timestamp used for rolling restarts.
     timestamp: "2021-10-18T00:00:00Z"
-    # resources captures the resource requests and limits for CockroachDB pods.
-    resources: ~
-      # limits:
-      #   cpu: 4000m
-      #   memory: 16Gi
-      # requests:
-      #   cpu: 4000m
-      #   memory: 16Gi
     # dataStore captures the disk configuration for CockroachDB storage.
     dataStore:
       # volumeClaimTemplate captures the PVC template for storage.
@@ -282,16 +274,13 @@ cockroachdb:
       # storageClassName: ""
       #
       # path is the absolute mount path inside the CockroachDB container to use for WAL failover side disk.
-      # Examples: 
+      # Examples:
       #   - /cockroach/cockroach-failover
       #   - /cockroach/custom/path
       # IMPORTANT: Set it only for fresh deployments. Changing it on upgrades might cause issues with the deployment.
       #
       # path: "/cockroach/cockroach-failover"
       #
-    # podLabels captures additional labels to apply to CockroachDB pods.
-    podLabels:
-      app.kubernetes.io/component: cockroachdb
     # startFlags specify the flags that will be used for starting the cluster.
     # Any flag defined in here will take precedence over the first-class
     # fields responsible for setting the same flags.
@@ -303,25 +292,8 @@ cockroachdb:
       # # omit defines a set of flags which will be omitted from the start command.
       # omit:
       #   - ""
-    # env captures environment variables set on CockroachDB pods.
-    env: []
-      # - name: APP_NAME
-      #   value: "CRDB"
-      # - name: POD_NAME
-      #   valueFrom:
-      #     fieldRef:
-      #       fieldPath: metadata.name
     # rollingRestartDelay specifies the delay between rolling restarts of CockroachDB pods.
     rollingRestartDelay: 30s
-    # topologySpreadConstraints captures pod topology spread constraints.
-    # It is recommended to spread CockroachDB pods across zones to ensure high availability.
-    topologySpreadConstraints:
-        # maxSkew defines the degree to which the pods can be unevenly distributed.
-      - maxSkew: 1
-        # topologyKey defines the key for topology spread.
-        topologyKey: topology.kubernetes.io/zone
-        # whenUnsatisfiable defines the behavior when constraints cannot be met.
-        whenUnsatisfiable: DoNotSchedule
     # service captures the Kubernetes Service configurations for CockroachDB pods.
     service:
       # ports captures the service port definitions.
@@ -368,43 +340,6 @@ cockroachdb:
           ingressClassName: ""
           annotations: {}
           host: ""
-    # podAnnotations captures annotations to apply to CockroachDB pods.
-    podAnnotations: {}
-    # terminationGracePeriod determines the time available to CockroachDB for graceful drain.
-    # It follows the metav1.Duration format, e.g., "300s", "5m" or "1h".
-    # terminationGracePeriod: "300s"
-    # nodeSelector captures the node selector labels for scheduling pods.
-    nodeSelector: {}
-    # affinity captures scheduling affinity rules for CockroachDB pods.
-    affinity:
-      # nodeAffinity:
-      #   requiredDuringSchedulingIgnoredDuringExecution:
-      #     nodeSelectorTerms:
-      #       - matchExpressions:
-      #           - key: kubernetes.io/os
-      #             operator: In
-      #             values:
-      #               - linux
-      # podAffinity:
-      #   requiredDuringSchedulingIgnoredDuringExecution:
-      #     - labelSelector:
-      #         matchExpressions:
-      #           - key: security
-      #             operator: In
-      #             values:
-      #               - S1
-      #       topologyKey: topology.kubernetes.io/zone
-      # podAntiAffinity:
-      #   preferredDuringSchedulingIgnoredDuringExecution:
-      #     - weight: 100
-      #       podAffinityTerm:
-      #         labelSelector:
-      #           matchExpressions:
-      #             - key: security
-      #               operator: In
-      #               values:
-      #                 - S2
-      #         topologyKey: topology.kubernetes.io/zone
       #
     # sideCars captures the configuration for sidecar containers.
     sideCars:
@@ -414,8 +349,6 @@ cockroachdb:
       containers: []
       # volumes captures additional volumes for CockroachDB pods.
       volumes: []
-    # tolerations captures the tolerations for scheduling CockroachDB pods.
-    tolerations: []
     # localityLabels captures labels used to determine node locality.
     # It is an ordered, comma-separated list of keys that which must be present as labels on the nodes.
     # For region and zone to be part of the locality, the labels (topology.kubernetes.io/region, topology.kubernetes.io/region) must be set on the nodes.
@@ -467,26 +400,86 @@ cockroachdb:
       # disablethp determines whether Transparent Huge Pages are disabled.
       # By default, disables THP, which can cause memory inefficiency for CockroachDB.
       disablethp: "1"
-    # podTemplate is an optional pod specification that overrides the default pod specification configured by the operator.
+    # podTemplate defines the pod specification to override default pod specification configured by the operator.
     # If specified, podTemplate is merged with the default pod specification, with settings in podTemplate taking precedence.
     # This can be used to add or update containers, volumes, and other settings of the CockroachDB pod.
-    podTemplate: {}
-      # # metadata captures the pod metadata for CockroachDB pods.
-      # metadata: {}
-      # # spec captures the pod specification for CockroachDB pods.
-      # spec:
-      #   # initContainers captures the list of init containers for CockroachDB pods.
-      #   initContainers:
-      #     - name : cockroachdb-init
-      #       image: us-docker.pkg.dev/cockroach-cloud-images/data-plane/init-container@sha256:c3e4ba851802a429c7f76c639a64b9152d206cebb31162c1760f05e98f7c4254
-      #   # containers captures the list of containers for CockroachDB pods.
-      #   containers:
-      #     - name: cockroachdb
-      #       image: cockroachdb/cockroach:v25.2.2
-      #     - name: cert-reloader
-      #       image: us-docker.pkg.dev/cockroach-cloud-images/data-plane/inotifywait:87edf086db32734c7fa083a62d1055d664900840
-      #   # imagePullSecrets captures the secrets for fetching images from private registries.
-      #   imagePullSecrets: []
+    podTemplate:
+      # metadata captures the pod metadata for CockroachDB pods.
+      metadata:
+        labels:
+          app.kubernetes.io/component: cockroachdb
+        annotations: {}
+      # spec captures the pod specification for CockroachDB pods.
+      spec:
+        # # imagePullSecrets captures the secrets for fetching images from private registries.
+        # imagePullSecrets: []
+        # # initContainers captures the list of init containers for CockroachDB pods.
+        # initContainers:
+        #   - name : cockroachdb-init
+        #     image: us-docker.pkg.dev/releases-prod/self-hosted/init-container@sha256:bcfc9312af84c7966f017c2325981b30314c0c293491f942e54da1667bedaf69
+        # containers captures the list of containers for CockroachDB pods.
+        containers:
+          - name: cockroachdb
+            # env captures environment variables set on CockroachDB pods.
+            env: []
+            # - name: APP_NAME
+            #   value: "CRDB"
+            # - name: POD_NAME
+            #   valueFrom:
+            #     fieldRef:
+            #       fieldPath: metadata.name
+            resources: {}
+            # image: cockroachdb/cockroach:v25.3.4
+            # - name: cert-reloader
+            #   image: us-docker.pkg.dev/releases-prod/self-hosted/inotifywait@sha256:2e443a2d00e6541bd596219204865db74f813e8d54678ce2fe71747e40254182
+        
+        # topologySpreadConstraints captures pod topology spread constraints.
+        # It is recommended to spread CockroachDB pods across zones to ensure high availability.
+        topologySpreadConstraints:
+            # maxSkew defines the degree to which the pods can be unevenly distributed.
+          - maxSkew: 1
+            # topologyKey defines the key for topology spread.
+            topologyKey: topology.kubernetes.io/zone
+            # whenUnsatisfiable defines the behavior when constraints cannot be met.
+            whenUnsatisfiable: DoNotSchedule
+        # # terminationGracePeriodSeconds determines the time available to CockroachDB for graceful drain.
+        # terminationGracePeriodSeconds: 300
+        # # tolerations captures the tolerations for pods of the self-signer job.
+        # # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+        # tolerations: []
+        # # nodeSelector captures the node selector labels for scheduling pods.
+        # nodeSelector: {}
+        # # affinity captures scheduling affinity rules for CockroachDB pods.
+        # affinity:
+        #   nodeAffinity:
+        #     requiredDuringSchedulingIgnoredDuringExecution:
+        #       nodeSelectorTerms:
+        #         - matchExpressions:
+        #             - key: kubernetes.io/os
+        #               operator: In
+        #               values:
+        #                 - linux
+        #   podAffinity:
+        #     requiredDuringSchedulingIgnoredDuringExecution:
+        #       - labelSelector:
+        #           matchExpressions:
+        #             - key: security
+        #               operator: In
+        #               values:
+        #                 - S1
+        #         topologyKey: topology.kubernetes.io/zone
+        #   podAntiAffinity:
+        #     preferredDuringSchedulingIgnoredDuringExecution:
+        #       - weight: 100
+        #         podAffinityTerm:
+        #           labelSelector:
+        #             matchExpressions:
+        #               - key: security
+        #                 operator: In
+        #                 values:
+        #                   - S2
+        #           topologyKey: topology.kubernetes.io/zone
+        #
 
     # persistentVolumeClaimRetentionPolicy is used to Retain or Delete the PVCs when the node is deleted.
     # If not specified, the PVCs will be deleted when the node is deleted.

--- a/cockroachdb-parent/Chart.lock
+++ b/cockroachdb-parent/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: operator
   repository: file://charts/operator
-  version: 25.3.4-preview
+  version: 25.3.4-preview+1
 - name: cockroachdb
   repository: file://charts/cockroachdb
-  version: 25.3.4-preview
-digest: sha256:3183216d170059cfb2f456d2bfacf8f4a5cd72cb0da9669e52545ac038111180
-generated: "2025-10-30T16:40:55.519890932Z"
+  version: 25.3.4-preview+1
+digest: sha256:d0a6019097a776a1a0957da0d00639856a5d16a61b826fec25d184f5cfedcfc0
+generated: "2025-10-31T00:56:21.004226+05:30"

--- a/cockroachdb-parent/Chart.yaml
+++ b/cockroachdb-parent/Chart.yaml
@@ -3,14 +3,14 @@ apiVersion: v2
 name: cockroachdb-parent
 description: A parent Helm chart for CockroachDB and its operator using helm-spray
 type: application
-version: 25.3.4-preview
+version: 25.3.4-preview+1
 appVersion: 25.3.4
 dependencies:
   - name: operator
-    version: 25.3.4-preview
+    version: 25.3.4-preview+1
     condition: operator.enabled
     repository: "file://charts/operator"
   - name: cockroachdb
-    version: 25.3.4-preview
+    version: 25.3.4-preview+1
     condition: cockroachdb.enabled
     repository: "file://charts/cockroachdb"

--- a/cockroachdb-parent/charts/cockroachdb/Chart.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 25.3.4-preview
+version: 25.3.4-preview+1
 appVersion: 25.3.4
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb-parent/charts/cockroachdb/templates/crdb.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/templates/crdb.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cluster.labels" . | nindent 4 }}
-    {{- with .Values.cockroachdb.crdbCluster.podLabels }}
+    {{- with .Values.cockroachdb.crdbCluster.podTemplate.metadata.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- with .Values.k8s.labels }}
@@ -25,9 +25,6 @@ spec:
   {{- with .Values.cockroachdb.crdbCluster.regions }}
   regions: {{- toYaml . | nindent 4 }}
   {{- end }}
-  features:
-    - reconcile
-    - reconcile-beta
   rollingRestartDelay: {{ .Values.cockroachdb.crdbCluster.rollingRestartDelay }}
   template:
     spec:
@@ -59,48 +56,12 @@ spec:
       {{- with .Values.cockroachdb.crdbCluster.walFailoverSpec }}
       walFailoverSpec: {{- toYaml . | nindent 8 }}
       {{- end }}
-      env:
-        - name: GODEBUG
-          value: {{ include "godebugList" . }}
-        {{- with .Values.cockroachdb.crdbCluster.env }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-      {{- with .Values.cockroachdb.crdbCluster.topologySpreadConstraints }}
-      topologySpreadConstraints: {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- if .Values.cockroachdb.crdbCluster.terminationGracePeriod }}
-      terminationGracePeriod: {{ .Values.cockroachdb.crdbCluster.terminationGracePeriod }}
-      {{- end }}
-      podLabels:
-        app.kubernetes.io/name: {{ template "cockroachdb.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name | quote }}
-        {{- with .Values.cockroachdb.crdbCluster.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-      podAnnotations:
-        helm.sh/restartedAt: {{ .Values.cockroachdb.crdbCluster.timestamp  | quote }}
-        {{- with .Values.cockroachdb.crdbCluster.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-      {{- with .Values.cockroachdb.crdbCluster.resources }}
-      resourceRequirements: {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- with .Values.cockroachdb.crdbCluster.localityLabels }}
       localityLabels: {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.cockroachdb.crdbCluster.localityMappings }}
       localityMappings: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cockroachdb.crdbCluster.tolerations }}
-      tolerations: {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.cockroachdb.crdbCluster.nodeSelector }}
-      nodeSelector: {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.cockroachdb.crdbCluster.affinity }}
-      affinity: {{- toYaml . | nindent 8 }}
-      {{- end }}
-      serviceAccountName: {{ include "cockroachdb.serviceAccount.name" . }}
       {{- if .Values.cockroachdb.crdbCluster.loggingConfigMapName }}
       loggingConfigMapName: {{ .Values.cockroachdb.crdbCluster.loggingConfigMapName }}
       {{- end }}
@@ -123,7 +84,23 @@ spec:
       startFlags: {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.cockroachdb.crdbCluster.podTemplate }}
-      podTemplate: {{- toYaml . | nindent 8 }}
+      podTemplate:
+        metadata:
+          labels:
+            app.kubernetes.io/name: {{ template "cockroachdb.name" $ }}
+            app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+            {{- with .metadata.labels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          annotations:
+            helm.sh/restartedAt: {{ $.Values.cockroachdb.crdbCluster.timestamp | quote }}
+            {{- with .metadata.annotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        spec:        
+            {{- $spec := deepCopy .spec }}
+            {{- $_ := set $spec "serviceAccountName" (include "cockroachdb.serviceAccount.name" $) }}
+            {{- toYaml $spec | nindent 12 }}
       {{- end }}
       {{- with .Values.cockroachdb.crdbCluster.persistentVolumeClaimRetentionPolicy }}
       persistentVolumeClaimRetentionPolicy: {{- toYaml . | nindent 8 }}

--- a/cockroachdb-parent/charts/cockroachdb/templates/service.public.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/templates/service.public.yaml
@@ -34,7 +34,7 @@ spec:
   selector:
     app.kubernetes.io/name: {{ template "cockroachdb.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
-  {{- with .Values.cockroachdb.crdbCluster.podLabels }}
+  {{- with .Values.cockroachdb.crdbCluster.podTemplate.metadata.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
   # Cockroach Cloud operator doesn't provide a way to change the sql,grpc and http ports for the pods. Hence, making these

--- a/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -169,14 +169,6 @@ cockroachdb:
     clusterSettings: ~
     # timestamp captures the annotation timestamp used for rolling restarts.
     timestamp: "2021-10-18T00:00:00Z"
-    # resources captures the resource requests and limits for CockroachDB pods.
-    resources: ~
-      # limits:
-      #   cpu: 4000m
-      #   memory: 16Gi
-      # requests:
-      #   cpu: 4000m
-      #   memory: 16Gi
     # dataStore captures the disk configuration for CockroachDB storage.
     dataStore:
       # volumeClaimTemplate captures the PVC template for storage.
@@ -283,16 +275,13 @@ cockroachdb:
       # storageClassName: ""
       #
       # path is the absolute mount path inside the CockroachDB container to use for WAL failover side disk.
-      # Examples: 
+      # Examples:
       #   - /cockroach/cockroach-failover
       #   - /cockroach/custom/path
       # IMPORTANT: Set it only for fresh deployments. Changing it on upgrades might cause issues with the deployment.
       #
       # path: "/cockroach/cockroach-failover"
       #
-    # podLabels captures additional labels to apply to CockroachDB pods.
-    podLabels:
-      app.kubernetes.io/component: cockroachdb
     # startFlags specify the flags that will be used for starting the cluster.
     # Any flag defined in here will take precedence over the first-class
     # fields responsible for setting the same flags.
@@ -304,25 +293,8 @@ cockroachdb:
       # # omit defines a set of flags which will be omitted from the start command.
       # omit:
       #   - ""
-    # env captures environment variables set on CockroachDB pods.
-    env: []
-      # - name: APP_NAME
-      #   value: "CRDB"
-      # - name: POD_NAME
-      #   valueFrom:
-      #     fieldRef:
-      #       fieldPath: metadata.name
     # rollingRestartDelay specifies the delay between rolling restarts of CockroachDB pods.
     rollingRestartDelay: 30s
-    # topologySpreadConstraints captures pod topology spread constraints.
-    # It is recommended to spread CockroachDB pods across zones to ensure high availability.
-    topologySpreadConstraints:
-        # maxSkew defines the degree to which the pods can be unevenly distributed.
-      - maxSkew: 1
-        # topologyKey defines the key for topology spread.
-        topologyKey: topology.kubernetes.io/zone
-        # whenUnsatisfiable defines the behavior when constraints cannot be met.
-        whenUnsatisfiable: DoNotSchedule
     # service captures the Kubernetes Service configurations for CockroachDB pods.
     service:
       # ports captures the service port definitions.
@@ -369,43 +341,6 @@ cockroachdb:
           ingressClassName: ""
           annotations: {}
           host: ""
-    # podAnnotations captures annotations to apply to CockroachDB pods.
-    podAnnotations: {}
-    # terminationGracePeriod determines the time available to CockroachDB for graceful drain.
-    # It follows the metav1.Duration format, e.g., "300s", "5m" or "1h".
-    # terminationGracePeriod: "300s"
-    # nodeSelector captures the node selector labels for scheduling pods.
-    nodeSelector: {}
-    # affinity captures scheduling affinity rules for CockroachDB pods.
-    affinity:
-      # nodeAffinity:
-      #   requiredDuringSchedulingIgnoredDuringExecution:
-      #     nodeSelectorTerms:
-      #       - matchExpressions:
-      #           - key: kubernetes.io/os
-      #             operator: In
-      #             values:
-      #               - linux
-      # podAffinity:
-      #   requiredDuringSchedulingIgnoredDuringExecution:
-      #     - labelSelector:
-      #         matchExpressions:
-      #           - key: security
-      #             operator: In
-      #             values:
-      #               - S1
-      #       topologyKey: topology.kubernetes.io/zone
-      # podAntiAffinity:
-      #   preferredDuringSchedulingIgnoredDuringExecution:
-      #     - weight: 100
-      #       podAffinityTerm:
-      #         labelSelector:
-      #           matchExpressions:
-      #             - key: security
-      #               operator: In
-      #               values:
-      #                 - S2
-      #         topologyKey: topology.kubernetes.io/zone
       #
     # sideCars captures the configuration for sidecar containers.
     sideCars:
@@ -415,8 +350,6 @@ cockroachdb:
       containers: []
       # volumes captures additional volumes for CockroachDB pods.
       volumes: []
-    # tolerations captures the tolerations for scheduling CockroachDB pods.
-    tolerations: []
     # localityLabels captures labels used to determine node locality.
     # It is an ordered, comma-separated list of keys that which must be present as labels on the nodes.
     # For region and zone to be part of the locality, the labels (topology.kubernetes.io/region, topology.kubernetes.io/region) must be set on the nodes.
@@ -468,26 +401,86 @@ cockroachdb:
       # disablethp determines whether Transparent Huge Pages are disabled.
       # By default, disables THP, which can cause memory inefficiency for CockroachDB.
       disablethp: "1"
-    # podTemplate is an optional pod specification that overrides the default pod specification configured by the operator.
+    # podTemplate defines the pod specification to override default pod specification configured by the operator.
     # If specified, podTemplate is merged with the default pod specification, with settings in podTemplate taking precedence.
     # This can be used to add or update containers, volumes, and other settings of the CockroachDB pod.
-    podTemplate: {}
-      # # metadata captures the pod metadata for CockroachDB pods.
-      # metadata: {}
-      # # spec captures the pod specification for CockroachDB pods.
-      # spec:
-      #   # initContainers captures the list of init containers for CockroachDB pods.
-      #   initContainers:
-      #     - name : cockroachdb-init
-      #       image: us-docker.pkg.dev/cockroach-cloud-images/data-plane/init-container@sha256:c3e4ba851802a429c7f76c639a64b9152d206cebb31162c1760f05e98f7c4254
-      #   # containers captures the list of containers for CockroachDB pods.
-      #   containers:
-      #     - name: cockroachdb
-      #       image: cockroachdb/cockroach:v25.2.2
-      #     - name: cert-reloader
-      #       image: us-docker.pkg.dev/cockroach-cloud-images/data-plane/inotifywait:87edf086db32734c7fa083a62d1055d664900840
-      #   # imagePullSecrets captures the secrets for fetching images from private registries.
-      #   imagePullSecrets: []
+    podTemplate:
+      # metadata captures the pod metadata for CockroachDB pods.
+      metadata:
+        labels:
+          app.kubernetes.io/component: cockroachdb
+        annotations: {}
+      # spec captures the pod specification for CockroachDB pods.
+      spec:
+        # # imagePullSecrets captures the secrets for fetching images from private registries.
+        # imagePullSecrets: []
+        # # initContainers captures the list of init containers for CockroachDB pods.
+        # initContainers:
+        #   - name : cockroachdb-init
+        #     image: us-docker.pkg.dev/releases-prod/self-hosted/init-container@sha256:bcfc9312af84c7966f017c2325981b30314c0c293491f942e54da1667bedaf69
+        # containers captures the list of containers for CockroachDB pods.
+        containers:
+          - name: cockroachdb
+            # env captures environment variables set on CockroachDB pods.
+            env: []
+            # - name: APP_NAME
+            #   value: "CRDB"
+            # - name: POD_NAME
+            #   valueFrom:
+            #     fieldRef:
+            #       fieldPath: metadata.name
+            resources: {}
+            # image: cockroachdb/cockroach:v25.3.4
+            # - name: cert-reloader
+            #   image: us-docker.pkg.dev/releases-prod/self-hosted/inotifywait@sha256:2e443a2d00e6541bd596219204865db74f813e8d54678ce2fe71747e40254182
+        
+        # topologySpreadConstraints captures pod topology spread constraints.
+        # It is recommended to spread CockroachDB pods across zones to ensure high availability.
+        topologySpreadConstraints:
+            # maxSkew defines the degree to which the pods can be unevenly distributed.
+          - maxSkew: 1
+            # topologyKey defines the key for topology spread.
+            topologyKey: topology.kubernetes.io/zone
+            # whenUnsatisfiable defines the behavior when constraints cannot be met.
+            whenUnsatisfiable: DoNotSchedule
+        # # terminationGracePeriodSeconds determines the time available to CockroachDB for graceful drain.
+        # terminationGracePeriodSeconds: 300
+        # # tolerations captures the tolerations for pods of the self-signer job.
+        # # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+        # tolerations: []
+        # # nodeSelector captures the node selector labels for scheduling pods.
+        # nodeSelector: {}
+        # # affinity captures scheduling affinity rules for CockroachDB pods.
+        # affinity:
+        #   nodeAffinity:
+        #     requiredDuringSchedulingIgnoredDuringExecution:
+        #       nodeSelectorTerms:
+        #         - matchExpressions:
+        #             - key: kubernetes.io/os
+        #               operator: In
+        #               values:
+        #                 - linux
+        #   podAffinity:
+        #     requiredDuringSchedulingIgnoredDuringExecution:
+        #       - labelSelector:
+        #           matchExpressions:
+        #             - key: security
+        #               operator: In
+        #               values:
+        #                 - S1
+        #         topologyKey: topology.kubernetes.io/zone
+        #   podAntiAffinity:
+        #     preferredDuringSchedulingIgnoredDuringExecution:
+        #       - weight: 100
+        #         podAffinityTerm:
+        #           labelSelector:
+        #             matchExpressions:
+        #               - key: security
+        #                 operator: In
+        #                 values:
+        #                   - S2
+        #           topologyKey: topology.kubernetes.io/zone
+        #
 
     # persistentVolumeClaimRetentionPolicy is used to Retain or Delete the PVCs when the node is deleted.
     # If not specified, the PVCs will be deleted when the node is deleted.

--- a/cockroachdb-parent/charts/operator/Chart.yaml
+++ b/cockroachdb-parent/charts/operator/Chart.yaml
@@ -4,4 +4,4 @@ name: operator
 description: A Helm chart for managing the CockroachDB operator.
 type: application
 appVersion: 25.3.4
-version: 25.3.4-preview
+version: 25.3.4-preview+1

--- a/cockroachdb-parent/charts/operator/templates/operator.yaml
+++ b/cockroachdb-parent/charts/operator/templates/operator.yaml
@@ -304,6 +304,8 @@ rules:
       - get
       - list
       - watch
+      - update
+      - patch
   - apiGroups:
       - "apps"
     resources:

--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 18.0.5
+version: 18.0.6
 appVersion: 25.3.4
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -279,7 +279,6 @@ func buildHelmValuesFromOperator(
 					"ingress": ingressValue,
 				},
 				"loggingConfigMapName": cluster.Spec.LogConfigMap,
-				"podLabels":            sts.Spec.Template.Labels,
 				"podTemplate": map[string]interface{}{
 					"metadata": map[string]interface{}{
 						"labels":      sts.Spec.Template.Labels,
@@ -636,7 +635,6 @@ func buildHelmValuesFromHelm(
 			},
 		},
 		"loggingConfigMapName": input.loggingConfigMap,
-		"podLabels":            sts.Spec.Template.Labels,
 		"podTemplate": map[string]interface{}{
 			"metadata": map[string]interface{}{
 				"labels":      sts.Spec.Template.Labels,

--- a/pkg/migrate/testdata/helm/allInput/values.yaml.golden
+++ b/pkg/migrate/testdata/helm/allInput/values.yaml.golden
@@ -17,10 +17,6 @@ cockroachdb:
     - country
     - region
     loggingConfigMapName: cockroachdb-log-config
-    podLabels:
-      app.kubernetes.io/component: cockroachdb
-      app.kubernetes.io/instance: cockroachdb
-      app.kubernetes.io/name: cockroachdb
     podTemplate:
       metadata:
         annotations:

--- a/pkg/migrate/testdata/operator/allInput/values.yaml.golden
+++ b/pkg/migrate/testdata/operator/allInput/values.yaml.golden
@@ -14,11 +14,6 @@ cockroachdb:
     image:
       name: cockroachdb/cockroach:v25.1.5
     loggingConfigMapName: cockroachdb-log-config
-    podLabels:
-      app.kubernetes.io/component: database
-      app.kubernetes.io/instance: cockroachdb
-      app.kubernetes.io/name: cockroachdb
-      crdb: is-cool
     podTemplate:
       metadata:
         annotations:

--- a/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
+++ b/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
@@ -216,7 +216,11 @@ func (r *multiRegion) TestHelmUpgrade(t *testing.T) {
 		options := &helm.Options{
 			KubectlOptions: kubectlOptions,
 			ExtraArgs: map[string][]string{
-				"upgrade": {"--reuse-values", "--set", fmt.Sprintf("cockroachdb.crdbCluster.resources.requests.cpu=%s", "100m")},
+				"upgrade": {
+					"--reuse-values",
+					"--set", "cockroachdb.crdbCluster.podTemplate.spec.containers[0].name=cockroachdb",
+					"--set", fmt.Sprintf("cockroachdb.crdbCluster.podTemplate.spec.containers[0].resources.requests.cpu=%s", "100m"),
+				},
 			},
 		}
 		// Apply Helm upgrade with updated values.

--- a/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
+++ b/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
@@ -272,7 +272,11 @@ func (r *singleRegion) TestHelmUpgrade(t *testing.T) {
 	options := &helm.Options{
 		KubectlOptions: kubectlOptions,
 		ExtraArgs: map[string][]string{
-			"upgrade": {"--reuse-values", "--set", fmt.Sprintf("cockroachdb.crdbCluster.resources.requests.cpu=%s", "100m")},
+			"upgrade": {
+				"--reuse-values",
+				"--set", "cockroachdb.crdbCluster.podTemplate.spec.containers[0].name=cockroachdb",
+				"--set", fmt.Sprintf("cockroachdb.crdbCluster.podTemplate.spec.containers[0].resources.requests.cpu=%s", "100m"),
+			},
 		},
 	}
 	// Apply Helm upgrade with updated values.

--- a/tests/template/cockroachdb_helm_template_test.go
+++ b/tests/template/cockroachdb_helm_template_test.go
@@ -2166,14 +2166,6 @@ func (v *podTemplateValidators) validateImagePullSecret(expectedName string) {
 	require.Equal(v.subT, expectedName, imagePullSecret.Name)
 }
 
-func (v *podTemplateValidators) validateEmptyPodTemplate() {
-	if v.spec != nil {
-		require.Empty(v.subT, v.spec.Metadata.Labels, "Expected podTemplate labels to be empty when no configuration is provided")
-		require.Empty(v.subT, v.spec.Metadata.Annotations, "Expected podTemplate annotations to be empty when no configuration is provided")
-		require.Empty(v.subT, v.spec.Spec.Containers, "Expected podTemplate containers to be empty when no configuration is provided")
-	}
-}
-
 // PodTemplateExpected represents expected validation criteria for pod template tests.
 type PodTemplateExpected struct {
 	hasMetadata         bool
@@ -2224,8 +2216,6 @@ func validatePodTemplateConfiguration(
 				validator.validateImagePullSecret(expected.imagePullSecretName)
 			}
 		}
-	} else {
-		validator.validateEmptyPodTemplate()
 	}
 }
 


### PR DESCRIPTION
This PR removes the deprecated fields from `cockroachdb-parent/charts/cockroachdb/values.yaml` in favour of podTemplate.