### PR TITLE
[CC-34466] release: advance to 25.4.2-preview+3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [cockroachdb-parent-25.4.2-preview+3] 2025-12-22
+### Fixed
+- Updated the Operator image to fix pkill command failures within the cert-reloader container.
+
 ## [cockroachdb-parent-25.4.0-preview] 2025-11-25
 ### Changed
 - Updated the CockroachDB version to v25.4.0.

--- a/build/templates/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/build/templates/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -429,9 +429,9 @@ cockroachdb:
             #     fieldRef:
             #       fieldPath: metadata.name
             resources: {}
-            # image: cockroachdb/cockroach:v25.4.1
+            # image: cockroachdb/cockroach:v25.4.2
             # - name: cert-reloader
-            #   image: us-docker.pkg.dev/releases-prod/self-hosted/inotifywait@sha256:2e443a2d00e6541bd596219204865db74f813e8d54678ce2fe71747e40254182
+            #   image: us-docker.pkg.dev/releases-prod/self-hosted/inotifywait@sha256:94db3d416e3df8d1ee2605f05b0526b3bd7217ae69b4eeb147929fe0b77aeafc
         
         # topologySpreadConstraints captures pod topology spread constraints.
         # It is recommended to spread CockroachDB pods across zones to ensure high availability.

--- a/build/templates/cockroachdb-parent/charts/operator/values.yaml
+++ b/build/templates/cockroachdb-parent/charts/operator/values.yaml
@@ -9,7 +9,7 @@ image:
   # pullPolicy specifies the image pull policy.
   pullPolicy: IfNotPresent
   # tag is the image tag.
-  tag: "c76c24c2a9f4b2a0af5bcea28731c282fcbf1c6e16307795d8a9d57392f6b574"
+  tag: "897dc492b863c347f9207f800b368a1744cf177e493874b7503987007b5ed869"
 # certificate defines the certificate settings for the Operator.
 certificate:
   # validForDays specifies the number of days the certificate is valid for.

--- a/cockroachdb-parent/Chart.lock
+++ b/cockroachdb-parent/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: operator
   repository: file://charts/operator
-  version: 25.4.2-preview+2
+  version: 25.4.2-preview+3
 - name: cockroachdb
   repository: file://charts/cockroachdb
-  version: 25.4.2-preview+2
-digest: sha256:8f18892f6e01aca10cc752a401406d0acb3bbcc9b9cc8ce5012e8b50c0c1c138
-generated: "2025-12-18T01:57:41.363784449Z"
+  version: 25.4.2-preview+3
+digest: sha256:77eaf4ea0d934be4d48c184fd2f51b19f37cf9375c48b12f1efff1c9217b840c
+generated: "2025-12-20T00:20:07.67853+05:30"

--- a/cockroachdb-parent/Chart.yaml
+++ b/cockroachdb-parent/Chart.yaml
@@ -3,14 +3,14 @@ apiVersion: v2
 name: cockroachdb-parent
 description: A parent Helm chart for CockroachDB and its operator using helm-spray
 type: application
-version: 25.4.2-preview+2
+version: 25.4.2-preview+3
 appVersion: 25.4.2
 dependencies:
   - name: operator
-    version: 25.4.2-preview+2
+    version: 25.4.2-preview+3
     condition: operator.enabled
     repository: "file://charts/operator"
   - name: cockroachdb
-    version: 25.4.2-preview+2
+    version: 25.4.2-preview+3
     condition: cockroachdb.enabled
     repository: "file://charts/cockroachdb"

--- a/cockroachdb-parent/charts/cockroachdb/Chart.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 25.4.2-preview+2
+version: 25.4.2-preview+3
 appVersion: 25.4.2
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -430,9 +430,9 @@ cockroachdb:
             #     fieldRef:
             #       fieldPath: metadata.name
             resources: {}
-            # image: cockroachdb/cockroach:v25.4.1
+            # image: cockroachdb/cockroach:v25.4.2
             # - name: cert-reloader
