### PR TITLE
fix(tls): correct template syntax and add client certificate support

### DIFF
--- a/cockroachdb/templates/serviceMonitor.yaml
+++ b/cockroachdb/templates/serviceMonitor.yaml
@@ -60,7 +60,7 @@ spec:
     {{- if $serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ $serviceMonitor.scrapeTimeout }}
     {{- end }}
-    {{- if and not .Values.visus.insecure .Values.serviceMonitor.tlsConfig }}
+    {{- if and (not .Values.visus.insecure) .Values.serviceMonitor.tlsConfig }}
     tlsConfig: {{ toYaml .Values.serviceMonitor.tlsConfig | nindent 6 }}
     {{- end }}
   {{- end }}

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - "cp -f /certs/* /cockroach-certs/; chmod 0400 /cockroach-certs/*.key"
+            - "cp -f /certs/* /cockroach-certs/; cp -f /client-certs/* /cockroach-certs/; chmod 0400 /cockroach-certs/*.key"
           env:
             - name: POD_NAMESPACE
               valueFrom:
@@ -77,6 +77,8 @@ spec:
               mountPath: /cockroach-certs/
             - name: certs-secret
               mountPath: /certs/
+            - name: client-secret
+              mountPath: /client-certs/
         {{- with .Values.tls.copyCerts.resources }}
           resources: {{- toYaml . | nindent 12 }}
         {{- end }}


### PR DESCRIPTION
- Fix Helm template syntax in serviceMonitor.yaml: wrap `not` function call in parentheses for proper boolean evaluation
- Add client certificate mounting in statefulset.yaml init container: copy client certs alongside server certs for mTLS authentication

Sorry I don't know what are the rules to submit pull requests