### PR TITLE
[CRDB-42772] tls: Add enableSighupRotation option for zero-downtime cert rotation

### DIFF
--- a/build/templates/cockroachdb/README.md
+++ b/build/templates/cockroachdb/README.md
@@ -129,6 +129,54 @@ By enabling `tls.certs.tlsSecret` the tls secrets are projected on to the correc
 
 For instructions on using cert-manager to provision certificates for the statefulset-based Helm chart, see the [Installation of statefulset-based Helm Chart with Cert Manager](../docs/certificate-management/cert-manager.md#Installation-of-statefulset-based-helm-chart-with-cert-manager) section in the documentation.
 
+### Zero-downtime certificate rotation
+
+The chart supports zero-downtime certificate rotation using SIGHUP signal when `tls.enableSighupRotation` is set to `true`. This allows you to rotate TLS certificates without restarting CockroachDB pods.
+
+**Important:** Zero-downtime SIGHUP-based rotation is only supported with externally managed certificates (user-provided or cert-manager) where the user controls the rotation and signaling process. It is **not compatible** with self-signed certificates (`tls.certs.selfSigner.enabled=true`), as the self-signer handles rotation by triggering pod restarts.
+
+**How it works:**
+
+When `enableSighupRotation` is enabled:
+- Node certificates (ca.crt, node.crt, node.key) are mounted directly from Kubernetes secrets (no copy-certs initContainer)
+- Certificate files have 0440 permissions (owner+group read) instead of 0400. This is required because with the chart's default pod `fsGroup: 1000` (set via `securityContext.enabled=true`), Kubernetes mounts secrets with `root:1000` ownership, and the CockroachDB process (running as user 1000) needs group read access. If you disable or override the pod securityContext, ensure the mounted secret file ownership/permissions still allow CockroachDB to read the certificates.
+- After updating the certificate secrets in Kubernetes, send SIGHUP signal to CockroachDB processes to reload certificates
+
+**Example usage:**
+
+```shell
+# Deploy with SIGHUP rotation enabled
+$ helm install my-release cockroachdb/cockroachdb \
+  --set tls.enabled=true \
+  --set tls.enableSighupRotation=true \
+  --set tls.certs.provided=true \
+  --set tls.certs.tlsSecret=true
+```
+
+**To rotate certificates:**
+
+1. Update the certificate secrets:
+```shell
+$ kubectl create secret generic cockroachdb-node \
+  --from-file=ca.crt=new-ca.crt \
+  --from-file=tls.crt=new-node.crt \
+  --from-file=tls.key=new-node.key \
+  --namespace=<your-namespace> \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+2. Wait for kubelet to sync the updated certificates to pods (30-60 seconds)
+
+3. Send SIGHUP signal to reload certificates without restarting:
+```shell
+$ for i in 0 1 2; do
+  kubectl exec my-release-cockroachdb-$i -- sh -c "kill -1 1"
+  sleep 5
+done
+```
+
+**Note:** When `enableSighupRotation` is disabled (default), certificates are copied by an initContainer with strict 0400 permissions, and pod restarts are required for certificate rotation.
+
 ## Upgrading the cluster
 
 ### Chart version 3.0.0 and after
@@ -347,6 +395,7 @@ For details see the [`values.yaml`](values.yaml) file.
 | `init.resources`                                          | Resource requests and limits for the `cluster-init` container                                                                                                                                                                                                                                                                            | `{}`                                                   |
 | `init.terminationGracePeriodSeconds`                      | Termination grace period for CRDB init job                                                                                                                                                                                                                                                                                               | `300`                                                  |
 | `tls.enabled`                                             | Whether to run securely using TLS certificates                                                                                                                                                                                                                                                                                           | `no`                                                   |
+| `tls.enableSighupRotation`                                | Enable zero-downtime certificate rotation using SIGHUP signal. When true, certificates are mounted directly with 0440 permissions. When false, initContainer copies certs with 0400 permissions and pod restarts are required for rotation                                                                                              | `no`                                                   |
 | `tls.serviceAccount.create`                               | Whether to create a new RBAC service account                                                                                                                                                                                                                                                                                             | `yes`                                                  |
 | `tls.serviceAccount.name`                                 | Name of RBAC service account to use                                                                                                                                                                                                                                                                                                      | `""`                                                   |
 | `tls.copyCerts.image`                                     | Image used in copy certs init container                                                                                                                                                                                                                                                                                                  | `busybox`                                              |

--- a/build/templates/cockroachdb/values.yaml
+++ b/build/templates/cockroachdb/values.yaml
@@ -585,6 +585,15 @@ init:
 # Whether to run securely using TLS certificates.
 tls:
   enabled: true
+  # EnableSighupRotation enables zero-downtime certificate rotation using SIGHUP signal.
+  # When true, node certificates (ca.crt, node.crt, node.key) are mounted directly from
+  # Kubernetes secrets with 0440 permissions (owner+group read), allowing CockroachDB to
+  # reload certificates via SIGHUP signal without pod restarts.
+  # When false (default), an initContainer copies certs to ensure 0400 permissions
+  # (owner read only) but pod restarts are required for certificate rotation.
+  # NOTE: Only supported with externally managed certificates (user-provided or cert-manager).
+  # Not compatible with self-signed certificates (tls.certs.selfSigner.enabled=true).
+  enableSighupRotation: false
   copyCerts:
     image: busybox
   certs:

--- a/cockroachdb/CHANGELOG.md
+++ b/cockroachdb/CHANGELOG.md
@@ -1,0 +1,11 @@
+# CockroachDB Helm Chart CHANGELOG
+
+All notable changes to the CockroachDB Helm chart will be documented in this file.
+
+## [20.0.5] Unreleased
+### Added
+  - Added `tls.enableSighupRotation` configuration option to enable zero-downtime certificate rotation using SIGHUP signal.
+    - When enabled, node certificates are mounted directly from Kubernetes secrets with 0440 permissions.
+    - Supports live certificate reload via SIGHUP without pod restarts.
+    - Only compatible with externally managed certificates (user-provided or cert-manager). Not compatible with self-signed certificates.
+    - **Backward compatible**: This is an opt-in feature (defaults to `false`). Existing deployments are unaffected and will continue to use the traditional certificate rotation approach with pod restarts.

--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -130,6 +130,54 @@ By enabling `tls.certs.tlsSecret` the tls secrets are projected on to the correc
 
 For instructions on using cert-manager to provision certificates for the statefulset-based Helm chart, see the [Installation of statefulset-based Helm Chart with Cert Manager](../docs/certificate-management/cert-manager.md#Installation-of-statefulset-based-helm-chart-with-cert-manager) section in the documentation.
 
+### Zero-downtime certificate rotation
+
+The chart supports zero-downtime certificate rotation using SIGHUP signal when `tls.enableSighupRotation` is set to `true`. This allows you to rotate TLS certificates without restarting CockroachDB pods.
+
+**Important:** Zero-downtime SIGHUP-based rotation is only supported with externally managed certificates (user-provided or cert-manager) where the user controls the rotation and signaling process. It is **not compatible** with self-signed certificates (`tls.certs.selfSigner.enabled=true`), as the self-signer handles rotation by triggering pod restarts.
+
+**How it works:**
+
+When `enableSighupRotation` is enabled:
+- Node certificates (ca.crt, node.crt, node.key) are mounted directly from Kubernetes secrets (no copy-certs initContainer)
+- Certificate files have 0440 permissions (owner+group read) instead of 0400. This is required because with the chart's default pod `fsGroup: 1000` (set via `securityContext.enabled=true`), Kubernetes mounts secrets with `root:1000` ownership, and the CockroachDB process (running as user 1000) needs group read access. If you disable or override the pod securityContext, ensure the mounted secret file ownership/permissions still allow CockroachDB to read the certificates.
+- After updating the certificate secrets in Kubernetes, send SIGHUP signal to CockroachDB processes to reload certificates
+
+**Example usage:**
+
+```shell
+# Deploy with SIGHUP rotation enabled
+$ helm install my-release cockroachdb/cockroachdb \
+  --set tls.enabled=true \
+  --set tls.enableSighupRotation=true \
+  --set tls.certs.provided=true \
+  --set tls.certs.tlsSecret=true
+```
+
+**To rotate certificates:**
+
+1. Update the certificate secrets:
+```shell
+$ kubectl create secret generic cockroachdb-node \
+  --from-file=ca.crt=new-ca.crt \
+  --from-file=tls.crt=new-node.crt \
+  --from-file=tls.key=new-node.key \
+  --namespace=<your-namespace> \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+2. Wait for kubelet to sync the updated certificates to pods (30-60 seconds)
+
+3. Send SIGHUP signal to reload certificates without restarting:
+```shell
+$ for i in 0 1 2; do
+  kubectl exec my-release-cockroachdb-$i -- sh -c "kill -1 1"
+  sleep 5
+done
+```
+
+**Note:** When `enableSighupRotation` is disabled (default), certificates are copied by an initContainer with strict 0400 permissions, and pod restarts are required for certificate rotation.
+
 ## Upgrading the cluster
 
 ### Chart version 3.0.0 and after
@@ -348,6 +396,7 @@ For details see the [`values.yaml`](values.yaml) file.
 | `init.resources`                                          | Resource requests and limits for the `cluster-init` container                                                                                                                                                                                                                                                                            | `{}`                                                   |
 | `init.terminationGracePeriodSeconds`                      | Termination grace period for CRDB init job                                                                                                                                                                                                                                                                                               | `300`                                                  |
 | `tls.enabled`                                             | Whether to run securely using TLS certificates                                                                                                                                                                                                                                                                                           | `no`                                                   |
+| `tls.enableSighupRotation`                                | Enable zero-downtime certificate rotation using SIGHUP signal. When true, certificates are mounted directly with 0440 permissions. When false, initContainer copies certs with 0400 permissions and pod restarts are required for rotation                                                                                              | `no`                                                   |
 | `tls.serviceAccount.create`                               | Whether to create a new RBAC service account                                                                                                                                                                                                                                                                                             | `yes`                                                  |
 | `tls.serviceAccount.name`                                 | Name of RBAC service account to use                                                                                                                                                                                                                                                                                                      | `""`                                                   |
 | `tls.copyCerts.image`                                     | Image used in copy certs init container                                                                                                                                                                                                                                                                                                  | `busybox`                                              |

--- a/cockroachdb/templates/_helpers.tpl
+++ b/cockroachdb/templates/_helpers.tpl
@@ -279,6 +279,9 @@ Validate that if user enabled tls, then either self-signed certificates or certi
 {{- if and .Values.tls.certs.selfSigner.enabled .Values.tls.certs.certManager -}}
     {{ fail "Can not enable the self signed certificates and certificate manager at the same time" }}
 {{- end -}}
+{{- if and .Values.tls.enableSighupRotation .Values.tls.certs.selfSigner.enabled -}}
+    {{ fail "Can not enable SIGHUP rotation with self-signed certificates. SIGHUP rotation is only supported with externally managed certificates (user-provided or cert-manager)" }}
+{{- end -}}
 {{- if and (not .Values.tls.certs.selfSigner.enabled) (not .Values.tls.certs.certManager) -}}
     {{- if not .Values.tls.certs.provided -}}
         {{ fail "You have to enable either self signed certificates or certificate manager, if you have enabled tls" }}

--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -55,7 +55,7 @@ spec:
         - name: {{ template "cockroachdb.fullname" . }}.db.registry
     {{- end }}
       serviceAccountName: {{ template "cockroachdb.serviceAccount.name" . }}
-    {{- if .Values.tls.enabled }}
+    {{- if and .Values.tls.enabled (not .Values.tls.enableSighupRotation) }}
       initContainers:
         - name: copy-certs
           image: {{ .Values.tls.copyCerts.image | quote }}
@@ -251,8 +251,15 @@ spec:
         {{- end }}
         {{- if .Values.tls.enabled }}
           volumeMounts:
+          {{- if .Values.tls.enableSighupRotation }}
+            {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager .Values.tls.certs.selfSigner.enabled }}
+            - name: client-secret
+              mountPath: /cockroach-certs/
+            {{- end }}
+          {{- else }}
             - name: client-certs
               mountPath: /cockroach-certs/
