### PR TITLE
tests: Ensure single operator replica for tests

### DIFF
--- a/build/templates/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/build/templates/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -429,7 +429,7 @@ cockroachdb:
             #     fieldRef:
             #       fieldPath: metadata.name
             resources: {}
-            # image: cockroachdb/cockroach:v25.3.4
+            # image: cockroachdb/cockroach:v25.4.1
             # - name: cert-reloader
             #   image: us-docker.pkg.dev/releases-prod/self-hosted/inotifywait@sha256:2e443a2d00e6541bd596219204865db74f813e8d54678ce2fe71747e40254182
         

--- a/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -430,7 +430,7 @@ cockroachdb:
             #     fieldRef:
             #       fieldPath: metadata.name
             resources: {}
-            # image: cockroachdb/cockroach:v25.3.4
+            # image: cockroachdb/cockroach:v25.4.1
             # - name: cert-reloader
             #   image: us-docker.pkg.dev/releases-prod/self-hosted/inotifywait@sha256:2e443a2d00e6541bd596219204865db74f813e8d54678ce2fe71747e40254182
         

--- a/tests/e2e/operator/region.go
+++ b/tests/e2e/operator/region.go
@@ -506,7 +506,7 @@ func (r *Region) createOperatorRegions(index int, nodes int, customDomains map[i
 }
 
 // VerifyInitCommandInOperatorLogs verifies that the operator logs contain the expected init command.
-func (r Region) VerifyInitCommandInOperatorLogs(t *testing.T, kubectlOptions *k8s.KubectlOptions, expected string) {
+func VerifyInitCommandInOperatorLogs(t *testing.T, kubectlOptions *k8s.KubectlOptions, expected string) {
 	// Get operator pods
 	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
 		LabelSelector: OperatorLabelSelector,
@@ -527,7 +527,10 @@ func InstallCockroachDBEnterpriseOperator(t *testing.T, kubectlOptions *k8s.Kube
 
 	operatorOpts := &helm.Options{
 		KubectlOptions: kubectlOptions,
-		ExtraArgs:      helmExtraArgs,
+		SetValues: map[string]string{
+			"numReplicas": "1",
+		},
+		ExtraArgs: helmExtraArgs,
 	}
 
 	// Install Operator on the cluster.

--- a/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
+++ b/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
@@ -213,7 +213,7 @@ func (r *singleRegion) TestHelmInstallVirtualCluster(t *testing.T) {
 			kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, operatorNamespace)
 
 			// Verify init command in logs
-			r.VerifyInitCommandInOperatorLogs(t, kubectlOptions, tt.initCommand)
+			operator.VerifyInitCommandInOperatorLogs(t, kubectlOptions, tt.initCommand)
 			r.Namespace[cluster] = operatorNamespace
 		})
 	}

--- a/tests/k3d/dev-multi-cluster.sh
+++ b/tests/k3d/dev-multi-cluster.sh
@@ -35,10 +35,10 @@ REQUIRED_IMAGES=(
     "quay.io/jetstack/cert-manager-ctl:v1.11.0"
     "coredns/coredns:1.9.2"
     "$(bin/yq '.cockroachdb.crdbCluster.image.name' ./cockroachdb-parent/charts/cockroachdb/values.yaml)"
-    "us-docker.pkg.dev/cockroach-cloud-images/data-plane/inotifywait:87edf086db32734c7fa083a62d1055d664900840"
+    "us-docker.pkg.dev/releases-prod/self-hosted/inotifywait@sha256:2e443a2d00e6541bd596219204865db74f813e8d54678ce2fe71747e40254182"
     "bash:latest"
     "busybox"
-    "us-docker.pkg.dev/cockroach-cloud-images/data-plane/init-container:f21cb0727676a48d0000bc3f32108ce59d51c3e7"
+    "us-docker.pkg.dev/releases-prod/self-hosted/init-container@sha256:bcfc9312af84c7966f017c2325981b30314c0c293491f942e54da1667bedaf69"
     "${REGISTRY}/${REPOSITORY}:$(bin/yq '.cockroachdb.tls.selfSigner.image.tag' ./cockroachdb-parent/charts/cockroachdb/values.yaml)"
 )
 

--- a/tests/kind/dev-multi-cluster.sh
+++ b/tests/kind/dev-multi-cluster.sh
@@ -33,10 +33,10 @@ REQUIRED_IMAGES=(
     "quay.io/jetstack/cert-manager-ctl:v1.11.0"
     "coredns/coredns:1.9.2"
     "$(bin/yq '.cockroachdb.crdbCluster.image.name' ./cockroachdb-parent/charts/cockroachdb/values.yaml)"
-    "us-docker.pkg.dev/cockroach-cloud-images/data-plane/inotifywait:87edf086db32734c7fa083a62d1055d664900840"
+    "us-docker.pkg.dev/releases-prod/self-hosted/inotifywait@sha256:2e443a2d00e6541bd596219204865db74f813e8d54678ce2fe71747e40254182"
     "bash:latest"
     "busybox"
-    "us-docker.pkg.dev/cockroach-cloud-images/data-plane/init-container:f21cb0727676a48d0000bc3f32108ce59d51c3e7"
+    "us-docker.pkg.dev/releases-prod/self-hosted/init-container@sha256:bcfc9312af84c7966f017c2325981b30314c0c293491f942e54da1667bedaf69"
     "${REGISTRY}/${REPOSITORY}:$(bin/yq '.cockroachdb.tls.selfSigner.image.tag' ./cockroachdb-parent/charts/cockroachdb/values.yaml)"
 )
 


### PR DESCRIPTION
The `TestHelmInstallVirtualCluster` validation relies on checking the operator's pod logs to verify the init command. Since the default operator replicas were recently increased to `3`, the test may start failing, as the specific log required for validation could reside in any one of the active(leader) pod.

This change modifies the test environment to use only one operator pod.