### PR TITLE
Fix lack of labelSelector for cockroachDB

### DIFF
--- a/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -445,7 +445,7 @@ cockroachdb:
             whenUnsatisfiable: DoNotSchedule
             labelSelector:
               matchLabels:
-                app: cockroachdb
+                crdb.cockroachlabs.com/cluster: cockroachdb
         # # terminationGracePeriodSeconds determines the time available to CockroachDB for graceful drain.
         # terminationGracePeriodSeconds: 300
         # # tolerations captures the tolerations for pods of the self-signer job.


### PR DESCRIPTION
I recently discovered that if you do not set a labelSelector, it seems not to match anything - so the spread constraint is not useful: https://github.com/kubernetes/kubernetes/issues/135797#issuecomment-3666222736.

I happened to notice this applies to cockroachDB too.