+          {{- end }}
         {{- end }}
         {{- with .Values.init.resources }}
           resources: {{- toYaml . | nindent 12 }}
@@ -265,6 +272,35 @@ spec:
         {{- end }}
     {{- if .Values.tls.enabled }}
       volumes:
+      {{- if .Values.tls.enableSighupRotation }}
+        {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager .Values.tls.certs.selfSigner.enabled }}
+        - name: client-secret
+          {{- if or .Values.tls.certs.tlsSecret .Values.tls.certs.certManager .Values.tls.certs.selfSigner.enabled }}
+          projected:
+            sources:
+            - secret:
+                {{- if .Values.tls.certs.selfSigner.enabled }}
+                name: {{ template "cockroachdb.fullname" . }}-client-secret
+                {{ else }}
+                name: {{ .Values.tls.certs.clientRootSecret }}
+                {{ end -}}
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                  mode: 0400
+                - key: tls.crt
+                  path: client.root.crt
+                  mode: 0400
+                - key: tls.key
+                  path: client.root.key
+                  mode: 0400
+          {{- else }}
+          secret:
+            secretName: {{ .Values.tls.certs.clientRootSecret }}
+            defaultMode: 0400
+          {{- end }}
+        {{- end }}
+      {{- else }}
         - name: client-certs
           emptyDir: {}
           {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager .Values.tls.certs.selfSigner.enabled }}