-            #   image: us-docker.pkg.dev/releases-prod/self-hosted/inotifywait@sha256:2e443a2d00e6541bd596219204865db74f813e8d54678ce2fe71747e40254182
+            #   image: us-docker.pkg.dev/releases-prod/self-hosted/inotifywait@sha256:94db3d416e3df8d1ee2605f05b0526b3bd7217ae69b4eeb147929fe0b77aeafc
         
         # topologySpreadConstraints captures pod topology spread constraints.
         # It is recommended to spread CockroachDB pods across zones to ensure high availability.

--- a/cockroachdb-parent/charts/operator/Chart.yaml
+++ b/cockroachdb-parent/charts/operator/Chart.yaml
@@ -4,4 +4,4 @@ name: operator
 description: A Helm chart for managing the CockroachDB operator.
 type: application
 appVersion: 25.4.2
-version: 25.4.2-preview+2
+version: 25.4.2-preview+3

--- a/cockroachdb-parent/charts/operator/values.yaml
+++ b/cockroachdb-parent/charts/operator/values.yaml
@@ -10,7 +10,7 @@ image:
   # pullPolicy specifies the image pull policy.
   pullPolicy: IfNotPresent
   # tag is the image tag.
-  tag: "c76c24c2a9f4b2a0af5bcea28731c282fcbf1c6e16307795d8a9d57392f6b574"
+  tag: "897dc492b863c347f9207f800b368a1744cf177e493874b7503987007b5ed869"
 # certificate defines the certificate settings for the Operator.
 certificate:
   # validForDays specifies the number of days the certificate is valid for.

--- a/tests/k3d/dev-multi-cluster.sh
+++ b/tests/k3d/dev-multi-cluster.sh
@@ -35,9 +35,8 @@ REQUIRED_IMAGES=(
     "quay.io/jetstack/cert-manager-ctl:v1.11.0"
     "coredns/coredns:1.9.2"
     "$(bin/yq '.cockroachdb.crdbCluster.image.name' ./cockroachdb-parent/charts/cockroachdb/values.yaml)"
-    "us-docker.pkg.dev/releases-prod/self-hosted/inotifywait@sha256:2e443a2d00e6541bd596219204865db74f813e8d54678ce2fe71747e40254182"
+    "us-docker.pkg.dev/releases-prod/self-hosted/inotifywait@sha256:94db3d416e3df8d1ee2605f05b0526b3bd7217ae69b4eeb147929fe0b77aeafc"
     "bash:latest"
-    "busybox"
     "us-docker.pkg.dev/releases-prod/self-hosted/init-container@sha256:bcfc9312af84c7966f017c2325981b30314c0c293491f942e54da1667bedaf69"
     "${REGISTRY}/${REPOSITORY}:$(bin/yq '.cockroachdb.tls.selfSigner.image.tag' ./cockroachdb-parent/charts/cockroachdb/values.yaml)"
 )

--- a/tests/kind/dev-multi-cluster.sh
+++ b/tests/kind/dev-multi-cluster.sh
@@ -33,9 +33,8 @@ REQUIRED_IMAGES=(
     "quay.io/jetstack/cert-manager-ctl:v1.11.0"
     "coredns/coredns:1.9.2"
     "$(bin/yq '.cockroachdb.crdbCluster.image.name' ./cockroachdb-parent/charts/cockroachdb/values.yaml)"
-    "us-docker.pkg.dev/releases-prod/self-hosted/inotifywait@sha256:2e443a2d00e6541bd596219204865db74f813e8d54678ce2fe71747e40254182"
+    "us-docker.pkg.dev/releases-prod/self-hosted/inotifywait@sha256:94db3d416e3df8d1ee2605f05b0526b3bd7217ae69b4eeb147929fe0b77aeafc"
     "bash:latest"
-    "busybox"
     "us-docker.pkg.dev/releases-prod/self-hosted/init-container@sha256:bcfc9312af84c7966f017c2325981b30314c0c293491f942e54da1667bedaf69"
     "${REGISTRY}/${REPOSITORY}:$(bin/yq '.cockroachdb.tls.selfSigner.image.tag' ./cockroachdb-parent/charts/cockroachdb/values.yaml)"
 )


### PR DESCRIPTION
The cert-reloader container was experiencing pkill command failures. This commit updates the operator image that includes the necessary fixes to resolve this bug.