@@ -294,5 +330,6 @@ spec:
             defaultMode: 0400
           {{- end }}
           {{- end }}
+      {{- end }}
     {{- end }}
 {{- end }}

--- a/cockroachdb/templates/statefulset.yaml
+++ b/cockroachdb/templates/statefulset.yaml
@@ -49,15 +49,16 @@ spec:
         - name: {{ template "cockroachdb.fullname" . }}.db.registry
     {{- end }}
       serviceAccountName: {{ template "cockroachdb.serviceAccount.name" . }}
+      {{- if or (and .Values.tls.enabled (not .Values.tls.enableSighupRotation)) .Values.visus.enabled .Values.statefulset.initContainers }}
       initContainers:
-        {{- if .Values.tls.enabled }}
+        {{- if and .Values.tls.enabled (not .Values.tls.enableSighupRotation) }}
         - name: copy-certs
           image: {{ .Values.tls.copyCerts.image | quote }}
           imagePullPolicy: {{ .Values.tls.selfSigner.image.pullPolicy | quote }}
           command:
             - /bin/sh
             - -c
-            - "cp -f /certs/* /cockroach-certs/; chmod 0400 /cockroach-certs/*.key"
+            - "cp -f /certs/* /cockroach/cockroach-certs/; chmod 0400 /cockroach/cockroach-certs/*.key"
           env:
             - name: POD_NAMESPACE
               valueFrom:
@@ -74,7 +75,7 @@ spec:
         {{- end }}
           volumeMounts:
             - name: certs
-              mountPath: /cockroach-certs/
+              mountPath: /cockroach/cockroach-certs/
             - name: certs-secret
               mountPath: /certs/
         {{- with .Values.tls.copyCerts.resources }}
@@ -115,12 +116,19 @@ spec:
               protocol: TCP
           volumeMounts:
             {{- if .Values.tls.enabled }}
+            {{- if .Values.tls.enableSighupRotation }}
+            - name: certs-combined
+              mountPath: /cockroach-certs/
+            - name: client-secret
+              mountPath: /cockroach/client
+            {{- else }}
             - name: certs
               mountPath: /cockroach-certs/
             - name: certs-secret
               mountPath: /cockroach/node/
             - name: client-secret
               mountPath: /cockroach/client
+            {{- end }}
             {{- end }}
         {{- end }}
         {{- range $ic := .Values.statefulset.initContainers }}
@@ -130,6 +138,7 @@ spec:
           {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- end }}
+      {{- end }}
     {{- if or .Values.statefulset.nodeAffinity .Values.statefulset.podAffinity .Values.statefulset.podAntiAffinity }}
       affinity:
       {{- with .Values.statefulset.nodeAffinity }}
@@ -335,12 +344,21 @@ spec:
             {{- end }}
           {{- end }}
           {{- if .Values.tls.enabled }}
+            {{- if .Values.tls.enableSighupRotation }}
+            - name: certs-combined
+              mountPath: /cockroach/cockroach-certs/
+              {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager .Values.tls.certs.selfSigner.enabled }}
+            - name: client-secret
+              mountPath: /cockroach/certs/
+              {{- end }}
+            {{- else }}
             - name: certs
               mountPath: /cockroach/cockroach-certs/
               {{- if .Values.tls.certs.provided }}
             - name: certs-secret
               mountPath: /cockroach/certs/
               {{- end }}
+            {{- end }}
           {{- end }}
           {{- range .Values.statefulset.secretMounts }}
             - name: {{ printf "secret-%s" . | quote }}
@@ -446,8 +464,40 @@ spec:
           {{ toYaml . | nindent 8 }}
         {{- end }}
       {{- if .Values.tls.enabled }}
+        {{- if .Values.tls.enableSighupRotation }}
+        - name: certs-combined
+          projected:
+            sources:
+            - secret:
+                {{- if .Values.tls.certs.selfSigner.enabled }}
+                name: {{ template "cockroachdb.fullname" . }}-node-secret
+                {{ else }}
+                name: {{ .Values.tls.certs.nodeSecret }}
+                {{ end -}}
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                  mode: 288
+                {{- if or .Values.tls.certs.tlsSecret .Values.tls.certs.certManager .Values.tls.certs.selfSigner.enabled }}
+                - key: tls.crt
+                  path: node.crt
+                  mode: 288
+                - key: tls.key
+                  path: node.key
+                  mode: 288
+                {{- else }}
+                - key: node.crt
+                  path: node.crt
+                  mode: 288
+                - key: node.key
+                  path: node.key
+                  mode: 288
+                {{- end }}
+        {{- else }}
         - name: certs
           emptyDir: {}
+        {{- end }}
+        {{- if not .Values.tls.enableSighupRotation }}
           {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager  .Values.tls.certs.selfSigner.enabled }}
         - name: certs-secret
           {{- if or .Values.tls.certs.tlsSecret .Values.tls.certs.certManager .Values.tls.certs.selfSigner.enabled }}
@@ -475,6 +525,7 @@ spec:
             defaultMode: 256
           {{- end }}
           {{- end }}
+        {{- end }}
         {{- if or .Values.tls.certs.provided .Values.tls.certs.certManager .Values.tls.certs.selfSigner.enabled }}
         - name: client-secret
         {{- if or .Values.tls.certs.tlsSecret .Values.tls.certs.certManager .Values.tls.certs.selfSigner.enabled }}

--- a/cockroachdb/values.schema.json
+++ b/cockroachdb/values.schema.json
@@ -4,6 +4,9 @@
     "tls": {
       "type": "object",
       "properties": {
+        "enableSighupRotation": {
+          "type": "boolean"
+        },
         "certs": {
           "type": "object",
           "properties": {

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -586,6 +586,15 @@ init:
 # Whether to run securely using TLS certificates.
 tls:
   enabled: true
+  # EnableSighupRotation enables zero-downtime certificate rotation using SIGHUP signal.
+  # When true, node certificates (ca.crt, node.crt, node.key) are mounted directly from
+  # Kubernetes secrets with 0440 permissions (owner+group read), allowing CockroachDB to
+  # reload certificates via SIGHUP signal without pod restarts.
+  # When false (default), an initContainer copies certs to ensure 0400 permissions
+  # (owner read only) but pod restarts are required for certificate rotation.
+  # NOTE: Only supported with externally managed certificates (user-provided or cert-manager).
+  # Not compatible with self-signed certificates (tls.certs.selfSigner.enabled=true).
+  enableSighupRotation: false
   copyCerts:
     image: busybox
   certs:

--- a/tests/template/sighup_rotation_test.go
+++ b/tests/template/sighup_rotation_test.go
@@ -1,0 +1,414 @@
+package template
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	sighupHelmChartPath = func() string {
+		path, err := filepath.Abs("../../cockroachdb")
+		if err != nil {
+			panic(err)
+		}
+		return path
+	}()
+	sighupReleaseName   = "sighup-test"
+	sighupNamespaceName = "sighup-" + strings.ToLower(random.UniqueId())
+)
+
+// TestSighupRotationValidation tests that enableSighupRotation cannot be enabled with self-signed certificates
+func TestSighupRotationValidation(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		values     map[string]string
+		expectErr  bool
+		errMessage string
+	}{
+		{
+			name: "SIGHUP rotation with self-signed certs should fail",
+			values: map[string]string{
+				"tls.enabled":                  "true",
+				"tls.enableSighupRotation":     "true",
+				"tls.certs.selfSigner.enabled": "true",
+				"operator.enabled":             "false",
+			},
+			expectErr:  true,
+			errMessage: "Can not enable SIGHUP rotation with self-signed certificates",
+		},
+		{
+			name: "SIGHUP rotation with cert-manager should succeed",
+			values: map[string]string{
+				"tls.enabled":                  "true",
+				"tls.enableSighupRotation":     "true",
+				"tls.certs.selfSigner.enabled": "false",
+				"tls.certs.certManager":        "true",
+				"operator.enabled":             "false",
+			},
+			expectErr: false,
+		},
+		{
+			name: "SIGHUP rotation with provided certs should succeed",
+			values: map[string]string{
+				"tls.enabled":                  "true",
+				"tls.enableSighupRotation":     "true",
+				"tls.certs.selfSigner.enabled": "false",
+				"tls.certs.certManager":        "false",
+				"tls.certs.provided":           "true",
+				"operator.enabled":             "false",
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(subT *testing.T) {
+			subT.Parallel()
+
+			options := &helm.Options{
+				KubectlOptions: k8s.NewKubectlOptions("", "", sighupNamespaceName),
+				SetValues:      tc.values,
+			}
+
+			_, err := helm.RenderTemplateE(subT, options, sighupHelmChartPath, sighupReleaseName, []string{"templates/statefulset.yaml"})
+
+			if tc.expectErr {
+				require.Error(subT, err)
+				require.Contains(subT, err.Error(), tc.errMessage)
+			} else {
+				require.NoError(subT, err)
+			}
+		})
+	}
+}
+
+// TestSighupRotationStatefulSetInitContainers verifies that copy-certs initContainer is skipped when SIGHUP rotation is enabled
+func TestSighupRotationStatefulSetInitContainers(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                         string
+		values                       map[string]string
+		expectCopyCertsInitContainer bool
+	}{
+		{
+			name: "SIGHUP rotation enabled - no copy-certs initContainer",
+			values: map[string]string{
+				"tls.enabled":                  "true",
+				"tls.enableSighupRotation":     "true",
+				"tls.certs.selfSigner.enabled": "false",
+				"tls.certs.certManager":        "true",
+				"operator.enabled":             "false",
+			},
+			expectCopyCertsInitContainer: false,
+		},
+		{
+			name: "SIGHUP rotation disabled - copy-certs initContainer present",
+			values: map[string]string{
+				"tls.enabled":                  "true",
+				"tls.enableSighupRotation":     "false",
+				"tls.certs.selfSigner.enabled": "false",
+				"tls.certs.certManager":        "true",
+				"operator.enabled":             "false",
+			},
+			expectCopyCertsInitContainer: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(subT *testing.T) {
+			subT.Parallel()
+
+			options := &helm.Options{
+				KubectlOptions: k8s.NewKubectlOptions("", "", sighupNamespaceName),
+				SetValues:      tc.values,
+			}
+
+			output, err := helm.RenderTemplateE(subT, options, sighupHelmChartPath, sighupReleaseName, []string{"templates/statefulset.yaml"})
+			require.NoError(subT, err)
+
+			var sts appsv1.StatefulSet
+			helm.UnmarshalK8SYaml(subT, output, &sts)
+
+			hasCopyCerts := false
+			for _, ic := range sts.Spec.Template.Spec.InitContainers {
+				if ic.Name == "copy-certs" {
+					hasCopyCerts = true
+					break
+				}
+			}
+
+			require.Equal(subT, tc.expectCopyCertsInitContainer, hasCopyCerts,
+				"Expected copy-certs initContainer presence: %v, got: %v", tc.expectCopyCertsInitContainer, hasCopyCerts)
+		})
+	}
+}
+
+// TestSighupRotationStatefulSetVolumes verifies volume configuration when SIGHUP rotation is enabled
+func TestSighupRotationStatefulSetVolumes(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                string
+		values              map[string]string
+		expectCertsCombined bool
+		expectCertsVolume   bool
+	}{
+		{
+			name: "SIGHUP rotation enabled - certs-combined volume present",
+			values: map[string]string{
+				"tls.enabled":                  "true",
+				"tls.enableSighupRotation":     "true",
+				"tls.certs.selfSigner.enabled": "false",
+				"tls.certs.certManager":        "true",
+				"operator.enabled":             "false",
+			},
+			expectCertsCombined: true,
+			expectCertsVolume:   false,
+		},
+		{
+			name: "SIGHUP rotation disabled - certs volume present",
+			values: map[string]string{
+				"tls.enabled":                  "true",
+				"tls.enableSighupRotation":     "false",
+				"tls.certs.selfSigner.enabled": "false",
+				"tls.certs.certManager":        "true",
+				"operator.enabled":             "false",
+			},
+			expectCertsCombined: false,
+			expectCertsVolume:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(subT *testing.T) {
+			subT.Parallel()
+
+			options := &helm.Options{
+				KubectlOptions: k8s.NewKubectlOptions("", "", sighupNamespaceName),
+				SetValues:      tc.values,
+			}
+
+			output, err := helm.RenderTemplateE(subT, options, sighupHelmChartPath, sighupReleaseName, []string{"templates/statefulset.yaml"})
+			require.NoError(subT, err)
+
+			var sts appsv1.StatefulSet
+			helm.UnmarshalK8SYaml(subT, output, &sts)
+
+			hasCertsCombined := false
+			hasCertsVolume := false
+
+			for _, vol := range sts.Spec.Template.Spec.Volumes {
+				if vol.Name == "certs-combined" {
+					hasCertsCombined = true
+					// Verify it's a projected volume
+					require.NotNil(subT, vol.Projected, "certs-combined should be a projected volume")
+				}
+				if vol.Name == "certs" {
+					hasCertsVolume = true
+				}
+			}
+
+			require.Equal(subT, tc.expectCertsCombined, hasCertsCombined,
+				"Expected certs-combined volume: %v, got: %v", tc.expectCertsCombined, hasCertsCombined)
+			require.Equal(subT, tc.expectCertsVolume, hasCertsVolume,
+				"Expected certs volume: %v, got: %v", tc.expectCertsVolume, hasCertsVolume)
+		})
+	}
+}
+
+// TestSighupRotationStatefulSetVolumeMounts verifies volume mount configuration when SIGHUP rotation is enabled
+func TestSighupRotationStatefulSetVolumeMounts(t *testing.T) {
+	t.Parallel()
+
+	options := &helm.Options{
+		KubectlOptions: k8s.NewKubectlOptions("", "", sighupNamespaceName),
+		SetValues: map[string]string{
+			"tls.enabled":                  "true",
+			"tls.enableSighupRotation":     "true",
+			"tls.certs.selfSigner.enabled": "false",
+			"tls.certs.certManager":        "true",
+			"operator.enabled":             "false",
+		},
+	}
+
+	output, err := helm.RenderTemplateE(t, options, sighupHelmChartPath, sighupReleaseName, []string{"templates/statefulset.yaml"})
+	require.NoError(t, err)
+
+	var sts appsv1.StatefulSet
+	helm.UnmarshalK8SYaml(t, output, &sts)
+
+	// Find the db container
+	var dbContainer *corev1.Container
+	for i := range sts.Spec.Template.Spec.Containers {
+		if sts.Spec.Template.Spec.Containers[i].Name == "db" {
+			dbContainer = &sts.Spec.Template.Spec.Containers[i]
+			break
+		}
+	}
+	require.NotNil(t, dbContainer, "db container not found")
+
+	// Verify certs-combined is mounted to /cockroach/cockroach-certs/
+	hasCertsCombinedMount := false
+	for _, vm := range dbContainer.VolumeMounts {
+		if vm.Name == "certs-combined" && vm.MountPath == "/cockroach/cockroach-certs/" {
+			hasCertsCombinedMount = true
+			break
+		}
+	}
+	require.True(t, hasCertsCombinedMount, "certs-combined should be mounted to /cockroach/cockroach-certs/")
+
+	// Verify client-secret is mounted to /cockroach/certs/
+	hasClientSecretMount := false
+	for _, vm := range dbContainer.VolumeMounts {
+		if vm.Name == "client-secret" && vm.MountPath == "/cockroach/certs/" {
+			hasClientSecretMount = true
+			break
+		}
+	}
+	require.True(t, hasClientSecretMount, "client-secret should be mounted to /cockroach/certs/")
+}
+
+// TestSighupRotationProjectedVolumePermissions verifies that projected volumes have correct permissions (0440)
+func TestSighupRotationProjectedVolumePermissions(t *testing.T) {
+	t.Parallel()
+
+	options := &helm.Options{
+		KubectlOptions: k8s.NewKubectlOptions("", "", sighupNamespaceName),
+		SetValues: map[string]string{
+			"tls.enabled":                  "true",
+			"tls.enableSighupRotation":     "true",
+			"tls.certs.selfSigner.enabled": "false",
+			"tls.certs.certManager":        "true",
+			"operator.enabled":             "false",
+		},
+	}
+
+	output, err := helm.RenderTemplateE(t, options, sighupHelmChartPath, sighupReleaseName, []string{"templates/statefulset.yaml"})
+	require.NoError(t, err)
+
+	var sts appsv1.StatefulSet
+	helm.UnmarshalK8SYaml(t, output, &sts)
+
+	// Find the certs-combined projected volume
+	var certsCombinedVolume *corev1.Volume
+	for i := range sts.Spec.Template.Spec.Volumes {
+		if sts.Spec.Template.Spec.Volumes[i].Name == "certs-combined" {
+			certsCombinedVolume = &sts.Spec.Template.Spec.Volumes[i]
+			break
+		}
+	}
+	require.NotNil(t, certsCombinedVolume, "certs-combined volume not found")
+	require.NotNil(t, certsCombinedVolume.Projected, "certs-combined should be a projected volume")
+
+	// Verify permissions are 0440 (octal 440 = decimal 288)
+	expectedMode := int32(288) // 0440 in octal = 288 in decimal
+	for _, source := range certsCombinedVolume.Projected.Sources {
+		if source.Secret != nil {
+			for _, item := range source.Secret.Items {
+				require.NotNil(t, item.Mode, "Mode should be set for %s", item.Path)
+				require.Equal(t, expectedMode, *item.Mode,
+					"Expected mode 288 (0440) for %s, got %d", item.Path, *item.Mode)
+			}
+		}
+	}
+}
+
+// TestSighupRotationJobInitVolumes verifies job.init.yaml volume configuration when SIGHUP rotation is enabled
+func TestSighupRotationJobInitVolumes(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                         string
+		values                       map[string]string
+		expectCopyCertsInitContainer bool
+		expectClientSecretVolume     bool
+		expectClientCertsVolume      bool
+	}{
+		{
+			name: "SIGHUP rotation enabled - no copy-certs, client-secret volume present",
+			values: map[string]string{
+				"tls.enabled":                  "true",
+				"tls.enableSighupRotation":     "true",
+				"tls.certs.selfSigner.enabled": "false",
+				"tls.certs.certManager":        "true",
+				"operator.enabled":             "false",
+			},
+			expectCopyCertsInitContainer: false,
+			expectClientSecretVolume:     true,
+			expectClientCertsVolume:      false,
+		},
+		{
+			name: "SIGHUP rotation disabled - copy-certs present, client-certs volume present",
+			values: map[string]string{
+				"tls.enabled":                  "true",
+				"tls.enableSighupRotation":     "false",
+				"tls.certs.selfSigner.enabled": "false",
+				"tls.certs.certManager":        "true",
+				"operator.enabled":             "false",
+			},
+			expectCopyCertsInitContainer: true,
+			expectClientSecretVolume:     false,
+			expectClientCertsVolume:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(subT *testing.T) {
+			subT.Parallel()
+
+			options := &helm.Options{
+				KubectlOptions: k8s.NewKubectlOptions("", "", sighupNamespaceName),
+				SetValues:      tc.values,
+			}
+
+			output, err := helm.RenderTemplateE(subT, options, sighupHelmChartPath, sighupReleaseName, []string{"templates/job.init.yaml"})
+			require.NoError(subT, err)
+
+			var job batchv1.Job
+			helm.UnmarshalK8SYaml(subT, output, &job)
+
+			// Check initContainers
+			hasCopyCerts := false
+			for _, ic := range job.Spec.Template.Spec.InitContainers {
+				if ic.Name == "copy-certs" {
+					hasCopyCerts = true
+					break
+				}
+			}
+			require.Equal(subT, tc.expectCopyCertsInitContainer, hasCopyCerts,
+				"Expected copy-certs initContainer in job.init: %v, got: %v", tc.expectCopyCertsInitContainer, hasCopyCerts)
+
+			// Check volumes
+			hasClientSecret := false
+			hasClientCerts := false
+			for _, vol := range job.Spec.Template.Spec.Volumes {
+				if vol.Name == "client-secret" {
+					hasClientSecret = true
+				}
+				if vol.Name == "client-certs" {
+					hasClientCerts = true
+				}
+			}
+			require.Equal(subT, tc.expectClientSecretVolume, hasClientSecret,
+				"Expected client-secret volume in job.init: %v, got: %v", tc.expectClientSecretVolume, hasClientSecret)
+			require.Equal(subT, tc.expectClientCertsVolume, hasClientCerts,
+				"Expected client-certs volume in job.init: %v, got: %v", tc.expectClientCertsVolume, hasClientCerts)
+		})
+	}
+}


### PR DESCRIPTION
Implements CRDB-42772 to enable zero-downtime certificate rotation in CockroachDB Helm charts using SIGHUP signal.

## Changes:
- Add `tls.enableSighupRotation` configuration option (default: false)
- When `tls.enableSighupRotation=true`, node certificates mount directly from secrets in a projected volume
- Enables live certificate reload via SIGHUP without pod restarts
- Certificate permissions set to 0440 (vs 0400 in traditional mode) to allow group read access, since secrets mount with root:1000 ownership when `securityContext.enabled=true`
- Only node certificates (ca.crt, node.crt, node.key) are mounted in the DB container's `--certs-dir`
- Client certificates remain in a separate volume for use by visus and other components that need them
- Conditional copy-certs initContainer (skipped when `tls.enableSighupRotation=true`)

## Documentation:
- Add zero-downtime certificate rotation section to README.md
- Document SIGHUP-based rotation with deployment and usage examples
- Explain 0440 permissions requirement due to Kubernetes fsGroup behavior
- Update CHANGELOG.md with feature description

All procedures validated against live GKE cluster deployment.
