### PR TITLE
[CRDB-53890] helm: setup the infra on the openshift to run single and multi region tests

### DIFF
--- a/.github/workflows/integration-tests-advanced.yaml
+++ b/.github/workflows/integration-tests-advanced.yaml
@@ -1,0 +1,139 @@
+name: advanced-features-tests
+
+on:
+  schedule:
+    - cron: "15 6 * * 1"  # Run at 6:15 AM on every Monday UTC to avoid peak times
+  # Allow manual trigger on any branch
+  workflow_dispatch:
+
+jobs:
+  integration-tests-advanced-features:
+    runs-on: ubuntu-latest-4-core
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: [k3d, kind]
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23
+      - name: Authenticate to Google Cloud
+        uses: 'google-github-actions/auth@v2'
+        id: auth
+        with:
+          token_format: access_token
+          project_id: 'cockroach-helm-testing'
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Install gke-gcloud-auth-plugin
+        run: |
+          gcloud components install gke-gcloud-auth-plugin
+      - name: Run tests (advanced features)
+        env:
+          PROVIDER: ${{ matrix.provider }}
+          TEST_ADVANCED_FEATURES: true
+          USE_GKE_GCLOUD_AUTH_PLUGIN: True
+        run: |
+          set -euo pipefail
+          make test/nightly-e2e/advanced | tee test_output.log
+      - name: Run multi-region tests (advanced features)
+        env:
+          PROVIDER: ${{ matrix.provider }}
+          TEST_ADVANCED_FEATURES: true
+          USE_GKE_GCLOUD_AUTH_PLUGIN: True
+        run: |
+          set -euo pipefail
+          make test/nightly-e2e/advanced/multi-region | tee -a test_output.log
+      - name: Archive test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: advanced-features-test-results-${{ matrix.provider }}
+          path: |
+            test_output.log
+            test_output.json
+      - name: Slack notification (advanced features)
+        if: ${{ always() && github.ref_name == 'master' }}
+        run: |
+          echo "Preparing Slack message for advanced features tests..."
+
+          if [ ! -f test_output.json ]; then
+            echo "Generating test_output.json from log..."
+            grep -E "=== RUN|--- PASS:|--- FAIL:" test_output.log | awk '
+              /=== RUN/ {
+                test_name = $3
+                tests[test_name] = "running"
+              }
+              /--- PASS:/ {
+                test_name = $3
+                if (test_name in tests) {
+                  print "{\"Action\":\"pass\",\"Test\":\"" test_name "\"}"
+                }
+              }
+              /--- FAIL:/ {
+                test_name = $3
+                if (test_name in tests) {
+                  print "{\"Action\":\"fail\",\"Test\":\"" test_name "\"}"
+                }
+              }' > test_output.json
+          fi
+
+          PASSED_TESTS=$(jq -r 'select(.Action=="pass") | .Test' test_output.json | sed 's|.*/||' | grep '^Test' | grep -v '^TestOperatorIn' | sort | uniq | head -n 20 | paste -sd ", " -)
+          FAILED_TESTS=$(jq -r 'select(.Action=="fail") | .Test' test_output.json | sed 's|.*/||' | grep '^Test' | grep -v '^TestOperatorIn' | sort | uniq | head -n 20 | paste -sd ", " -)
+          PASSED_COUNT=$(jq -r 'select(.Action=="pass") | .Test' test_output.json | sed 's|.*/||' | grep '^Test' | grep -v '^TestOperatorIn' | sort | uniq | wc -l)
+          FAILED_COUNT=$(jq -r 'select(.Action=="fail") | .Test' test_output.json | sed 's|.*/||' | grep '^Test' | grep -v '^TestOperatorIn' | sort | uniq | wc -l)
+
+          if [ "$FAILED_COUNT" -gt 0 ]; then
+            STATUS="❌ *Advanced features integration tests failed!*"
+            COLOR="#ff0000"
+          else
+            STATUS="✅ *Advanced features integration tests passed!*"
+            COLOR="#36a64f"
+          fi
+
+          REPO_NAME="helm-charts"
+
+          PAYLOAD=$(jq -n \
+            --arg text "$STATUS" \
+            --arg color "$COLOR" \
+            --arg repo "$REPO_NAME" \
+            --arg branch "${{ github.ref_name }}" \
+            --arg workflow "${{ github.workflow }}" \
+            --arg provider "${{ matrix.provider }}" \
+            --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg passed "$PASSED_COUNT" \
+            --arg failed "$FAILED_COUNT" \
+            --arg passed_tests "$PASSED_TESTS" \
+            --arg failed_tests "$FAILED_TESTS" \
+            '{
+              text: $text,
+              attachments: [
+                {
+                  color: $color,
+                  fields: [
+                    {"title": "Repository", "value": $repo, "short": true},
+                    {"title": "Branch", "value": $branch, "short": true},
+                    {"title": "Provider", "value": $provider, "short": true},
+                    {"title": "✅ Passed", "value": $passed, "short": true},
+                    {"title": "❌ Failed", "value": $failed, "short": true},
+                    {"title": "❌ Failed Tests", "value": (if $failed_tests == "" then "None" else $failed_tests end), "short": false},
+                    {"title": "✅ Passed Tests", "value": (if $passed_tests == "" then "None" else $passed_tests end), "short": false},
+                    {"title": "Run URL", "value": $url, "short": false}
+                  ]
+                }
+              ]
+            }')
+
+          curl -X POST -H 'Content-type: application/json' \
+            --data "$PAYLOAD" \
+            "${{ secrets.SLACK_WEBHOOK_URL }}"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ bin/
 build/artifacts
 bazel-*
 /vendor/
+
+# Submariner broker credentials — generated at runtime by subctl deploy-broker,
+# never committed. Contains service account tokens, CA certs, and PSK.
+broker-info.subm
+*.subm

--- a/Makefile
+++ b/Makefile
@@ -120,11 +120,20 @@ test/e2e/%: bin/cockroach bin/kubectl bin/helm build/self-signer test/cluster/up
 	$(MAKE) test/cluster/down; \
 	exit $${EXIT_CODE:-0}
 
+# E2E_MULTI_REGION_TIMEOUT controls the go test timeout for multi-region tests.
+# OpenShift clusters take ~40–60 min to provision, so the default is generous.
+# Override to a lower value (e.g. 60m) when running against faster providers.
+E2E_MULTI_REGION_TIMEOUT ?= 300m
+
 test/e2e/multi-region: bin/cockroach bin/kubectl bin/helm  build/self-signer bin/k3d bin/kind
-	@PATH="$(PWD)/bin:${PATH}" go test -timeout 60m -v -test.run TestOperatorInMultiRegion ./tests/e2e/operator/multiRegion/... || (echo "Multi region tests failed with exit code $$?" && exit 1)
+	@PATH="$(PWD)/bin:${PATH}" go test -timeout $(E2E_MULTI_REGION_TIMEOUT) -v -test.run TestOperatorInMultiRegion ./tests/e2e/operator/multiRegion/... || (echo "Multi region tests failed with exit code $$?" && exit 1)
+
+# E2E_SINGLE_REGION_TIMEOUT controls the go test timeout for single-region tests.
+# OpenShift provisioning takes ~40-60 min, so override when running against it.
+E2E_SINGLE_REGION_TIMEOUT ?= 60m
 
 test/e2e/single-region: bin/cockroach bin/kubectl bin/helm build/self-signer bin/k3d bin/kind
-	@PATH="$(PWD)/bin:${PATH}" go test -timeout 60m -v -test.run TestOperatorInSingleRegion ./tests/e2e/operator/singleRegion/... || (echo "Single region tests failed with exit code $$?" && exit 1)
+	@PATH="$(PWD)/bin:${PATH}" go test -timeout $(E2E_SINGLE_REGION_TIMEOUT) -v -test.run TestOperatorInSingleRegion ./tests/e2e/operator/singleRegion/... || (echo "Single region tests failed with exit code $$?" && exit 1)
 
 test/e2e/migrate: bin/cockroach bin/kubectl bin/helm bin/migration-helper build/self-signer test/cluster/up/3
 	@PATH="$(PWD)/bin:${PATH}" go test -timeout 30m -v ./tests/e2e/migrate/... || EXIT_CODE=$$?; \

--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,34 @@ test/single-cluster/up: bin/k3d
 test/multi-cluster/down: bin/k3d
 	 ./tests/k3d/dev-multi-cluster.sh down
 
+test/nightly-e2e/advanced: bin/cockroach bin/kubectl bin/helm build/self-signer bin/k3d bin/kind
+	@PATH="$(PWD)/bin:${PATH}" TEST_ADVANCED_FEATURES=true go test -timeout 90m -v -test.run TestOperatorInSingleRegion ./tests/e2e/operator/singleRegion/... || (echo "Advanced features tests failed with exit code $$?" && exit 1)
+
+test/nightly-e2e/advanced/multi-region: bin/cockroach bin/kubectl bin/helm build/self-signer bin/k3d bin/kind
+	@PATH="$(PWD)/bin:${PATH}" TEST_ADVANCED_FEATURES=true go test -timeout 90m -v -test.run TestOperatorInMultiRegion ./tests/e2e/operator/multiRegion/... || (echo "Advanced features multi-region tests failed with exit code $$?" && exit 1)
+
+# Run advanced e2e tests using kind clusters on a GCE worker.
+# Creates kind clusters, runs all advanced feature tests, and leaves clusters running (no cleanup).
+# Use this for the first run or whenever you want a fresh cluster.
+test/nightly-e2e/advanced/kind: bin/cockroach bin/kubectl bin/helm build/self-signer bin/kind
+	@PATH="$(PWD)/bin:${PATH}" PROVIDER=kind SKIP_CLEANUP=true TEST_ADVANCED_FEATURES=true go test -timeout 90m -v -test.run TestOperatorInSingleRegion ./tests/e2e/operator/singleRegion/... || (echo "Advanced features tests (kind) failed with exit code $$?" && exit 1)
+
+# Re-run advanced e2e tests on existing kind clusters (skips cluster creation).
+# Use this after test/nightly-e2e/advanced/kind when clusters are already up and you want to
+# iterate on failures without recreating infrastructure.
+test/nightly-e2e/advanced/kind/reuse: bin/cockroach bin/kubectl bin/helm build/self-signer bin/kind
+	@PATH="$(PWD)/bin:${PATH}" PROVIDER=kind REUSE_INFRA=true SKIP_CLEANUP=true TEST_ADVANCED_FEATURES=true go test -timeout 90m -v -test.run TestOperatorInSingleRegion ./tests/e2e/operator/singleRegion/... || (echo "Advanced features tests (kind reuse) failed with exit code $$?" && exit 1)
+
+# Run multi-region advanced e2e tests using kind clusters on a GCE worker.
+# Creates kind clusters, runs all multi-region advanced feature tests, and leaves clusters running.
+test/nightly-e2e/advanced/kind/multi-region: bin/cockroach bin/kubectl bin/helm build/self-signer bin/kind
+	@PATH="$(PWD)/bin:${PATH}" PROVIDER=kind SKIP_CLEANUP=true TEST_ADVANCED_FEATURES=true go test -timeout 90m -v -test.run TestOperatorInMultiRegion ./tests/e2e/operator/multiRegion/... || (echo "Advanced features tests (kind multi-region) failed with exit code $$?" && exit 1)
+
+# Re-run multi-region advanced e2e tests on existing kind clusters (skips cluster creation).
+test/nightly-e2e/advanced/kind/multi-region/reuse: bin/cockroach bin/kubectl bin/helm build/self-signer bin/kind
+	@PATH="$(PWD)/bin:${PATH}" PROVIDER=kind REUSE_INFRA=true SKIP_CLEANUP=true TEST_ADVANCED_FEATURES=true go test -timeout 90m -v -test.run TestOperatorInMultiRegion ./tests/e2e/operator/multiRegion/... || (echo "Advanced features tests (kind multi-region reuse) failed with exit code $$?" && exit 1)
+
+
 test/lint: bin/helm ## lint the helm chart
 	@build/lint.sh && \
 	bin/helm lint cockroachdb && \

--- a/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -415,9 +415,9 @@ cockroachdb:
         # # imagePullSecrets captures the secrets for fetching images from private registries.
         # imagePullSecrets: []
         # # initContainers captures the list of init containers for CockroachDB pods.
-        # initContainers:
-        #   - name : cockroachdb-init
-        #     image: us-docker.pkg.dev/releases-prod/self-hosted/init-container@sha256:bcfc9312af84c7966f017c2325981b30314c0c293491f942e54da1667bedaf69
+        initContainers:
+          - name: cockroachdb-init
+            image: us-docker.pkg.dev/releases-prod/self-hosted/init-container@sha256:82871ea47eef7c59c1bb08cf7612420cefc35139eb46659cb3fa1459e2e6d148
         # containers captures the list of containers for CockroachDB pods.
         containers:
           - name: cockroachdb

--- a/tests/e2e/coredns/coredns.go
+++ b/tests/e2e/coredns/coredns.go
@@ -148,6 +148,46 @@ func CoreDNSService(IpAddress *string, annotations map[string]string) *corev1.Se
 	return svc
 }
 
+// CoreDNSInternalService returns a ClusterIP-only Service that exposes both UDP/53 and TCP/53
+// to the CoreDNS pods. This is used by OpenShift so the built-in DNS operator can forward
+// queries via UDP (its default protocol) to our custom CoreDNS. The main LoadBalancer service
+// (CoreDNSService) only exposes TCP/53 due to GCP LB constraints.
+func CoreDNSInternalService() *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "crl-core-dns-internal",
+			Namespace: "kube-system",
+			Labels: map[string]string{
+				"k8s-app": "kube-dns",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "dns-udp",
+					Port:       53,
+					Protocol:   corev1.ProtocolUDP,
+					TargetPort: intstr.Parse("53"),
+				},
+				{
+					Name:       "dns-tcp",
+					Port:       53,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.Parse("53"),
+				},
+			},
+			Selector: map[string]string{
+				"k8s-app": "kube-dns",
+			},
+		},
+	}
+}
+
 // CoreDNSDeployment returns coredns deployment object.
 func CoreDNSDeployment(replicas int32) *appsv1.Deployment {
 	healthCheckPort := intstr.FromInt32(8080)

--- a/tests/e2e/migrate/helm_chart_to_cockroach_enterprise_operator_test.go
+++ b/tests/e2e/migrate/helm_chart_to_cockroach_enterprise_operator_test.go
@@ -143,7 +143,7 @@ func (h *HelmChartToOperator) TestDefaultMigration(t *testing.T) {
 		k8s.RunKubectl(t, kubectlOptions, "delete", "priorityclass", "crdb-critical")
 	}()
 
-	operator.InstallCockroachDBEnterpriseOperator(t, kubectlOptions)
+	operator.InstallCockroachDBEnterpriseOperator(t, kubectlOptions, "us-east-1")
 	defer func() {
 		t.Log("Uninstall the cockroachdb enterprise operator")
 		operator.UninstallCockroachDBEnterpriseOperator(t, kubectlOptions)
@@ -261,7 +261,7 @@ func (h *HelmChartToOperator) TestCertManagerMigration(t *testing.T) {
 		k8s.RunKubectl(t, kubectlOptions, "delete", "priorityclass", "crdb-critical")
 	}()
 
-	operator.InstallCockroachDBEnterpriseOperator(t, kubectlOptions)
+	operator.InstallCockroachDBEnterpriseOperator(t, kubectlOptions, "us-east-1")
 	defer func() {
 		t.Log("Uninstall the cockroachdb enterprise operator")
 		operator.UninstallCockroachDBEnterpriseOperator(t, kubectlOptions)
@@ -348,7 +348,7 @@ func (h *HelmChartToOperator) TestPCRPrimaryMigration(t *testing.T) {
 		k8s.RunKubectl(t, kubectlOptions, "delete", "priorityclass", "crdb-critical")
 	}()
 
-	operator.InstallCockroachDBEnterpriseOperator(t, kubectlOptions)
+	operator.InstallCockroachDBEnterpriseOperator(t, kubectlOptions, "us-east-1")
 	defer func() {
 		t.Log("Uninstall the cockroachdb enterprise operator")
 		operator.UninstallCockroachDBEnterpriseOperator(t, kubectlOptions)

--- a/tests/e2e/migrate/public_operator_to_cockroach_enterprise_operator_test.go
+++ b/tests/e2e/migrate/public_operator_to_cockroach_enterprise_operator_test.go
@@ -156,7 +156,7 @@ func (o *PublicOperatorToCockroachEnterpriseOperator) TestDefaultMigration(t *te
 	k8s.KubectlApply(t, kubectlOptions, filepath.Join(manifestsDirPath, "rbac.yaml"))
 
 	t.Log("Install the cockroachdb enterprise operator")
-	operator.InstallCockroachDBEnterpriseOperator(t, kubectlOptions)
+	operator.InstallCockroachDBEnterpriseOperator(t, kubectlOptions, "us-east-1")
 	defer func() {
 		t.Log("Uninstall the cockroachdb enterprise operator")
 		operator.UninstallCockroachDBEnterpriseOperator(t, kubectlOptions)

--- a/tests/e2e/operator/infra/common.go
+++ b/tests/e2e/operator/infra/common.go
@@ -33,10 +33,6 @@ const (
 	loadBalancerInterval  = 10 * time.Second
 	coreDNSDeploymentName = "coredns"
 	coreDNSServiceName    = "crl-core-dns"
-	// coreDNSInternalServiceName is a ClusterIP-only service with both UDP/53 and TCP/53.
-	// OpenShift's built-in DNS operator forwards to our custom CoreDNS via UDP by default,
-	// but the crl-core-dns LoadBalancer service only exposes TCP/53 (GCP LB constraint).
-	// This internal service allows UDP+TCP so the DNS operator forwarding works correctly.
 	coreDNSInternalServiceName = "crl-core-dns-internal"
 	coreDNSNamespace           = "kube-system"
 	coreDNSReplicas       = 2
@@ -71,7 +67,7 @@ var LoadBalancerAnnotations = map[string]map[string]string{
 	},
 	ProviderK3D:       {},
 	ProviderKind:      {},
-	ProviderOpenShift: {}, // GKE-specific annotations don't apply; LB gets external GCP IP
+	ProviderOpenShift: {},
 }
 
 // NetworkConfigs defines standard network configurations for each provider and region.
@@ -224,10 +220,7 @@ func deployCoreDNSService(t *testing.T, kubectlOpts *k8s.KubectlOptions, staticI
 		return fmt.Errorf("failed to apply CoreDNS Service: %w", err)
 	}
 
-	// For OpenShift, also create a ClusterIP-only service with both UDP/53 and TCP/53.
-	// The LoadBalancer service (crl-core-dns) exposes only TCP/53 due to GCP LB constraints,
-	// but the OpenShift DNS operator forwards queries via UDP by default. The internal service
-	// allows both protocols so that in-cluster DNS forwarding works correctly.
+	// For OpenShift, also deploy an internal ClusterIP service 
 	if provider == ProviderOpenShift {
 		internalSvc := coredns.CoreDNSInternalService()
 		internalSvcYAML := coredns.ToYAML(t, internalSvc)

--- a/tests/e2e/operator/infra/common.go
+++ b/tests/e2e/operator/infra/common.go
@@ -18,9 +18,10 @@ import (
 
 // Provider types.
 const (
-	ProviderK3D  = "k3d"
-	ProviderKind = "kind"
-	ProviderGCP  = "gcp"
+	ProviderK3D       = "k3d"
+	ProviderKind      = "kind"
+	ProviderGCP       = "gcp"
+	ProviderOpenShift = "openshift"
 )
 
 // Common constants.
@@ -32,7 +33,12 @@ const (
 	loadBalancerInterval  = 10 * time.Second
 	coreDNSDeploymentName = "coredns"
 	coreDNSServiceName    = "crl-core-dns"
-	coreDNSNamespace      = "kube-system"
+	// coreDNSInternalServiceName is a ClusterIP-only service with both UDP/53 and TCP/53.
+	// OpenShift's built-in DNS operator forwards to our custom CoreDNS via UDP by default,
+	// but the crl-core-dns LoadBalancer service only exposes TCP/53 (GCP LB constraint).
+	// This internal service allows UDP+TCP so the DNS operator forwarding works correctly.
+	coreDNSInternalServiceName = "crl-core-dns-internal"
+	coreDNSNamespace           = "kube-system"
 	coreDNSReplicas       = 2
 )
 
@@ -50,9 +56,10 @@ const (
 
 // RegionCodes maps provider types to their region codes
 var RegionCodes = map[string][]string{
-	ProviderK3D:  {"us-east1", "us-east2"},
-	ProviderKind: {"us-east1", "us-east2"},
-	ProviderGCP:  {"us-central1", "us-east1"},
+	ProviderK3D:       {"us-east1", "us-east2"},
+	ProviderKind:      {"us-east1", "us-east2"},
+	ProviderGCP:       {"us-central1", "us-east1"},
+	ProviderOpenShift: {"us-central1", "us-east1"},
 }
 
 // LoadBalancerAnnotations contains provider-specific service annotations.
@@ -62,8 +69,9 @@ var LoadBalancerAnnotations = map[string]map[string]string{
 		"networking.gke.io/load-balancer-type":                         "Internal",
 		"cloud.google.com/load-balancer-type":                          "Internal",
 	},
-	ProviderK3D:  {},
-	ProviderKind: {},
+	ProviderK3D:       {},
+	ProviderKind:      {},
+	ProviderOpenShift: {}, // GKE-specific annotations don't apply; LB gets external GCP IP
 }
 
 // NetworkConfigs defines standard network configurations for each provider and region.
@@ -214,6 +222,18 @@ func deployCoreDNSService(t *testing.T, kubectlOpts *k8s.KubectlOptions, staticI
 	svcYAML := coredns.ToYAML(t, service)
 	if err := k8s.KubectlApplyFromStringE(t, kubectlOpts, svcYAML); err != nil {
 		return fmt.Errorf("failed to apply CoreDNS Service: %w", err)
+	}
+
+	// For OpenShift, also create a ClusterIP-only service with both UDP/53 and TCP/53.
+	// The LoadBalancer service (crl-core-dns) exposes only TCP/53 due to GCP LB constraints,
+	// but the OpenShift DNS operator forwards queries via UDP by default. The internal service
+	// allows both protocols so that in-cluster DNS forwarding works correctly.
+	if provider == ProviderOpenShift {
+		internalSvc := coredns.CoreDNSInternalService()
+		internalSvcYAML := coredns.ToYAML(t, internalSvc)
+		if err := k8s.KubectlApplyFromStringE(t, kubectlOpts, internalSvcYAML); err != nil {
+			return fmt.Errorf("failed to apply CoreDNS internal ClusterIP service: %w", err)
+		}
 	}
 
 	return nil

--- a/tests/e2e/operator/infra/local.go
+++ b/tests/e2e/operator/infra/local.go
@@ -41,9 +41,22 @@ type LocalRegion struct {
 //   - CoreDNS instances forward requests for other cluster domains; endpoints can be
 //     ClusterIP/pod IPs (with Calico) or LB IPs (with MetalLB).
 func (r *LocalRegion) SetUpInfra(t *testing.T) {
-	// If using existing infra return clients.
+	// If using existing infra, skip cluster creation and CNI setup but still
+	// populate clients so ValidateCRDB and other helpers can use them.
 	if r.ReusingInfra {
 		t.Logf("[%s] Reusing existing infrastructure", r.ProviderType)
+		if r.Clients == nil {
+			r.Clients = make(map[string]client.Client)
+		}
+		for _, cluster := range r.Clusters {
+			cfg, err := config.GetConfigWithContext(cluster)
+			require.NoError(t, err)
+			k8sClient, err := client.New(cfg, client.Options{})
+			require.NoError(t, err)
+			_ = apiextv1.AddToScheme(k8sClient.Scheme())
+			calico.RegisterCalicoGVK(k8sClient.Scheme())
+			r.Clients[cluster] = k8sClient
+		}
 		return
 	}
 

--- a/tests/e2e/operator/infra/openshift.go
+++ b/tests/e2e/operator/infra/openshift.go
@@ -24,31 +24,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
-// ─── OPENSHIFT CONSTANTS ──────────────────────────────────────────────────────
-
 const (
-	// env vars consumed by openshift.go
 	envOpenShiftPullSecret = "OPENSHIFT_PULL_SECRET"
 	envOpenShiftSSHPubKey  = "OPENSHIFT_SSH_PUB_KEY"
 	envOpenShiftBaseDomain = "OPENSHIFT_BASE_DOMAIN"
-	// envOpenShiftInstallDir points to an existing openshift-install state directory.
-	// When set, SetUpInfra skips provisioning and reuses the existing cluster.
-	// Example: OPENSHIFT_INSTALL_DIR=/var/folders/.../ocp-ocp-0qaif4-2872850045
+	// single directory for single-region reuse
 	envOpenShiftInstallDir = "OPENSHIFT_INSTALL_DIR"
-	// envOpenShiftInstallDirs is a comma-separated list of existing openshift-install
-	// state directories, one per cluster in order. When set, SetUpInfra skips
-	// provisioning for all clusters and reuses the existing ones. VPC peering,
-	// CoreDNS, and DNS operator setup still run (they are idempotent).
-	// Example: OPENSHIFT_INSTALL_DIRS=/path/to/cluster-0,/path/to/cluster-1
 	envOpenShiftInstallDirs = "OPENSHIFT_INSTALL_DIRS"
-
-	// defaultOpenShiftProjectID is the GCP project used when GCP_PROJECT_ID is not set.
-	// TODO: Change this to "helm-testing" to match the GCP provider default and avoid
-	// accidental provisioning into a personal project when GCP_PROJECT_ID is unset.
+	// TODO: Change this to "helm-testing" to match the GCP provider default 
 	defaultOpenShiftProjectID = "cockroach-shreyaskm"
-
-	// maxInstallerNameLen is the maximum length of the cluster name in install-config.yaml.
-	// OpenShift enforces a 14-character limit on metadata.name.
 	maxInstallerNameLen = 14
 )
 
@@ -127,8 +111,6 @@ type installConfigData struct {
 	ServiceNetwork string
 }
 
-// ─── OPENSHIFT REGION ─────────────────────────────────────────────────────────
-
 // openShiftMetadata mirrors the fields we need from the metadata.json file
 // that openshift-install writes to the install directory after provisioning.
 type openShiftMetadata struct {
@@ -155,12 +137,6 @@ type OpenShiftRegion struct {
 
 // SetUpInfra provisions one OpenShift cluster per entry in r.Clusters.
 // For single-region tests there is exactly one cluster.
-//
-// Cluster reuse modes (skip provisioning):
-//   - OPENSHIFT_INSTALL_DIRS: comma-separated list of existing openshift-install
-//     state directories, one per cluster in order. VPC peering, CoreDNS, and DNS
-//     operator setup still run (they are idempotent). Use this for multi-region.
-//   - OPENSHIFT_INSTALL_DIR: single directory for single-region reuse.
 func (r *OpenShiftRegion) SetUpInfra(t *testing.T) {
 	if r.ReusingInfra {
 		t.Logf("[%s] Reusing existing infrastructure, skipping setup", ProviderOpenShift)
@@ -214,7 +190,6 @@ func (r *OpenShiftRegion) SetUpInfra(t *testing.T) {
 			r.Clients[clusterName] = k8sClient
 			t.Logf("[%s] Cluster %q client ready (reused)", ProviderOpenShift, clusterName)
 		}
-		// Fall through to VPC peering + CoreDNS + DNS operator setup below.
 
 	case reuseDir != "":
 		// Single-region reuse: existing OPENSHIFT_INSTALL_DIR behavior.
@@ -236,11 +211,8 @@ func (r *OpenShiftRegion) SetUpInfra(t *testing.T) {
 		}
 		r.Clients[clusterName] = k8sClient
 		t.Logf("[%s] Cluster %q client ready (reused)", ProviderOpenShift, clusterName)
-		// Fall through to the common post-setup block below (DNS patching, autoscaler)
-		// so single-cluster reuse behaves identically to fresh provisioning.
 
 	default:
-		// Fresh provisioning.
 		pullSecret := mustEnv(t, envOpenShiftPullSecret)
 		sshPubKey := mustEnv(t, envOpenShiftSSHPubKey)
 		baseDomain := mustEnv(t, envOpenShiftBaseDomain)
@@ -284,7 +256,7 @@ func (r *OpenShiftRegion) SetUpInfra(t *testing.T) {
 		}
 	}
 
-	// Common: VPC peering, CoreDNS deployment, and DNS operator patching.
+	// VPC peering, CoreDNS deployment, and DNS operator patching.
 	kubeConfigPath, err := r.EnsureKubeConfigPath()
 	require.NoError(t, err)
 
@@ -320,22 +292,11 @@ func (r *OpenShiftRegion) SetUpInfra(t *testing.T) {
 			t.Fatalf("[%s] Failed to set up Submariner: %v", ProviderOpenShift, err)
 		}
 
-		// Enable cluster autoscaler so TestClusterScaleUp can schedule the 4th
-		// CockroachDB pod on a new node (mirrors GKE's --enable-autoscaling).
-		if err := r.setupClusterAutoscaler(t, kubeConfigPath); err != nil {
-			t.Fatalf("[%s] Failed to set up cluster autoscaler: %v", ProviderOpenShift, err)
-		}
-	} else {
-		// Single-region: the charts use the cluster's default domain (cluster.local),
-		// which the OpenShift DNS operator already handles natively. Forwarding
-		// cluster1.local → dns-default would create a self-referential loop, so we
-		// skip DNS patching entirely here.
+	}
 
-		// Enable cluster autoscaler so TestClusterScaleUp can schedule the 4th
-		// CockroachDB pod on a new node (mirrors GKE's --enable-autoscaling).
-		if err := r.setupClusterAutoscaler(t, kubeConfigPath); err != nil {
-			t.Fatalf("[%s] Failed to set up cluster autoscaler: %v", ProviderOpenShift, err)
-		}
+	// Enable cluster autoscaler
+	if err := r.setupClusterAutoscaler(t, kubeConfigPath); err != nil {
+		t.Fatalf("[%s] Failed to set up cluster autoscaler: %v", ProviderOpenShift, err)
 	}
 
 	r.ReusingInfra = true
@@ -343,9 +304,6 @@ func (r *OpenShiftRegion) SetUpInfra(t *testing.T) {
 }
 
 // TeardownInfra destroys all provisioned OpenShift clusters.
-// openshift-install destroy cluster handles all GCP resource cleanup automatically.
-// Clusters that were reused via OPENSHIFT_INSTALL_DIR/OPENSHIFT_INSTALL_DIRS are
-// left untouched — only clusters this test provisioned itself are destroyed.
 func (r *OpenShiftRegion) TeardownInfra(t *testing.T) {
 	t.Logf("[%s] Starting infrastructure teardown", ProviderOpenShift)
 
@@ -365,7 +323,6 @@ func (r *OpenShiftRegion) TeardownInfra(t *testing.T) {
 		cmd.Stderr = os.Stderr
 
 		if err := cmd.Run(); err != nil {
-			// Log but don't fatal — best-effort cleanup.
 			t.Logf("[%s] Warning: destroy cluster %q failed: %v", ProviderOpenShift, clusterName, err)
 		} else {
 			t.Logf("[%s] Cluster %q destroyed successfully", ProviderOpenShift, clusterName)
@@ -380,25 +337,17 @@ func (r *OpenShiftRegion) TeardownInfra(t *testing.T) {
 	t.Logf("[%s] Infrastructure teardown complete", ProviderOpenShift)
 }
 
-// ScaleNodePool is a no-op for OpenShift: the ClusterAutoscaler provisioned
-// in SetUpInfra handles node scaling transparently when pods are Pending.
+// ScaleNodePool is a no-op for OpenShift
 func (r *OpenShiftRegion) ScaleNodePool(t *testing.T, location string, nodeCount, index int) {
 	t.Logf("[%s] Node pool scaling delegated to ClusterAutoscaler (no explicit action needed)", ProviderOpenShift)
 }
 
 // CanScale reports whether this provider supports scaling.
-// OpenShift uses the ClusterAutoscaler + MachineAutoscaler set up in SetUpInfra
-// to provision new nodes automatically when pods are Pending.
 func (r *OpenShiftRegion) CanScale() bool {
 	return true
 }
 
-// ─── CLUSTER PROVISIONING ────────────────────────────────────────────────────
-
-// shortInstallerName derives a ≤14-character name for install-config.yaml metadata.name.
-// OpenShift enforces this limit; our internal cluster names are much longer.
-// The last component of the cluster name is the random UniqueId (e.g. "ab12cd"),
-// so we prefix it with "ocp-" to get a unique, short, valid name.
+// OpenShift enforces a limit of ≤14-character name
 func shortInstallerName(clusterName string) string {
 	parts := strings.Split(clusterName, "-")
 	suffix := parts[len(parts)-1]
@@ -482,7 +431,7 @@ func (r *OpenShiftRegion) provisionCluster(
 		// Preserve the install directory (which contains the log bundle and
 		// .openshift_install.log) when SKIP_CLEANUP is set so the operator can
 		// inspect bootstrap diagnostics after a failure.
-		if os.Getenv("SKIP_CLEANUP") == "true" || os.Getenv("PRESERVE_INFRA_ON_FAILURE") == "true" {
+		if os.Getenv("SKIP_CLEANUP") == "true" {
 			t.Logf("[%s] Install dir preserved for debugging: %s", ProviderOpenShift, installDir)
 			t.Logf("[%s] Check for log bundle: %s/log-bundle-*.tar.gz", ProviderOpenShift, installDir)
 		} else {
@@ -496,8 +445,6 @@ func (r *OpenShiftRegion) provisionCluster(
 	// (e.g., the VPC is "<infraID>-network", not "<installerName>-network").
 	infraID, err := readOpenShiftInfraID(installDir)
 	if err != nil {
-		// Non-fatal: fall back to the installer name so VPC peering can still
-		// be attempted (it may fail gracefully if the name is wrong).
 		t.Logf("[%s] Warning: could not read infraID from metadata.json, using installer name %q: %v",
 			ProviderOpenShift, installerName, err)
 		infraID = installerName
@@ -524,8 +471,6 @@ func readOpenShiftInfraID(installDir string) (string, error) {
 	}
 	return meta.InfraID, nil
 }
-
-// ─── VPC PEERING ─────────────────────────────────────────────────────────────
 
 // setupOpenShiftVPCPeering creates bidirectional GCP VPC peering between the
 // two OpenShift cluster VPCs so that pods can reach each other cross-cluster.
@@ -663,20 +608,9 @@ func (r *OpenShiftRegion) setupOpenShiftVPCPeering(t *testing.T, projectID strin
 	return nil
 }
 
-// ─── SUBMARINER ──────────────────────────────────────────────────────────────
-
 // setupSubmariner installs Submariner on both clusters to provide cross-cluster
 // pod-to-pod networking. OpenShift uses OVN-Kubernetes overlay networking whose
-// pod IPs are not routable across VPC-peered networks by default. Submariner
-// creates IPsec tunnels between gateway nodes (which use routable machine IPs)
-// and programs OVN-K routing policies for remote pod CIDRs.
-//
-// Prerequisites (handled by setupOpenShiftVPCPeering):
-//   - VPC peering with ImportCustomRoutes/ExportCustomRoutes enabled
-//   - Firewall rule allowing ESP (IP protocol 50) for IPsec data plane
-//
-// This function is idempotent: if the submariner-operator namespace already
-// exists on cluster-0, setup is skipped.
+// pod IPs are not routable across VPC-peered networks by default.
 func (r *OpenShiftRegion) setupSubmariner(t *testing.T, kubeConfigPath string) error {
 	if len(r.Clusters) < 2 {
 		return nil
@@ -783,20 +717,7 @@ func (r *OpenShiftRegion) setupSubmariner(t *testing.T, kubeConfigPath string) e
 	return nil
 }
 
-// ─── CLUSTER AUTOSCALER ──────────────────────────────────────────────────────
-
-// setupClusterAutoscaler enables the OpenShift cluster autoscaler on each cluster,
-// mirroring GKE's --enable-autoscaling flag. This is required for TestClusterScaleUp:
-// when CockroachDB scales from 3 → 4 replicas, the 4th pod goes Pending (anti-affinity
-// prevents two pods per node), the autoscaler detects it and provisions a new node via
-// MachineSet — exactly the same flow as GKE node pool autoscaling.
-//
-// Two resources are created per cluster:
-//   - ClusterAutoscaler: watches for Pending pods and triggers scale-up/down
-//   - MachineAutoscaler: per MachineSet, sets min/max replicas (equivalent to
-//     GKE's --min-nodes/--max-nodes)
-//
-// This function is idempotent: kubectl apply is used throughout.
+// setupClusterAutoscaler enables the OpenShift cluster autoscaler on each cluster
 func (r *OpenShiftRegion) setupClusterAutoscaler(t *testing.T, kubeConfigPath string) error {
 	const clusterAutoscalerYAML = `apiVersion: autoscaling.openshift.io/v1
 kind: ClusterAutoscaler
@@ -868,16 +789,10 @@ spec:
 	return nil
 }
 
-// ─── COREDNS DEPLOYMENT ───────────────────────────────────────────────────────
-
 // deployAndConfigureOpenShiftCoreDNS deploys a custom CoreDNS instance to
-// kube-system on each cluster with an external LoadBalancer service. It then:
-//  1. Grants SCC permissions for the CoreDNS pods (OpenShift security).
-//  2. Waits for the external LB IP.
-//  3. Populates r.CorednsClusterOptions with those IPs.
-//  4. Applies the full cross-cluster Corefile to every cluster.
+// kube-system on each cluster with an external LoadBalancer service.
 func (r *OpenShiftRegion) deployAndConfigureOpenShiftCoreDNS(t *testing.T, kubeConfigPath string) error {
-	// Phase 1: deploy CoreDNS on each cluster and collect external LB IPs.
+	// deploy CoreDNS on each cluster and collect external LB IPs.
 	for i, clusterName := range r.Clusters {
 		t.Logf("[%s] Deploying custom CoreDNS on cluster %q", ProviderOpenShift, clusterName)
 
@@ -889,10 +804,6 @@ func (r *OpenShiftRegion) deployAndConfigureOpenShiftCoreDNS(t *testing.T, kubeC
 		}
 
 		// Grant anyuid SCC to the CoreDNS SA in kube-system so the pods can run.
-		// Must come after RBAC deployment so the SA exists.
-		// Use "kubectl create clusterrolebinding" instead of "oc adm policy add-scc-to-user":
-		// k8s.RunKubectlE prepends --context before the subcommand, which the oc adm
-		// plugin rejects with "flags cannot be placed before plugin name: --context".
 		if err := k8s.RunKubectlE(t, kubectlOpts,
 			"create", "clusterrolebinding", "crl-coredns-anyuid",
 			"--clusterrole=system:openshift:scc:anyuid",
@@ -922,17 +833,13 @@ func (r *OpenShiftRegion) deployAndConfigureOpenShiftCoreDNS(t *testing.T, kubeC
 		t.Logf("[%s] CoreDNS LB IPs for cluster %q: %v", ProviderOpenShift, clusterName, ips)
 	}
 
-	// Phase 2: update the Corefile on every cluster with the full cross-cluster config.
+	// update the Corefile on every cluster with the full cross-cluster config.
 	UpdateCoreDNSConfiguration(t, r.Region, kubeConfigPath)
 
 	return nil
 }
 
 // getCoreDNSClusterIP returns the ClusterIP of the crl-core-dns-internal service in kube-system.
-// This is a ClusterIP-only service exposing both UDP/53 and TCP/53 to the CoreDNS pods.
-// The DNS operator patch uses this IP so that the built-in OpenShift DNS can forward
-// queries via UDP (its default) to our custom CoreDNS. The LoadBalancer service
-// (crl-core-dns) is TCP-only due to GCP LB constraints and cannot be used here.
 func (r *OpenShiftRegion) getCoreDNSClusterIP(t *testing.T, clusterName, kubeConfigPath string) (string, error) {
 	kubectlOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, coreDNSNamespace)
 
@@ -955,8 +862,6 @@ func (r *OpenShiftRegion) getCoreDNSClusterIP(t *testing.T, clusterName, kubeCon
 	}
 	return clusterIP, nil
 }
-
-// ─── DNS ─────────────────────────────────────────────────────────────────────
 
 // patchOpenShiftDNSAllDomains patches the OpenShift DNS operator to forward ALL
 // custom cluster domains (cluster1.local, cluster2.local, …) to the local custom
@@ -1004,8 +909,6 @@ func (r *OpenShiftRegion) patchOpenShiftDNSAllDomains(
 	return nil
 }
 
-// ─── GCP COMPUTE CLIENT ──────────────────────────────────────────────────────
-
 // createOpenShiftComputeClient creates a GCP Compute Service client using
 // the same credential resolution as the GCP provider.
 func createOpenShiftComputeClient(ctx context.Context) (*compute.Service, error) {
@@ -1016,18 +919,9 @@ func createOpenShiftComputeClient(ctx context.Context) (*compute.Service, error)
 	return compute.NewService(ctx, opts...)
 }
 
-// ─── KUBECONFIG ──────────────────────────────────────────────────────────────
-
 // mergeOpenShiftKubeconfig merges the installer-generated kubeconfig into the
 // current user kubeconfig and renames the context to clusterAlias so the rest
 // of the test framework can reference it by name.
-//
-// Every OpenShift cluster generates a kubeconfig whose user is named "admin".
-// When multiple clusters are merged sequentially, the second cluster's "admin"
-// entry would silently overwrite the first cluster's credentials, breaking
-// authentication to the first cluster. To prevent this, we rename the user to
-// "admin-<clusterAlias>" in a temporary copy before merging so each cluster's
-// credentials coexist under distinct names.
 func mergeOpenShiftKubeconfig(t *testing.T, generatedKubeconfig, clusterAlias string) error {
 	// Determine destination kubeconfig path.
 	// KUBECONFIG may legally be a colon-separated list of paths; normalize to a
@@ -1141,8 +1035,6 @@ func renamedKubeconfigUser(src, oldName, newName string) (string, error) {
 	return tmpFile.Name(), nil
 }
 
-// ─── HELPERS ─────────────────────────────────────────────────────────────────
-
 // getOpenShiftProjectID returns the GCP project ID for OpenShift provisioning.
 func getOpenShiftProjectID() string {
 	if id := os.Getenv("GCP_PROJECT_ID"); id != "" {
@@ -1154,15 +1046,6 @@ func getOpenShiftProjectID() string {
 // installerEnv returns the environment slice for openshift-install commands.
 // It propagates the current environment and ensures the Go GCP client inside
 // openshift-install uses the correct service-account credentials.
-//
-// Credential handling:
-//   - If GOOGLE_CREDENTIALS is JSON content (CI "Mint mode"), strip
-//     GOOGLE_APPLICATION_CREDENTIALS so that ADC does not override it.
-//   - If GOOGLE_CREDENTIALS is a file path (local dev), replace
-//     GOOGLE_APPLICATION_CREDENTIALS with that path so that both Terraform
-//     and the Go GCP client (used for GCS bucket creation, etc.) use the
-//     same SA key.  Without this, the Go client falls back to ADC user
-//     credentials which may lack storage.buckets.create in the target project.
 func installerEnv() []string {
 	googleCreds := os.Getenv("GOOGLE_CREDENTIALS")
 	// isFilePath is true when GOOGLE_CREDENTIALS holds a file path rather than

--- a/tests/e2e/operator/infra/openshift.go
+++ b/tests/e2e/operator/infra/openshift.go
@@ -1,0 +1,1182 @@
+package infra
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+// ─── OPENSHIFT CONSTANTS ──────────────────────────────────────────────────────
+
+const (
+	// env vars consumed by openshift.go
+	envOpenShiftPullSecret = "OPENSHIFT_PULL_SECRET"
+	envOpenShiftSSHPubKey  = "OPENSHIFT_SSH_PUB_KEY"
+	envOpenShiftBaseDomain = "OPENSHIFT_BASE_DOMAIN"
+	// envOpenShiftInstallDir points to an existing openshift-install state directory.
+	// When set, SetUpInfra skips provisioning and reuses the existing cluster.
+	// Example: OPENSHIFT_INSTALL_DIR=/var/folders/.../ocp-ocp-0qaif4-2872850045
+	envOpenShiftInstallDir = "OPENSHIFT_INSTALL_DIR"
+	// envOpenShiftInstallDirs is a comma-separated list of existing openshift-install
+	// state directories, one per cluster in order. When set, SetUpInfra skips
+	// provisioning for all clusters and reuses the existing ones. VPC peering,
+	// CoreDNS, and DNS operator setup still run (they are idempotent).
+	// Example: OPENSHIFT_INSTALL_DIRS=/path/to/cluster-0,/path/to/cluster-1
+	envOpenShiftInstallDirs = "OPENSHIFT_INSTALL_DIRS"
+
+	// defaultOpenShiftProjectID is the GCP project used when GCP_PROJECT_ID is not set.
+	// TODO: Change this to "helm-testing" to match the GCP provider default and avoid
+	// accidental provisioning into a personal project when GCP_PROJECT_ID is unset.
+	defaultOpenShiftProjectID = "cockroach-shreyaskm"
+
+	// maxInstallerNameLen is the maximum length of the cluster name in install-config.yaml.
+	// OpenShift enforces a 14-character limit on metadata.name.
+	maxInstallerNameLen = 14
+)
+
+// openShiftNetworkConfig holds per-cluster network CIDR configuration.
+// Two clusters must use non-overlapping ranges so VPC peering routes are unambiguous.
+type openShiftNetworkConfig struct {
+	MachineCIDR    string
+	ClusterNetwork string
+	HostPrefix     int
+	ServiceNetwork string
+}
+
+// openShiftNetworkConfigs defines non-overlapping CIDRs for each cluster index.
+// Index 0 → us-central1 cluster, index 1 → us-east1 cluster.
+var openShiftNetworkConfigs = []openShiftNetworkConfig{
+	{
+		MachineCIDR:    "10.0.0.0/16",
+		ClusterNetwork: "10.128.0.0/14",
+		HostPrefix:     23,
+		ServiceNetwork: "172.30.0.0/16",
+	},
+	{
+		MachineCIDR:    "10.1.0.0/16",
+		ClusterNetwork: "10.132.0.0/14",
+		HostPrefix:     23,
+		ServiceNetwork: "172.31.0.0/16",
+	},
+}
+
+// installConfigTemplate is the install-config.yaml template for openshift-install.
+// It includes explicit networking ranges so that two clusters in the same GCP project
+// use non-overlapping pod/service CIDRs, enabling VPC peering.
+var installConfigTemplate = template.Must(template.New("install-config").Parse(`apiVersion: v1
+baseDomain: {{ .BaseDomain }}
+metadata:
+  name: {{ .ClusterName }}
+compute:
+  - architecture: amd64
+    hyperthreading: Enabled
+    name: worker
+    platform: {}
+    replicas: 3
+controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
+  name: master
+  platform: {}
+  replicas: 3
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+    - cidr: {{ .MachineCIDR }}
+  clusterNetwork:
+    - cidr: {{ .ClusterNetwork }}
+      hostPrefix: {{ .HostPrefix }}
+  serviceNetwork:
+    - {{ .ServiceNetwork }}
+platform:
+  gcp:
+    projectID: {{ .ProjectID }}
+    region: {{ .Region }}
+pullSecret: '{{ .PullSecret }}'
+sshKey: {{ .SSHPubKey }}
+`))
+
+type installConfigData struct {
+	BaseDomain     string
+	ClusterName    string
+	ProjectID      string
+	Region         string
+	PullSecret     string
+	SSHPubKey      string
+	MachineCIDR    string
+	ClusterNetwork string
+	HostPrefix     int
+	ServiceNetwork string
+}
+
+// ─── OPENSHIFT REGION ─────────────────────────────────────────────────────────
+
+// openShiftMetadata mirrors the fields we need from the metadata.json file
+// that openshift-install writes to the install directory after provisioning.
+type openShiftMetadata struct {
+	InfraID string `json:"infraID"`
+}
+
+// OpenShiftRegion implements CloudProvider for OpenShift clusters on GCP,
+// provisioned via openshift-install.
+type OpenShiftRegion struct {
+	*operator.Region
+	// installDirs maps cluster name → temp directory that holds install-config.yaml
+	// and all state produced by openshift-install (auth/kubeconfig, terraform state, etc.)
+	installDirs map[string]string
+	// provisionedInstallDirs is the subset of installDirs that this test actually
+	// provisioned (i.e. not provided via OPENSHIFT_INSTALL_DIR/OPENSHIFT_INSTALL_DIRS).
+	// TeardownInfra only destroys and removes directories in this set, leaving
+	// user-provided reuse directories untouched.
+	provisionedInstallDirs map[string]bool
+	// infraIDs maps cluster name → the infraID written to metadata.json by openshift-install.
+	// OpenShift creates the VPC as "<infraID>-network" — this differs from the
+	// metadata.name (installer name) which is the shorter user-supplied cluster name.
+	infraIDs map[string]string
+}
+
+// SetUpInfra provisions one OpenShift cluster per entry in r.Clusters.
+// For single-region tests there is exactly one cluster.
+//
+// Cluster reuse modes (skip provisioning):
+//   - OPENSHIFT_INSTALL_DIRS: comma-separated list of existing openshift-install
+//     state directories, one per cluster in order. VPC peering, CoreDNS, and DNS
+//     operator setup still run (they are idempotent). Use this for multi-region.
+//   - OPENSHIFT_INSTALL_DIR: single directory for single-region reuse.
+func (r *OpenShiftRegion) SetUpInfra(t *testing.T) {
+	if r.ReusingInfra {
+		t.Logf("[%s] Reusing existing infrastructure, skipping setup", ProviderOpenShift)
+		return
+	}
+	r.installDirs = make(map[string]string)
+	r.provisionedInstallDirs = make(map[string]bool)
+	r.infraIDs = make(map[string]string)
+	r.Clients = make(map[string]client.Client)
+	r.CorednsClusterOptions = make(map[string]coredns.CoreDNSClusterOption)
+
+	reuseDirsEnv := os.Getenv(envOpenShiftInstallDirs)
+	reuseDir := os.Getenv(envOpenShiftInstallDir)
+
+	switch {
+	case reuseDirsEnv != "":
+		// Multi-region reuse: OPENSHIFT_INSTALL_DIRS is a comma-separated list of
+		// existing install directories, one per cluster in order.
+		// Provisioning is skipped; infraIDs are read from each metadata.json.
+		// VPC peering, CoreDNS, and DNS operator setup still run (idempotent).
+		dirs := splitTrimmed(reuseDirsEnv)
+		if len(dirs) != len(r.Clusters) {
+			t.Fatalf("[%s] OPENSHIFT_INSTALL_DIRS has %d entries but %d clusters expected",
+				ProviderOpenShift, len(dirs), len(r.Clusters))
+		}
+		t.Logf("[%s] Reusing %d existing clusters from OPENSHIFT_INSTALL_DIRS", ProviderOpenShift, len(dirs))
+		for i, clusterName := range r.Clusters {
+			installDir := dirs[i]
+			r.installDirs[clusterName] = installDir
+
+			infraID, err := readOpenShiftInfraID(installDir)
+			if err != nil {
+				t.Fatalf("[%s] Failed to read infraID for cluster %q from %s: %v",
+					ProviderOpenShift, clusterName, installDir, err)
+			}
+			r.infraIDs[clusterName] = infraID
+			t.Logf("[%s] Cluster %q infraID: %q (reused)", ProviderOpenShift, clusterName, infraID)
+
+			generatedKubeconfig := filepath.Join(installDir, "auth", "kubeconfig")
+			if err := mergeOpenShiftKubeconfig(t, generatedKubeconfig, clusterName); err != nil {
+				t.Fatalf("[%s] Failed to merge kubeconfig for %q: %v", ProviderOpenShift, clusterName, err)
+			}
+			restCfg, err := config.GetConfigWithContext(clusterName)
+			if err != nil {
+				t.Fatalf("[%s] Failed to get rest config for %q: %v", ProviderOpenShift, clusterName, err)
+			}
+			k8sClient, err := client.New(restCfg, client.Options{})
+			if err != nil {
+				t.Fatalf("[%s] Failed to create k8s client for %q: %v", ProviderOpenShift, clusterName, err)
+			}
+			r.Clients[clusterName] = k8sClient
+			t.Logf("[%s] Cluster %q client ready (reused)", ProviderOpenShift, clusterName)
+		}
+		// Fall through to VPC peering + CoreDNS + DNS operator setup below.
+
+	case reuseDir != "":
+		// Single-region reuse: existing OPENSHIFT_INSTALL_DIR behavior.
+		t.Logf("[%s] Reusing existing cluster from OPENSHIFT_INSTALL_DIR=%s", ProviderOpenShift, reuseDir)
+		clusterName := r.Clusters[0]
+		r.installDirs[clusterName] = reuseDir
+
+		generatedKubeconfig := filepath.Join(reuseDir, "auth", "kubeconfig")
+		if err := mergeOpenShiftKubeconfig(t, generatedKubeconfig, clusterName); err != nil {
+			t.Fatalf("[%s] Failed to merge kubeconfig for %q: %v", ProviderOpenShift, clusterName, err)
+		}
+		restCfg, err := config.GetConfigWithContext(clusterName)
+		if err != nil {
+			t.Fatalf("[%s] Failed to get rest config for %q: %v", ProviderOpenShift, clusterName, err)
+		}
+		k8sClient, err := client.New(restCfg, client.Options{})
+		if err != nil {
+			t.Fatalf("[%s] Failed to create k8s client for %q: %v", ProviderOpenShift, clusterName, err)
+		}
+		r.Clients[clusterName] = k8sClient
+		t.Logf("[%s] Cluster %q client ready (reused)", ProviderOpenShift, clusterName)
+		// Fall through to the common post-setup block below (DNS patching, autoscaler)
+		// so single-cluster reuse behaves identically to fresh provisioning.
+
+	default:
+		// Fresh provisioning.
+		pullSecret := mustEnv(t, envOpenShiftPullSecret)
+		sshPubKey := mustEnv(t, envOpenShiftSSHPubKey)
+		baseDomain := mustEnv(t, envOpenShiftBaseDomain)
+		projectID := getOpenShiftProjectID()
+
+		for i, clusterName := range r.Clusters {
+			regionCode := r.RegionCodes[i]
+			t.Logf("[%s] Provisioning cluster %q in region %s (project %s)", ProviderOpenShift, clusterName, regionCode, projectID)
+
+			netCfg := openShiftNetworkConfigs[0]
+			if i < len(openShiftNetworkConfigs) {
+				netCfg = openShiftNetworkConfigs[i]
+			}
+
+			installDir, infraID, err := r.provisionCluster(t, clusterName, regionCode, projectID, baseDomain, pullSecret, sshPubKey, netCfg)
+			if err != nil {
+				t.Fatalf("[%s] Failed to provision cluster %q: %v", ProviderOpenShift, clusterName, err)
+			}
+			r.installDirs[clusterName] = installDir
+			r.provisionedInstallDirs[clusterName] = true
+			r.infraIDs[clusterName] = infraID
+
+			generatedKubeconfig := filepath.Join(installDir, "auth", "kubeconfig")
+			if err := mergeOpenShiftKubeconfig(t, generatedKubeconfig, clusterName); err != nil {
+				t.Fatalf("[%s] Failed to merge kubeconfig for %q: %v", ProviderOpenShift, clusterName, err)
+			}
+			restCfg, err := config.GetConfigWithContext(clusterName)
+			if err != nil {
+				t.Fatalf("[%s] Failed to get rest config for %q: %v", ProviderOpenShift, clusterName, err)
+			}
+			k8sClient, err := client.New(restCfg, client.Options{})
+			if err != nil {
+				t.Fatalf("[%s] Failed to create k8s client for %q: %v", ProviderOpenShift, clusterName, err)
+			}
+			r.Clients[clusterName] = k8sClient
+			t.Logf("[%s] Cluster %q is ready", ProviderOpenShift, clusterName)
+
+			if !r.IsMultiRegion {
+				break
+			}
+		}
+	}
+
+	// Common: VPC peering, CoreDNS deployment, and DNS operator patching.
+	kubeConfigPath, err := r.EnsureKubeConfigPath()
+	require.NoError(t, err)
+
+	if r.IsMultiRegion {
+		if err := r.setupOpenShiftVPCPeering(t, getOpenShiftProjectID()); err != nil {
+			t.Fatalf("[%s] Failed to set up VPC peering: %v", ProviderOpenShift, err)
+		}
+
+		if err := r.deployAndConfigureOpenShiftCoreDNS(t, kubeConfigPath); err != nil {
+			t.Fatalf("[%s] Failed to deploy CoreDNS: %v", ProviderOpenShift, err)
+		}
+
+		// Patch each cluster's DNS operator to forward ALL custom cluster domains
+		// to the local custom CoreDNS ClusterIP.
+		var allDomains []string
+		for j := range r.Clusters {
+			allDomains = append(allDomains, operator.CustomDomains[j])
+		}
+
+		for _, clusterName := range r.Clusters {
+			clusterIP, err := r.getCoreDNSClusterIP(t, clusterName, kubeConfigPath)
+			if err != nil {
+				t.Fatalf("[%s] Failed to get CoreDNS ClusterIP for cluster %q: %v", ProviderOpenShift, clusterName, err)
+			}
+			if err := r.patchOpenShiftDNSAllDomains(t, clusterName, kubeConfigPath, allDomains, clusterIP); err != nil {
+				t.Fatalf("[%s] Failed to patch DNS operator on cluster %q: %v", ProviderOpenShift, clusterName, err)
+			}
+		}
+
+		// Set up Submariner for cross-cluster pod networking.
+		// OVN-K overlay pod IPs are not routable across VPC peering without this.
+		if err := r.setupSubmariner(t, kubeConfigPath); err != nil {
+			t.Fatalf("[%s] Failed to set up Submariner: %v", ProviderOpenShift, err)
+		}
+
+		// Enable cluster autoscaler so TestClusterScaleUp can schedule the 4th
+		// CockroachDB pod on a new node (mirrors GKE's --enable-autoscaling).
+		if err := r.setupClusterAutoscaler(t, kubeConfigPath); err != nil {
+			t.Fatalf("[%s] Failed to set up cluster autoscaler: %v", ProviderOpenShift, err)
+		}
+	} else {
+		// Single-region: the charts use the cluster's default domain (cluster.local),
+		// which the OpenShift DNS operator already handles natively. Forwarding
+		// cluster1.local → dns-default would create a self-referential loop, so we
+		// skip DNS patching entirely here.
+
+		// Enable cluster autoscaler so TestClusterScaleUp can schedule the 4th
+		// CockroachDB pod on a new node (mirrors GKE's --enable-autoscaling).
+		if err := r.setupClusterAutoscaler(t, kubeConfigPath); err != nil {
+			t.Fatalf("[%s] Failed to set up cluster autoscaler: %v", ProviderOpenShift, err)
+		}
+	}
+
+	r.ReusingInfra = true
+	t.Logf("[%s] Infrastructure setup complete", ProviderOpenShift)
+}
+
+// TeardownInfra destroys all provisioned OpenShift clusters.
+// openshift-install destroy cluster handles all GCP resource cleanup automatically.
+// Clusters that were reused via OPENSHIFT_INSTALL_DIR/OPENSHIFT_INSTALL_DIRS are
+// left untouched — only clusters this test provisioned itself are destroyed.
+func (r *OpenShiftRegion) TeardownInfra(t *testing.T) {
+	t.Logf("[%s] Starting infrastructure teardown", ProviderOpenShift)
+
+	for clusterName, installDir := range r.installDirs {
+		if !r.provisionedInstallDirs[clusterName] {
+			t.Logf("[%s] Skipping teardown for reused cluster %q (not provisioned by this test)", ProviderOpenShift, clusterName)
+			continue
+		}
+
+		t.Logf("[%s] Destroying cluster %q", ProviderOpenShift, clusterName)
+
+		cmd := exec.Command("openshift-install", "destroy", "cluster",
+			"--dir", installDir,
+			"--log-level", "info",
+		)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		if err := cmd.Run(); err != nil {
+			// Log but don't fatal — best-effort cleanup.
+			t.Logf("[%s] Warning: destroy cluster %q failed: %v", ProviderOpenShift, clusterName, err)
+		} else {
+			t.Logf("[%s] Cluster %q destroyed successfully", ProviderOpenShift, clusterName)
+		}
+
+		// Remove the temp install directory regardless of destroy outcome.
+		if err := os.RemoveAll(installDir); err != nil {
+			t.Logf("[%s] Warning: failed to remove install dir %s: %v", ProviderOpenShift, installDir, err)
+		}
+	}
+
+	t.Logf("[%s] Infrastructure teardown complete", ProviderOpenShift)
+}
+
+// ScaleNodePool is a no-op for OpenShift: the ClusterAutoscaler provisioned
+// in SetUpInfra handles node scaling transparently when pods are Pending.
+func (r *OpenShiftRegion) ScaleNodePool(t *testing.T, location string, nodeCount, index int) {
+	t.Logf("[%s] Node pool scaling delegated to ClusterAutoscaler (no explicit action needed)", ProviderOpenShift)
+}
+
+// CanScale reports whether this provider supports scaling.
+// OpenShift uses the ClusterAutoscaler + MachineAutoscaler set up in SetUpInfra
+// to provision new nodes automatically when pods are Pending.
+func (r *OpenShiftRegion) CanScale() bool {
+	return true
+}
+
+// ─── CLUSTER PROVISIONING ────────────────────────────────────────────────────
+
+// shortInstallerName derives a ≤14-character name for install-config.yaml metadata.name.
+// OpenShift enforces this limit; our internal cluster names are much longer.
+// The last component of the cluster name is the random UniqueId (e.g. "ab12cd"),
+// so we prefix it with "ocp-" to get a unique, short, valid name.
+func shortInstallerName(clusterName string) string {
+	parts := strings.Split(clusterName, "-")
+	suffix := parts[len(parts)-1]
+	name := "ocp-" + suffix
+	if len(name) > maxInstallerNameLen {
+		name = name[:maxInstallerNameLen]
+	}
+	return strings.TrimRight(name, "-")
+}
+
+// provisionCluster writes an install-config.yaml and runs openshift-install create cluster.
+// Returns the install directory path and the infraID (read from metadata.json) on success.
+// The infraID is used to construct GCP resource names such as "<infraID>-network".
+func (r *OpenShiftRegion) provisionCluster(
+	t *testing.T,
+	clusterName, region, projectID, baseDomain, pullSecret, sshPubKey string,
+	netCfg openShiftNetworkConfig,
+) (string, string, error) {
+	// OpenShift metadata.name must be ≤14 chars; derive a short name from the
+	// random suffix of the full cluster name.
+	installerName := shortInstallerName(clusterName)
+	t.Logf("[%s] Using installer name %q for cluster %q", ProviderOpenShift, installerName, clusterName)
+	// Create a temp directory to hold all installer state.
+	installDir, err := os.MkdirTemp("", fmt.Sprintf("ocp-%s-*", installerName))
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create install dir: %w", err)
+	}
+
+	// Write install-config.yaml.
+	configPath := filepath.Join(installDir, "install-config.yaml")
+	f, err := os.Create(configPath)
+	if err != nil {
+		_ = os.RemoveAll(installDir)
+		return "", "", fmt.Errorf("failed to create install-config.yaml: %w", err)
+	}
+
+	data := installConfigData{
+		BaseDomain:     baseDomain,
+		ClusterName:    installerName,
+		ProjectID:      projectID,
+		Region:         region,
+		PullSecret:     pullSecret,
+		SSHPubKey:      sshPubKey,
+		MachineCIDR:    netCfg.MachineCIDR,
+		ClusterNetwork: netCfg.ClusterNetwork,
+		HostPrefix:     netCfg.HostPrefix,
+		ServiceNetwork: netCfg.ServiceNetwork,
+	}
+	if err := installConfigTemplate.Execute(f, data); err != nil {
+		f.Close()
+		_ = os.RemoveAll(installDir)
+		return "", "", fmt.Errorf("failed to render install-config.yaml: %w", err)
+	}
+	f.Close()
+
+	t.Logf("[%s] Running: openshift-install create cluster --dir=%s", ProviderOpenShift, installDir)
+
+	cmd := exec.Command("openshift-install", "create", "cluster",
+		"--dir", installDir,
+		"--log-level", "info",
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	// Clear GOOGLE_APPLICATION_CREDENTIALS from the installer environment so
+	// that ADC does not take precedence over GOOGLE_CREDENTIALS (Mint mode),
+	// which is expected to be set in the CI environment.
+	cmd.Env = installerEnv()
+
+	if err := cmd.Run(); err != nil {
+		// Attempt cleanup before returning the error.
+		t.Logf("[%s] openshift-install failed, attempting destroy cluster for cleanup", ProviderOpenShift)
+		destroyCmd := exec.Command("openshift-install", "destroy", "cluster",
+			"--dir", installDir, "--log-level", "warn")
+		destroyCmd.Stdout = os.Stdout
+		destroyCmd.Stderr = os.Stderr
+		destroyCmd.Env = installerEnv()
+		_ = destroyCmd.Run()
+		_ = os.RemoveAll(installDir)
+		return "", "", fmt.Errorf("openshift-install create cluster failed: %w", err)
+	}
+
+	// Read the infraID from metadata.json that openshift-install writes.
+	// This is the authoritative ID used by OpenShift to name GCP resources
+	// (e.g., the VPC is "<infraID>-network", not "<installerName>-network").
+	infraID, err := readOpenShiftInfraID(installDir)
+	if err != nil {
+		// Non-fatal: fall back to the installer name so VPC peering can still
+		// be attempted (it may fail gracefully if the name is wrong).
+		t.Logf("[%s] Warning: could not read infraID from metadata.json, using installer name %q: %v",
+			ProviderOpenShift, installerName, err)
+		infraID = installerName
+	}
+	t.Logf("[%s] Cluster %q infraID: %q", ProviderOpenShift, clusterName, infraID)
+
+	return installDir, infraID, nil
+}
+
+// readOpenShiftInfraID reads the infraID field from the metadata.json file
+// that openshift-install writes to the install directory after provisioning.
+func readOpenShiftInfraID(installDir string) (string, error) {
+	metadataPath := filepath.Join(installDir, "metadata.json")
+	data, err := os.ReadFile(metadataPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read metadata.json: %w", err)
+	}
+	var meta openShiftMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return "", fmt.Errorf("failed to parse metadata.json: %w", err)
+	}
+	if meta.InfraID == "" {
+		return "", fmt.Errorf("infraID is empty in metadata.json")
+	}
+	return meta.InfraID, nil
+}
+
+// ─── VPC PEERING ─────────────────────────────────────────────────────────────
+
+// setupOpenShiftVPCPeering creates bidirectional GCP VPC peering between the
+// two OpenShift cluster VPCs so that pods can reach each other cross-cluster.
+// OpenShift names each cluster's VPC "<infraID>-network" where infraID is read
+// from metadata.json after provisioning.
+func (r *OpenShiftRegion) setupOpenShiftVPCPeering(t *testing.T, projectID string) error {
+	if len(r.Clusters) < 2 {
+		return nil
+	}
+
+	infraID0 := r.infraIDs[r.Clusters[0]]
+	infraID1 := r.infraIDs[r.Clusters[1]]
+	vpc0Name := infraID0 + "-network"
+	vpc1Name := infraID1 + "-network"
+
+	t.Logf("[%s] Setting up VPC peering: %q ↔ %q", ProviderOpenShift, vpc0Name, vpc1Name)
+
+	ctx := context.Background()
+	computeService, err := createOpenShiftComputeClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create compute client: %w", err)
+	}
+
+	vpc0SelfLink := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/networks/%s", projectID, vpc0Name)
+	vpc1SelfLink := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/networks/%s", projectID, vpc1Name)
+
+	// Peer vpc0 → vpc1.
+	peerName01 := fmt.Sprintf("peer-%s-to-%s", infraID0, infraID1)
+	if len(peerName01) > 63 {
+		peerName01 = peerName01[:63]
+	}
+	peering01 := &compute.NetworkPeering{
+		Name:                 peerName01,
+		Network:              vpc1SelfLink,
+		ExchangeSubnetRoutes: true,
+		ImportCustomRoutes:   true,
+		ExportCustomRoutes:   true,
+	}
+	op01, err := computeService.Networks.AddPeering(projectID, vpc0Name, &compute.NetworksAddPeeringRequest{
+		NetworkPeering: peering01,
+	}).Context(ctx).Do()
+	if err != nil && IsResourceConflict(err) {
+		// Peering already exists — update it to ensure custom routes are enabled.
+		op01, err = computeService.Networks.UpdatePeering(projectID, vpc0Name, &compute.NetworksUpdatePeeringRequest{
+			NetworkPeering: peering01,
+		}).Context(ctx).Do()
+	}
+	if err != nil {
+		return fmt.Errorf("failed to create/update peering %s→%s: %w", vpc0Name, vpc1Name, err)
+	}
+	if op01 != nil {
+		waitForGlobalComputeOperation(ctx, computeService, projectID, op01.Name)
+	}
+	t.Logf("[%s] Peering %s→%s created/updated (ImportCustomRoutes=true, ExportCustomRoutes=true)", ProviderOpenShift, vpc0Name, vpc1Name)
+
+	// Peer vpc1 → vpc0.
+	peerName10 := fmt.Sprintf("peer-%s-to-%s", infraID1, infraID0)
+	if len(peerName10) > 63 {
+		peerName10 = peerName10[:63]
+	}
+	peering10 := &compute.NetworkPeering{
+		Name:                 peerName10,
+		Network:              vpc0SelfLink,
+		ExchangeSubnetRoutes: true,
+		ImportCustomRoutes:   true,
+		ExportCustomRoutes:   true,
+	}
+	op10, err := computeService.Networks.AddPeering(projectID, vpc1Name, &compute.NetworksAddPeeringRequest{
+		NetworkPeering: peering10,
+	}).Context(ctx).Do()
+	if err != nil && IsResourceConflict(err) {
+		// Peering already exists — update it to ensure custom routes are enabled.
+		op10, err = computeService.Networks.UpdatePeering(projectID, vpc1Name, &compute.NetworksUpdatePeeringRequest{
+			NetworkPeering: peering10,
+		}).Context(ctx).Do()
+	}
+	if err != nil {
+		return fmt.Errorf("failed to create/update peering %s→%s: %w", vpc1Name, vpc0Name, err)
+	}
+	if op10 != nil {
+		waitForGlobalComputeOperation(ctx, computeService, projectID, op10.Name)
+	}
+	t.Logf("[%s] Peering %s→%s created/updated (ImportCustomRoutes=true, ExportCustomRoutes=true)", ProviderOpenShift, vpc1Name, vpc0Name)
+
+	// Add firewall rules on each VPC to allow traffic from the other cluster's
+	// machine and pod CIDRs on all TCP/UDP ports (CockroachDB needs 26257).
+	for i, clusterName := range r.Clusters {
+		if i >= len(openShiftNetworkConfigs) {
+			break
+		}
+		// The "other" cluster index and its network config.
+		other := 1 - i
+		if other >= len(openShiftNetworkConfigs) {
+			break
+		}
+		otherNet := openShiftNetworkConfigs[other]
+		infraID := r.infraIDs[clusterName]
+		vpcName := infraID + "-network"
+		vpcSelfLink := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/networks/%s", projectID, vpcName)
+
+		ruleName := fmt.Sprintf("%s-allow-peer", infraID)
+		if len(ruleName) > 63 {
+			ruleName = ruleName[:63]
+		}
+
+		// Source ranges: other cluster's machine CIDR + pod CIDR.
+		sources := []string{otherNet.MachineCIDR, otherNet.ClusterNetwork}
+		fw := &compute.Firewall{
+			Name:    ruleName,
+			Network: vpcSelfLink,
+			Allowed: []*compute.FirewallAllowed{
+				{IPProtocol: "tcp"},
+				{IPProtocol: "udp"},
+				{IPProtocol: "icmp"},
+				// ESP (IP protocol 50) is required for Submariner's IPsec data plane tunnel.
+				// GCP drops ESP by default; without this, cross-cluster pod networking fails.
+				{IPProtocol: "esp"},
+			},
+			SourceRanges: sources,
+			Direction:    "INGRESS",
+		}
+		_, fwErr := computeService.Firewalls.Insert(projectID, fw).Context(ctx).Do()
+		if fwErr != nil && IsResourceConflict(fwErr) {
+			// Rule already exists — update it to ensure ESP is included.
+			_, fwErr = computeService.Firewalls.Update(projectID, ruleName, fw).Context(ctx).Do()
+		}
+		if fwErr != nil {
+			t.Logf("[%s] Warning: failed to add/update cross-cluster firewall rule on %s: %v", ProviderOpenShift, vpcName, fwErr)
+		} else {
+			t.Logf("[%s] Cross-cluster firewall rule added/updated on %s (sources: %s, ESP enabled)", ProviderOpenShift, vpcName, strings.Join(sources, ", "))
+		}
+	}
+
+	t.Logf("[%s] VPC peering setup complete", ProviderOpenShift)
+	return nil
+}
+
+// ─── SUBMARINER ──────────────────────────────────────────────────────────────
+
+// setupSubmariner installs Submariner on both clusters to provide cross-cluster
+// pod-to-pod networking. OpenShift uses OVN-Kubernetes overlay networking whose
+// pod IPs are not routable across VPC-peered networks by default. Submariner
+// creates IPsec tunnels between gateway nodes (which use routable machine IPs)
+// and programs OVN-K routing policies for remote pod CIDRs.
+//
+// Prerequisites (handled by setupOpenShiftVPCPeering):
+//   - VPC peering with ImportCustomRoutes/ExportCustomRoutes enabled
+//   - Firewall rule allowing ESP (IP protocol 50) for IPsec data plane
+//
+// This function is idempotent: if the submariner-operator namespace already
+// exists on cluster-0, setup is skipped.
+func (r *OpenShiftRegion) setupSubmariner(t *testing.T, kubeConfigPath string) error {
+	if len(r.Clusters) < 2 {
+		return nil
+	}
+
+	// Verify subctl is available.
+	if _, err := exec.LookPath("subctl"); err != nil {
+		return fmt.Errorf("subctl not found in PATH — install from https://github.com/submariner-io/subctl/releases: %w", err)
+	}
+
+	// Idempotency: skip if Submariner is already installed on cluster-0.
+	kubectlOpts0 := k8s.NewKubectlOptions(r.Clusters[0], kubeConfigPath, "")
+	if _, err := k8s.RunKubectlAndGetOutputE(t, kubectlOpts0,
+		"get", "namespace", "submariner-operator"); err == nil {
+		t.Logf("[%s] Submariner already installed (submariner-operator namespace exists), skipping", ProviderOpenShift)
+		return nil
+	}
+
+	// Label one gateway node per cluster before joining.
+	// subctl join requires a gateway-labeled node to avoid interactive prompts.
+	for _, clusterName := range r.Clusters {
+		kubectlOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, "")
+		output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOpts,
+			"get", "nodes",
+			"-l", "node-role.kubernetes.io/worker",
+			"--no-headers",
+			"-o", "custom-columns=NAME:.metadata.name")
+		if err != nil {
+			return fmt.Errorf("failed to list worker nodes for cluster %s: %w", clusterName, err)
+		}
+		nodes := strings.Fields(strings.TrimSpace(output))
+		if len(nodes) == 0 {
+			return fmt.Errorf("no worker nodes found for cluster %s", clusterName)
+		}
+		gatewayNode := nodes[0]
+		t.Logf("[%s] Labeling gateway node %s on cluster %s", ProviderOpenShift, gatewayNode, clusterName)
+		if err := k8s.RunKubectlE(t, kubectlOpts,
+			"label", "node", gatewayNode, "submariner.io/gateway=true", "--overwrite"); err != nil {
+			return fmt.Errorf("failed to label gateway node on cluster %s: %w", clusterName, err)
+		}
+	}
+
+	// Use a temp directory so broker-info.subm is written to a known location.
+	brokerDir, err := os.MkdirTemp("", "submariner-broker-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp dir for Submariner broker info: %w", err)
+	}
+	defer os.RemoveAll(brokerDir)
+
+	// Deploy Submariner broker on cluster-0. This writes broker-info.subm to brokerDir.
+	cluster0 := r.Clusters[0]
+	t.Logf("[%s] Deploying Submariner broker on cluster %s", ProviderOpenShift, cluster0)
+	brokerCmd := exec.Command("subctl", "deploy-broker",
+		"--context", cluster0,
+		"--kubeconfig", kubeConfigPath,
+	)
+	brokerCmd.Dir = brokerDir
+	brokerCmd.Stdout = os.Stdout
+	brokerCmd.Stderr = os.Stderr
+	if err := brokerCmd.Run(); err != nil {
+		return fmt.Errorf("subctl deploy-broker failed on cluster %s: %w", cluster0, err)
+	}
+
+	brokerInfoPath := filepath.Join(brokerDir, "broker-info.subm")
+
+	// Join each cluster to the broker.
+	// --natt=false: both clusters are in the same GCP project; no NAT traversal needed.
+	// --globalnet=false: pod CIDRs are non-overlapping; no global IP remapping needed.
+	for _, clusterName := range r.Clusters {
+		t.Logf("[%s] Joining cluster %s to Submariner", ProviderOpenShift, clusterName)
+		joinCmd := exec.Command("subctl", "join", brokerInfoPath,
+			"--context", clusterName,
+			"--kubeconfig", kubeConfigPath,
+			"--natt=false",
+			"--globalnet=false",
+		)
+		joinCmd.Dir = brokerDir
+		joinCmd.Stdout = os.Stdout
+		joinCmd.Stderr = os.Stderr
+		if err := joinCmd.Run(); err != nil {
+			return fmt.Errorf("subctl join failed for cluster %s: %w", clusterName, err)
+		}
+	}
+
+	// Wait for the Submariner gateway DaemonSet to be ready on both clusters.
+	// This confirms the IPsec tunnels are up and cross-cluster pod routing is active.
+	for _, clusterName := range r.Clusters {
+		kubectlOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, "submariner-operator")
+		t.Logf("[%s] Waiting for Submariner gateway to be ready on cluster %s", ProviderOpenShift, clusterName)
+		_, err := retry.DoWithRetryE(t,
+			fmt.Sprintf("wait for submariner-gateway DaemonSet on %s", clusterName),
+			30, 20*time.Second,
+			func() (string, error) {
+				return k8s.RunKubectlAndGetOutputE(t, kubectlOpts,
+					"rollout", "status", "daemonset/submariner-gateway", "--timeout=15s")
+			})
+		if err != nil {
+			return fmt.Errorf("Submariner gateway not ready on cluster %s: %w", clusterName, err)
+		}
+		t.Logf("[%s] Submariner gateway ready on cluster %s", ProviderOpenShift, clusterName)
+	}
+
+	t.Logf("[%s] Submariner setup complete — cross-cluster pod networking active", ProviderOpenShift)
+	return nil
+}
+
+// ─── CLUSTER AUTOSCALER ──────────────────────────────────────────────────────
+
+// setupClusterAutoscaler enables the OpenShift cluster autoscaler on each cluster,
+// mirroring GKE's --enable-autoscaling flag. This is required for TestClusterScaleUp:
+// when CockroachDB scales from 3 → 4 replicas, the 4th pod goes Pending (anti-affinity
+// prevents two pods per node), the autoscaler detects it and provisions a new node via
+// MachineSet — exactly the same flow as GKE node pool autoscaling.
+//
+// Two resources are created per cluster:
+//   - ClusterAutoscaler: watches for Pending pods and triggers scale-up/down
+//   - MachineAutoscaler: per MachineSet, sets min/max replicas (equivalent to
+//     GKE's --min-nodes/--max-nodes)
+//
+// This function is idempotent: kubectl apply is used throughout.
+func (r *OpenShiftRegion) setupClusterAutoscaler(t *testing.T, kubeConfigPath string) error {
+	const clusterAutoscalerYAML = `apiVersion: autoscaling.openshift.io/v1
+kind: ClusterAutoscaler
+metadata:
+  name: default
+spec:
+  resourceLimits:
+    maxNodesTotal: 10
+  scaleDown:
+    enabled: true
+    delayAfterAdd: 10m
+    unneededTime: 5m`
+
+	for _, clusterName := range r.Clusters {
+		t.Logf("[%s] Setting up cluster autoscaler on cluster %s", ProviderOpenShift, clusterName)
+
+		// Apply the ClusterAutoscaler resource.
+		clusterOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, "")
+		if err := k8s.KubectlApplyFromStringE(t, clusterOpts, clusterAutoscalerYAML); err != nil {
+			return fmt.Errorf("failed to apply ClusterAutoscaler on cluster %s: %w", clusterName, err)
+		}
+		t.Logf("[%s] ClusterAutoscaler applied on cluster %s", ProviderOpenShift, clusterName)
+
+		// List MachineSets to create a MachineAutoscaler for each active one.
+		machineOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, "openshift-machine-api")
+		output, err := k8s.RunKubectlAndGetOutputE(t, machineOpts,
+			"get", "machinesets",
+			"--no-headers",
+			"-o", "custom-columns=NAME:.metadata.name,REPLICAS:.spec.replicas")
+		if err != nil {
+			return fmt.Errorf("failed to list MachineSets for cluster %s: %w", clusterName, err)
+		}
+
+		for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) < 2 {
+				continue
+			}
+			msName := fields[0]
+			msReplicas := fields[1]
+			// Skip MachineSets with 0 replicas — creating a MachineAutoscaler
+			// with minReplicas=1 on a 0-replica set would cause unwanted scale-up.
+			if msReplicas == "0" || msReplicas == "<none>" {
+				t.Logf("[%s] Skipping MachineAutoscaler for %s (replicas=%s)", ProviderOpenShift, msName, msReplicas)
+				continue
+			}
+
+			maYAML := fmt.Sprintf(`apiVersion: autoscaling.openshift.io/v1beta1
+kind: MachineAutoscaler
+metadata:
+  name: %s
+  namespace: openshift-machine-api
+spec:
+  minReplicas: 1
+  maxReplicas: 2
+  scaleTargetRef:
+    apiVersion: machine.openshift.io/v1beta1
+    kind: MachineSet
+    name: %s`, msName, msName)
+
+			if err := k8s.KubectlApplyFromStringE(t, machineOpts, maYAML); err != nil {
+				return fmt.Errorf("failed to apply MachineAutoscaler for %s on cluster %s: %w", msName, clusterName, err)
+			}
+			t.Logf("[%s] MachineAutoscaler applied for %s on cluster %s (min=1, max=2)", ProviderOpenShift, msName, clusterName)
+		}
+	}
+
+	t.Logf("[%s] Cluster autoscaler setup complete", ProviderOpenShift)
+	return nil
+}
+
+// ─── COREDNS DEPLOYMENT ───────────────────────────────────────────────────────
+
+// deployAndConfigureOpenShiftCoreDNS deploys a custom CoreDNS instance to
+// kube-system on each cluster with an external LoadBalancer service. It then:
+//  1. Grants SCC permissions for the CoreDNS pods (OpenShift security).
+//  2. Waits for the external LB IP.
+//  3. Populates r.CorednsClusterOptions with those IPs.
+//  4. Applies the full cross-cluster Corefile to every cluster.
+func (r *OpenShiftRegion) deployAndConfigureOpenShiftCoreDNS(t *testing.T, kubeConfigPath string) error {
+	// Phase 1: deploy CoreDNS on each cluster and collect external LB IPs.
+	for i, clusterName := range r.Clusters {
+		t.Logf("[%s] Deploying custom CoreDNS on cluster %q", ProviderOpenShift, clusterName)
+
+		kubectlOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, coreDNSNamespace)
+
+		// Deploy RBAC first so the coredns ServiceAccount exists before we bind SCC.
+		if err := deployCoreDNSRBAC(t, kubectlOpts); err != nil {
+			return fmt.Errorf("failed to deploy CoreDNS RBAC on cluster %s: %w", clusterName, err)
+		}
+
+		// Grant anyuid SCC to the CoreDNS SA in kube-system so the pods can run.
+		// Must come after RBAC deployment so the SA exists.
+		// Use "kubectl create clusterrolebinding" instead of "oc adm policy add-scc-to-user":
+		// k8s.RunKubectlE prepends --context before the subcommand, which the oc adm
+		// plugin rejects with "flags cannot be placed before plugin name: --context".
+		if err := k8s.RunKubectlE(t, kubectlOpts,
+			"create", "clusterrolebinding", "crl-coredns-anyuid",
+			"--clusterrole=system:openshift:scc:anyuid",
+			"--serviceaccount=kube-system:coredns"); err != nil {
+			t.Logf("[%s] Warning: create clusterrolebinding for coredns SA on %s: %v", ProviderOpenShift, clusterName, err)
+		}
+
+		// Deploy ConfigMap + Deployment + wait. RBAC is already applied above.
+		if err := deployCoreDNSResources(t, kubectlOpts, operator.CustomDomains[i], r.CorednsClusterOptions); err != nil {
+			return fmt.Errorf("failed to deploy CoreDNS resources on cluster %s: %w", clusterName, err)
+		}
+		if err := deployCoreDNSService(t, kubectlOpts, nil, ProviderOpenShift); err != nil {
+			return fmt.Errorf("failed to deploy CoreDNS service on cluster %s: %w", clusterName, err)
+		}
+
+		// Wait for the external LoadBalancer IP.
+		ips, err := WaitForCoreDNSServiceIPs(t, kubectlOpts)
+		if err != nil {
+			return fmt.Errorf("failed to get CoreDNS external IPs for cluster %s: %w", clusterName, err)
+		}
+
+		r.CorednsClusterOptions[operator.CustomDomains[i]] = coredns.CoreDNSClusterOption{
+			IPs:       ips,
+			Namespace: r.Namespace[clusterName],
+			Domain:    operator.CustomDomains[i],
+		}
+		t.Logf("[%s] CoreDNS LB IPs for cluster %q: %v", ProviderOpenShift, clusterName, ips)
+	}
+
+	// Phase 2: update the Corefile on every cluster with the full cross-cluster config.
+	UpdateCoreDNSConfiguration(t, r.Region, kubeConfigPath)
+
+	return nil
+}
+
+// getCoreDNSClusterIP returns the ClusterIP of the crl-core-dns-internal service in kube-system.
+// This is a ClusterIP-only service exposing both UDP/53 and TCP/53 to the CoreDNS pods.
+// The DNS operator patch uses this IP so that the built-in OpenShift DNS can forward
+// queries via UDP (its default) to our custom CoreDNS. The LoadBalancer service
+// (crl-core-dns) is TCP-only due to GCP LB constraints and cannot be used here.
+func (r *OpenShiftRegion) getCoreDNSClusterIP(t *testing.T, clusterName, kubeConfigPath string) (string, error) {
+	kubectlOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, coreDNSNamespace)
+
+	var clusterIP string
+	_, err := retry.DoWithRetryE(t,
+		fmt.Sprintf("get crl-core-dns-internal ClusterIP for %s", clusterName),
+		defaultRetries, defaultRetryInterval,
+		func() (string, error) {
+			ip, err := k8s.RunKubectlAndGetOutputE(t, kubectlOpts,
+				"get", "service", coreDNSInternalServiceName,
+				"-o", "jsonpath={.spec.clusterIP}")
+			if err != nil || ip == "" {
+				return "", fmt.Errorf("crl-core-dns-internal ClusterIP not ready yet")
+			}
+			clusterIP = ip
+			return ip, nil
+		})
+	if err != nil {
+		return "", fmt.Errorf("failed to get crl-core-dns-internal ClusterIP on cluster %q: %w", clusterName, err)
+	}
+	return clusterIP, nil
+}
+
+// ─── DNS ─────────────────────────────────────────────────────────────────────
+
+// patchOpenShiftDNSAllDomains patches the OpenShift DNS operator to forward ALL
+// custom cluster domains (cluster1.local, cluster2.local, …) to the local custom
+// CoreDNS ClusterIP. The custom CoreDNS Corefile handles cross-cluster forwarding.
+// Used for multi-region tests.
+func (r *OpenShiftRegion) patchOpenShiftDNSAllDomains(
+	t *testing.T,
+	clusterName, kubeConfigPath string,
+	allDomains []string,
+	coreDNSClusterIP string,
+) error {
+	t.Logf("[%s] Patching DNS operator on %q for all domains → %s",
+		ProviderOpenShift, clusterName, coreDNSClusterIP)
+
+	// Build the servers array for all custom domains.
+	var serverEntries []string
+	for _, domain := range allDomains {
+		entry := fmt.Sprintf(
+			`{"name":"%s-forwarder","zones":["%s"],"forwardPlugin":{"upstreams":["%s"]}}`,
+			strings.ReplaceAll(domain, ".", "-"),
+			domain,
+			coreDNSClusterIP,
+		)
+		serverEntries = append(serverEntries, entry)
+	}
+
+	// --type=merge intentionally replaces the entire spec.servers list. This is safe
+	// because spec.servers only holds user-defined forwarder entries for custom zones;
+	// the operator's built-in cluster DNS (cluster.local, <cluster>.<base-domain>) is
+	// managed separately and is unaffected. Replacing the list also ensures no stale
+	// entries from previous test runs accumulate.
+	patch := fmt.Sprintf(`{"spec":{"servers":[%s]}}`, strings.Join(serverEntries, ","))
+
+	kubectlOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, "")
+	_, err := k8s.RunKubectlAndGetOutputE(t, kubectlOpts,
+		"patch", "dns.operator.openshift.io", "default",
+		"--type=merge",
+		fmt.Sprintf("--patch=%s", patch))
+	if err != nil {
+		return fmt.Errorf("failed to patch DNS operator on cluster %q: %w", clusterName, err)
+	}
+
+	t.Logf("[%s] DNS operator patched on %q: forwarding %v → %s",
+		ProviderOpenShift, clusterName, allDomains, coreDNSClusterIP)
+	return nil
+}
+
+// ─── GCP COMPUTE CLIENT ──────────────────────────────────────────────────────
+
+// createOpenShiftComputeClient creates a GCP Compute Service client using
+// the same credential resolution as the GCP provider.
+func createOpenShiftComputeClient(ctx context.Context) (*compute.Service, error) {
+	var opts []option.ClientOption
+	if keyPath := getServiceAccountKeyPath(); keyPath != "" {
+		opts = append(opts, option.WithCredentialsFile(keyPath))
+	}
+	return compute.NewService(ctx, opts...)
+}
+
+// ─── KUBECONFIG ──────────────────────────────────────────────────────────────
+
+// mergeOpenShiftKubeconfig merges the installer-generated kubeconfig into the
+// current user kubeconfig and renames the context to clusterAlias so the rest
+// of the test framework can reference it by name.
+//
+// Every OpenShift cluster generates a kubeconfig whose user is named "admin".
+// When multiple clusters are merged sequentially, the second cluster's "admin"
+// entry would silently overwrite the first cluster's credentials, breaking
+// authentication to the first cluster. To prevent this, we rename the user to
+// "admin-<clusterAlias>" in a temporary copy before merging so each cluster's
+// credentials coexist under distinct names.
+func mergeOpenShiftKubeconfig(t *testing.T, generatedKubeconfig, clusterAlias string) error {
+	// Determine destination kubeconfig path.
+	// KUBECONFIG may legally be a colon-separated list of paths; normalize to a
+	// single writable file (the first entry) before using filesystem APIs.
+	destKubeconfig := os.Getenv("KUBECONFIG")
+	if destKubeconfig == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to determine home dir: %w", err)
+		}
+		destKubeconfig = filepath.Join(home, ".kube", "config")
+	} else if paths := filepath.SplitList(destKubeconfig); len(paths) > 1 {
+		destKubeconfig = strings.TrimSpace(paths[0])
+	}
+	if destKubeconfig == "" {
+		return fmt.Errorf("destination kubeconfig path is empty")
+	}
+
+	// Rename the "admin" user to "admin-<clusterAlias>" in a temp copy so that
+	// merging multiple clusters does not cause one cluster's credentials to
+	// overwrite another's (they all use "admin" by default).
+	renamedKubeconfig, err := renamedKubeconfigUser(generatedKubeconfig, "admin", "admin-"+clusterAlias)
+	if err != nil {
+		return fmt.Errorf("failed to rename user in generated kubeconfig: %w", err)
+	}
+	defer os.Remove(renamedKubeconfig)
+
+	// Merge by setting KUBECONFIG to both files and running kubectl config view --flatten.
+	// Put renamedKubeconfig first so the cluster-specific user entry takes
+	// precedence over any same-named entry already present in destKubeconfig.
+	merged := fmt.Sprintf("%s:%s", renamedKubeconfig, destKubeconfig)
+	flattenCmd := exec.Command("kubectl", "config", "view", "--flatten")
+	flattenCmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", merged))
+	flattenOut, err := flattenCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("kubectl config view --flatten failed: %w: %s", err, strings.TrimSpace(string(flattenOut)))
+	}
+
+	// Ensure the destination directory exists (may be absent in a clean CI environment).
+	if err := os.MkdirAll(filepath.Dir(destKubeconfig), 0700); err != nil {
+		return fmt.Errorf("failed to create kubeconfig directory: %w", err)
+	}
+
+	// Write merged config back to the destination file.
+	if err := os.WriteFile(destKubeconfig, flattenOut, 0600); err != nil {
+		return fmt.Errorf("failed to write merged kubeconfig: %w", err)
+	}
+
+	// Find the context name that openshift-install created and rename it to
+	// clusterAlias. We read from the renamed copy because the context name in
+	// the original generated kubeconfig is typically "admin".
+	getContextsCmd := exec.Command("kubectl", "config", "get-contexts",
+		"--no-headers", "-o", "name",
+		"--kubeconfig", renamedKubeconfig)
+	out, err := getContextsCmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to get contexts from generated kubeconfig: %w", err)
+	}
+
+	generatedContext := strings.TrimSpace(string(out))
+	if generatedContext == "" {
+		return fmt.Errorf("no context found in generated kubeconfig %s", generatedKubeconfig)
+	}
+	// Take only the first context if multiple lines.
+	generatedContext = strings.SplitN(generatedContext, "\n", 2)[0]
+
+	t.Logf("[%s] Renaming kubeconfig context %q → %q", ProviderOpenShift, generatedContext, clusterAlias)
+
+	renameCmd := exec.Command("kubectl", "config", "rename-context", generatedContext, clusterAlias)
+	if out, err := renameCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to rename context %q to %q: %w\n%s", generatedContext, clusterAlias, err, string(out))
+	}
+
+	return nil
+}
+
+// renamedKubeconfigUser loads the kubeconfig at src, renames the user entry
+// named oldName to newName (in both the users list and all context references),
+// writes the result to a temporary file, and returns the temp file path.
+// The caller is responsible for removing the temp file when done.
+func renamedKubeconfigUser(src, oldName, newName string) (string, error) {
+	cfg, err := clientcmd.LoadFromFile(src)
+	if err != nil {
+		return "", fmt.Errorf("failed to load kubeconfig %s: %w", src, err)
+	}
+
+	// Rename the AuthInfo (user) entry.
+	if authInfo, ok := cfg.AuthInfos[oldName]; ok {
+		cfg.AuthInfos[newName] = authInfo
+		delete(cfg.AuthInfos, oldName)
+	}
+
+	// Update any context that references the old user name.
+	for _, ctx := range cfg.Contexts {
+		if ctx.AuthInfo == oldName {
+			ctx.AuthInfo = newName
+		}
+	}
+
+	tmpFile, err := os.CreateTemp("", "kubeconfig-renamed-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp kubeconfig file: %w", err)
+	}
+	tmpFile.Close()
+
+	if err := clientcmd.WriteToFile(*cfg, tmpFile.Name()); err != nil {
+		_ = os.Remove(tmpFile.Name())
+		return "", fmt.Errorf("failed to write renamed kubeconfig: %w", err)
+	}
+
+	return tmpFile.Name(), nil
+}
+
+// ─── HELPERS ─────────────────────────────────────────────────────────────────
+
+// getOpenShiftProjectID returns the GCP project ID for OpenShift provisioning.
+func getOpenShiftProjectID() string {
+	if id := os.Getenv("GCP_PROJECT_ID"); id != "" {
+		return id
+	}
+	return defaultOpenShiftProjectID
+}
+
+// installerEnv returns the environment slice for openshift-install commands.
+// It propagates the current environment but explicitly removes
+// GOOGLE_APPLICATION_CREDENTIALS so that ADC does not take precedence over
+// the service-account key supplied via GOOGLE_CREDENTIALS (Mint mode).
+func installerEnv() []string {
+	env := make([]string, 0, len(os.Environ()))
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "GOOGLE_APPLICATION_CREDENTIALS=") {
+			continue
+		}
+		env = append(env, e)
+	}
+	return env
+}
+
+// splitTrimmed splits s by comma, trims whitespace from each element, and
+// returns only non-empty elements.
+func splitTrimmed(s string) []string {
+	var result []string
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			result = append(result, part)
+		}
+	}
+	return result
+}
+
+// mustEnv fatals the test if the named environment variable is not set.
+func mustEnv(t *testing.T, name string) string {
+	t.Helper()
+	val := os.Getenv(name)
+	if val == "" {
+		t.Fatalf("[%s] Required environment variable %q is not set", ProviderOpenShift, name)
+	}
+	return val
+}
+
+// Ensure OpenShiftRegion satisfies the CloudProvider interface at compile time.
+var _ CloudProvider = (*OpenShiftRegion)(nil)

--- a/tests/e2e/operator/infra/openshift.go
+++ b/tests/e2e/operator/infra/openshift.go
@@ -454,17 +454,20 @@ func (r *OpenShiftRegion) provisionCluster(
 	}
 	f.Close()
 
-	t.Logf("[%s] Running: openshift-install create cluster --dir=%s", ProviderOpenShift, installDir)
+	// Use debug log level to capture full bootstrap diagnostics in the test
+	// output (bootstrap serial console, ignition status, container pull progress).
+	logLevel := "debug"
+	if os.Getenv("OPENSHIFT_INSTALL_LOG_LEVEL") != "" {
+		logLevel = os.Getenv("OPENSHIFT_INSTALL_LOG_LEVEL")
+	}
+	t.Logf("[%s] Running: openshift-install create cluster --dir=%s --log-level=%s", ProviderOpenShift, installDir, logLevel)
 
 	cmd := exec.Command("openshift-install", "create", "cluster",
 		"--dir", installDir,
-		"--log-level", "info",
+		"--log-level", logLevel,
 	)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	// Clear GOOGLE_APPLICATION_CREDENTIALS from the installer environment so
-	// that ADC does not take precedence over GOOGLE_CREDENTIALS (Mint mode),
-	// which is expected to be set in the CI environment.
 	cmd.Env = installerEnv()
 
 	if err := cmd.Run(); err != nil {
@@ -476,7 +479,15 @@ func (r *OpenShiftRegion) provisionCluster(
 		destroyCmd.Stderr = os.Stderr
 		destroyCmd.Env = installerEnv()
 		_ = destroyCmd.Run()
-		_ = os.RemoveAll(installDir)
+		// Preserve the install directory (which contains the log bundle and
+		// .openshift_install.log) when SKIP_CLEANUP is set so the operator can
+		// inspect bootstrap diagnostics after a failure.
+		if os.Getenv("SKIP_CLEANUP") == "true" || os.Getenv("PRESERVE_INFRA_ON_FAILURE") == "true" {
+			t.Logf("[%s] Install dir preserved for debugging: %s", ProviderOpenShift, installDir)
+			t.Logf("[%s] Check for log bundle: %s/log-bundle-*.tar.gz", ProviderOpenShift, installDir)
+		} else {
+			_ = os.RemoveAll(installDir)
+		}
 		return "", "", fmt.Errorf("openshift-install create cluster failed: %w", err)
 	}
 
@@ -1141,13 +1152,31 @@ func getOpenShiftProjectID() string {
 }
 
 // installerEnv returns the environment slice for openshift-install commands.
-// It propagates the current environment but explicitly removes
-// GOOGLE_APPLICATION_CREDENTIALS so that ADC does not take precedence over
-// the service-account key supplied via GOOGLE_CREDENTIALS (Mint mode).
+// It propagates the current environment and ensures the Go GCP client inside
+// openshift-install uses the correct service-account credentials.
+//
+// Credential handling:
+//   - If GOOGLE_CREDENTIALS is JSON content (CI "Mint mode"), strip
+//     GOOGLE_APPLICATION_CREDENTIALS so that ADC does not override it.
+//   - If GOOGLE_CREDENTIALS is a file path (local dev), replace
+//     GOOGLE_APPLICATION_CREDENTIALS with that path so that both Terraform
+//     and the Go GCP client (used for GCS bucket creation, etc.) use the
+//     same SA key.  Without this, the Go client falls back to ADC user
+//     credentials which may lack storage.buckets.create in the target project.
 func installerEnv() []string {
+	googleCreds := os.Getenv("GOOGLE_CREDENTIALS")
+	// isFilePath is true when GOOGLE_CREDENTIALS holds a file path rather than
+	// raw JSON (i.e. not valid JSON and not empty).
+	isFilePath := googleCreds != "" && !json.Valid([]byte(googleCreds))
+
 	env := make([]string, 0, len(os.Environ()))
 	for _, e := range os.Environ() {
 		if strings.HasPrefix(e, "GOOGLE_APPLICATION_CREDENTIALS=") {
+			if isFilePath {
+				// Forward the SA key file so the Go GCP client can find it.
+				env = append(env, "GOOGLE_APPLICATION_CREDENTIALS="+googleCreds)
+			}
+			// Always skip the original entry (replaced above or stripped for CI).
 			continue
 		}
 		env = append(env, e)

--- a/tests/e2e/operator/infra/provider.go
+++ b/tests/e2e/operator/infra/provider.go
@@ -39,6 +39,10 @@ func ProviderFactory(providerType string, region *operator.Region) CloudProvider
 		provider := GcpRegion{Region: region}
 		provider.RegionCodes = GetRegionCodes(providerType)
 		return &provider
+	case ProviderOpenShift:
+		provider := OpenShiftRegion{Region: region}
+		provider.RegionCodes = GetRegionCodes(providerType)
+		return &provider
 	default:
 		return nil
 	}

--- a/tests/e2e/operator/multiRegion/cockroachdb_multi_region_advanced_features_test.go
+++ b/tests/e2e/operator/multiRegion/cockroachdb_multi_region_advanced_features_test.go
@@ -91,10 +91,16 @@ func (r *multiRegion) TestEncryptionAtRestMultiRegion(t *testing.T) {
 	cluster0 := r.Clusters[0]
 	secretName0 := "cmek-key-secret-region-0"
 
+	// OpenShift runs on GCP; the operator webhook only accepts "gcp" not "openshift".
+	cloudProvider := r.Provider
+	if cloudProvider == "openshift" {
+		cloudProvider = "gcp"
+	}
+
 	encryptionRegions0 := []map[string]interface{}{
 		{
 			"code":          r.RegionCodes[0],
-			"cloudProvider": r.Provider,
+			"cloudProvider": cloudProvider,
 			"nodes":         r.NodeCount,
 			"namespace":     r.Namespace[cluster0],
 			"domain":        operator.CustomDomains[0],

--- a/tests/e2e/operator/multiRegion/cockroachdb_multi_region_advanced_features_test.go
+++ b/tests/e2e/operator/multiRegion/cockroachdb_multi_region_advanced_features_test.go
@@ -1,0 +1,238 @@
+package multiRegion
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestWALFailoverMultiRegion tests WAL failover with different paths in each region
+// Region 0: WAL failover enabled with custom path
+// Region 1: WAL failover disabled
+func (r *multiRegion) TestWALFailoverMultiRegion(t *testing.T) {
+	// Setup namespaces and CA for each region
+	cleanup := r.SetupMultiClusterWithCA(t)
+	defer cleanup()
+
+	// Region 0: Install with WAL failover enabled
+	cluster0 := r.Clusters[0]
+	walPath0 := "/cockroach/wal-region-0"
+
+	t.Logf("Installing region 0 (%s) with WAL failover enabled at path %s", cluster0, walPath0)
+	config0 := operator.AdvancedInstallConfig{
+		WALFailoverEnabled: true,
+		WALFailoverSize:    "5Gi",
+		CustomValues: map[string]string{
+			"cockroachdb.crdbCluster.walFailoverSpec.path": walPath0,
+		},
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster0, 0, config0)
+
+	// Region 1: Install without WAL failover
+	cluster1 := r.Clusters[1]
+	t.Logf("Installing region 1 (%s) without WAL failover", cluster1)
+	config1 := operator.AdvancedInstallConfig{}
+	r.InstallChartsWithAdvancedConfig(t, cluster1, 1, config1)
+
+	// Validate CockroachDB cluster health in both regions
+	for _, cluster := range r.Clusters {
+		r.ValidateCRDB(t, cluster)
+	}
+
+	// Validate multi-region setup
+	r.ValidateMultiRegionSetup(t)
+
+	// Validate WAL failover in region 0
+	t.Log("Validating WAL failover in region 0...")
+	r.ValidateWALFailover(t, cluster0, &operator.AdvancedValidationConfig{
+		WALFailover: operator.WALFailoverValidation{
+			CustomPath: walPath0,
+		},
+	})
+
+	// Validate NO WAL failover in region 1
+	t.Log("Validating NO WAL failover in region 1...")
+	kubeConfig, _ := r.GetCurrentContext(t)
+	kubectlOptions1 := k8s.NewKubectlOptions(cluster1, kubeConfig, r.Namespace[cluster1])
+
+	pods := k8s.ListPods(t, kubectlOptions1, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found in region 1")
+
+	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions1,
+		"get", "pod", pods[0].Name, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+	require.NoError(t, err)
+	require.NotContains(t, podCommand, "--wal-failover", "Region 1 should not have WAL failover enabled")
+	t.Log("Confirmed region 1 does not have WAL failover")
+
+	t.Logf("WAL failover multi-region test completed successfully")
+}
+
+// TestEncryptionAtRestMultiRegion tests encryption at rest with different secrets per region
+// Region 0: Encryption enabled with secret "cmek-key-secret-region-0"
+// Region 1: Encryption disabled (no encryption)
+func (r *multiRegion) TestEncryptionAtRestMultiRegion(t *testing.T) {
+	// Setup namespaces and CA for each region
+	cleanup := r.SetupMultiClusterWithCA(t)
+	defer cleanup()
+
+	// Generate encryption key for region 0
+	encryptionKeyB64 := r.GenerateEncryptionKey(t)
+	t.Logf("Generated encryption key for region 0 (base64 length: %d)", len(encryptionKeyB64))
+
+	// Region 0: Install with encryption at rest enabled
+	cluster0 := r.Clusters[0]
+	secretName0 := "cmek-key-secret-region-0"
+
+	encryptionRegions0 := []map[string]interface{}{
+		{
+			"code":          r.RegionCodes[0],
+			"cloudProvider": r.Provider,
+			"nodes":         r.NodeCount,
+			"namespace":     r.Namespace[cluster0],
+			"domain":        operator.CustomDomains[0],
+			"encryptionAtRest": map[string]interface{}{
+				"platform":      "UNKNOWN_KEY_TYPE",
+				"keySecretName": secretName0,
+			},
+		},
+	}
+
+	t.Logf("Installing region 0 (%s) with encryption at rest enabled", cluster0)
+	config0 := operator.AdvancedInstallConfig{
+		EncryptionEnabled:       true,
+		EncryptionKeySecret:     encryptionKeyB64,
+		EncryptionKeySecretName: secretName0,
+		CustomRegions:           encryptionRegions0,
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster0, 0, config0)
+
+	// Region 1: Install without encryption
+	cluster1 := r.Clusters[1]
+	t.Logf("Installing region 1 (%s) without encryption at rest", cluster1)
+	config1 := operator.AdvancedInstallConfig{}
+	r.InstallChartsWithAdvancedConfig(t, cluster1, 1, config1)
+
+	// Validate CockroachDB cluster health in both regions
+	for _, cluster := range r.Clusters {
+		r.ValidateCRDB(t, cluster)
+	}
+
+	// Validate multi-region setup
+	r.ValidateMultiRegionSetup(t)
+
+	// Validate encryption in region 0
+	t.Log("Validating encryption at rest in region 0...")
+	r.ValidateEncryptionAtRest(t, cluster0, &operator.AdvancedValidationConfig{
+		EncryptionAtRest: operator.EncryptionAtRestValidation{
+			SecretName: secretName0,
+		},
+	})
+
+	// Validate NO encryption in region 1
+	t.Log("Validating NO encryption at rest in region 1...")
+	kubeConfig, _ := r.GetCurrentContext(t)
+	kubectlOptions1 := k8s.NewKubectlOptions(cluster1, kubeConfig, r.Namespace[cluster1])
+
+	pods := k8s.ListPods(t, kubectlOptions1, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found in region 1")
+
+	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions1,
+		"get", "pod", pods[0].Name, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+	require.NoError(t, err)
+	require.NotContains(t, podCommand, "--enterprise-encryption", "Region 1 should not have encryption enabled")
+	t.Log("Confirmed region 1 does not have encryption at rest")
+
+	t.Logf("Encryption at rest multi-region test completed successfully")
+}
+
+// TestPCRMultiRegion tests Physical Cluster Replication with multi-region setup
+// Creates a multi-region primary cluster, then creates a standby cluster and tests failover/failback
+func (r *multiRegion) TestPCRMultiRegion(t *testing.T) {
+	// Creating random namespace for primary multi-region cluster
+	for _, cluster := range r.Clusters {
+		r.Namespace[cluster] = fmt.Sprintf("%s-primary-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
+	}
+
+	// Create CA certificate once for all clusters
+	cleanupCA := r.RequireCACertificate(t)
+	defer cleanupCA()
+
+	var standbyNamespace string
+
+	// Cleanup both primary and standby clusters
+	defer r.CleanupResources(t)
+	defer func() {
+		if standbyNamespace != "" {
+			kubeConfig, _ := r.GetCurrentContext(t)
+			// Standby is always installed on Clusters[0]; use its context explicitly.
+			kubectlOptions := k8s.NewKubectlOptions(r.Clusters[0], kubeConfig, standbyNamespace)
+			k8s.DeleteNamespace(t, kubectlOptions, standbyNamespace)
+		}
+	}()
+
+	// Step 1: Install primary multi-region cluster
+	t.Log("Installing primary multi-region cluster...")
+	for i, cluster := range r.Clusters {
+		primaryConfig := operator.AdvancedInstallConfig{
+			VirtualClusterMode: "primary",
+		}
+		r.InstallChartsWithAdvancedConfig(t, cluster, i, primaryConfig)
+	}
+
+	// Validate primary cluster health in all regions
+	r.VirtualClusterModePrimary = true
+	for _, cluster := range r.Clusters {
+		r.ValidateCRDB(t, cluster)
+	}
+	r.VirtualClusterModePrimary = false
+
+	// Validate multi-region setup
+	r.ValidateMultiRegionSetup(t)
+	t.Log("Primary multi-region cluster is healthy")
+
+	// Step 2: Install standby cluster (single region for simplicity)
+	t.Log("Installing standby cluster...")
+	standbyCluster := r.Clusters[0] // Use first cluster for standby
+	standbyNamespace = fmt.Sprintf("%s-standby-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
+
+	// Temporarily update namespace for standby installation
+	originalNamespace := r.Namespace[standbyCluster]
+	r.Namespace[standbyCluster] = standbyNamespace
+
+	standbyConfig := operator.AdvancedInstallConfig{
+		VirtualClusterMode:  "standby",
+		SkipOperatorInstall: true, // Operator already installed
+	}
+	r.InstallChartsWithAdvancedConfig(t, standbyCluster, 0, standbyConfig)
+
+	// Validate standby cluster
+	r.VirtualClusterModeStandby = true
+	r.ValidateCRDB(t, standbyCluster)
+	r.VirtualClusterModeStandby = false
+	t.Log("Standby cluster is healthy")
+
+	// Step 3: Set up replication and test failover/failback
+	t.Log("Testing PCR failover and failback...")
+	r.ValidatePCR(t, &operator.AdvancedValidationConfig{
+		PCR: operator.PCRValidation{
+			Cluster:          standbyCluster,
+			PrimaryNamespace: originalNamespace,
+			StandbyNamespace: standbyNamespace,
+		},
+	})
+
+	// Restore original namespace
+	r.Namespace[standbyCluster] = originalNamespace
+
+	t.Logf("PCR multi-region test completed successfully")
+}

--- a/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
+++ b/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
@@ -75,20 +75,12 @@ func TestOperatorInMultiRegion(t *testing.T) {
 			t.Fatalf("Unsupported provider: %s", provider)
 		}
 
-		// Set PRESERVE_INFRA_ON_FAILURE=true to keep clusters alive after a
-		// test failure (or always, for validation runs). By default teardown runs.
-		preserveInfra := os.Getenv("PRESERVE_INFRA_ON_FAILURE") == "true"
-
 		skipCleanup := os.Getenv("SKIP_CLEANUP") == "true" ||
 			os.Getenv("REUSE_INFRA") == "true" ||
 			os.Getenv("INFRA_ONLY") == "true"
 
 		// Use t.Cleanup for guaranteed cleanup even on test timeout/panic.
 		t.Cleanup(func() {
-			if preserveInfra {
-				t.Logf("PRESERVE_INFRA_ON_FAILURE=true: skipping infrastructure teardown for provider: %s", provider)
-				return
-			}
 			t.Logf("Starting infrastructure cleanup for provider: %s", provider)
 			if skipCleanup {
 				t.Logf("Skipping infrastructure teardown (SKIP_CLEANUP/REUSE_INFRA/INFRA_ONLY is set)")
@@ -129,10 +121,6 @@ func TestOperatorInMultiRegion(t *testing.T) {
 				defer func() {
 					if t.Failed() {
 						testFailed = true
-						if preserveInfra {
-							t.Logf("PRESERVE_INFRA_ON_FAILURE=true: preserving infrastructure after failure in test %s", name)
-							return
-						}
 						t.Logf("Test %s failed, triggering immediate infrastructure cleanup", name)
 						if skipCleanup {
 							t.Logf("Skipping infrastructure teardown (SKIP_CLEANUP/REUSE_INFRA/INFRA_ONLY is set)")

--- a/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
+++ b/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
@@ -55,7 +55,7 @@ func TestOperatorInMultiRegion(t *testing.T) {
 		providerRegion.Region = operator.Region{
 			IsMultiRegion: true,
 			NodeCount:     3,
-			ReusingInfra:  false,
+			ReusingInfra:  os.Getenv("REUSE_INFRA") == "true",
 		}
 		providerRegion.Clients = make(map[string]client.Client)
 		providerRegion.Namespace = make(map[string]string)
@@ -79,27 +79,43 @@ func TestOperatorInMultiRegion(t *testing.T) {
 		// test failure (or always, for validation runs). By default teardown runs.
 		preserveInfra := os.Getenv("PRESERVE_INFRA_ON_FAILURE") == "true"
 
+		skipCleanup := os.Getenv("SKIP_CLEANUP") == "true" ||
+			os.Getenv("REUSE_INFRA") == "true" ||
+			os.Getenv("INFRA_ONLY") == "true"
+
+		// Use t.Cleanup for guaranteed cleanup even on test timeout/panic.
 		t.Cleanup(func() {
 			if preserveInfra {
 				t.Logf("PRESERVE_INFRA_ON_FAILURE=true: skipping infrastructure teardown for provider: %s", provider)
 				return
 			}
 			t.Logf("Starting infrastructure cleanup for provider: %s", provider)
-			cloudProvider.TeardownInfra(t)
+			if skipCleanup {
+				t.Logf("Skipping infrastructure teardown (SKIP_CLEANUP/REUSE_INFRA/INFRA_ONLY is set)")
+			} else {
+				cloudProvider.TeardownInfra(t)
+			}
 			t.Logf("Completed infrastructure cleanup for provider: %s", provider)
 		})
 
 		// Set up infrastructure for this provider once.
 		cloudProvider.SetUpInfra(t)
 
-		testCases := map[string]func(*testing.T){
-			"TestHelmInstall":           providerRegion.TestHelmInstall,
-			"TestHelmUpgrade":           providerRegion.TestHelmUpgrade,
-			"TestClusterRollingRestart": providerRegion.TestClusterRollingRestart,
-			"TestKillingCockroachNode":  providerRegion.TestKillingCockroachNode,
-			"TestClusterScaleUp":        func(t *testing.T) { providerRegion.TestClusterScaleUp(t, cloudProvider) },
-		}
+		// Build test cases based on TEST_ADVANCED_FEATURES environment variable
+		testCases := make(map[string]func(*testing.T))
 
+		// Run only advanced test cases when TEST_ADVANCED_FEATURES is enabled
+		if os.Getenv("TEST_ADVANCED_FEATURES") == "true" {
+			testCases["TestWALFailoverMultiRegion"] = providerRegion.TestWALFailoverMultiRegion
+			testCases["TestEncryptionAtRestMultiRegion"] = providerRegion.TestEncryptionAtRestMultiRegion
+			testCases["TestPCRMultiRegion"] = providerRegion.TestPCRMultiRegion
+		} else {
+			testCases["TestHelmInstall"] = providerRegion.TestHelmInstall
+			testCases["TestHelmUpgrade"] = providerRegion.TestHelmUpgrade
+			testCases["TestClusterRollingRestart"] = providerRegion.TestClusterRollingRestart
+			testCases["TestKillingCockroachNode"] = providerRegion.TestKillingCockroachNode
+			testCases["TestClusterScaleUp"] = func(t *testing.T) { providerRegion.TestClusterScaleUp(t, cloudProvider) }
+		}
 		// Run tests sequentially within a provider.
 		var testFailed bool
 		for name, method := range testCases {
@@ -118,7 +134,11 @@ func TestOperatorInMultiRegion(t *testing.T) {
 							return
 						}
 						t.Logf("Test %s failed, triggering immediate infrastructure cleanup", name)
-						cloudProvider.TeardownInfra(t)
+						if skipCleanup {
+							t.Logf("Skipping infrastructure teardown (SKIP_CLEANUP/REUSE_INFRA/INFRA_ONLY is set)")
+						} else {
+							cloudProvider.TeardownInfra(t)
+						}
 						t.Logf("Infrastructure cleanup completed due to test failure")
 					}
 				}()
@@ -163,7 +183,6 @@ func (r *multiRegion) TestHelmInstall(t *testing.T) {
 		if _, ok := rawConfig.Contexts[cluster]; !ok {
 			t.Fatalf("cluster context '%s' not found in kubeconfig", cluster)
 		}
-		rawConfig.CurrentContext = cluster
 		// Validate CockroachDB cluster.
 		r.ValidateCRDB(t, cluster)
 	}
@@ -205,7 +224,6 @@ func (r *multiRegion) TestHelmUpgrade(t *testing.T) {
 		if _, ok := rawConfig.Contexts[cluster]; !ok {
 			t.Fatalf("cluster context '%s' not found in kubeconfig", cluster)
 		}
-		rawConfig.CurrentContext = cluster
 		// Validate CockroachDB cluster.
 		r.ValidateCRDB(t, cluster)
 	}
@@ -286,7 +304,6 @@ func (r *multiRegion) TestClusterRollingRestart(t *testing.T) {
 		if _, ok := rawConfig.Contexts[cluster]; !ok {
 			t.Fatalf("cluster context '%s' not found in kubeconfig", cluster)
 		}
-		rawConfig.CurrentContext = cluster
 		r.ValidateCRDB(t, cluster)
 	}
 
@@ -375,7 +392,6 @@ func (r *multiRegion) TestKillingCockroachNode(t *testing.T) {
 		if _, ok := rawConfig.Contexts[cluster]; !ok {
 			t.Fatalf("cluster context '%s' not found in kubeconfig", cluster)
 		}
-		rawConfig.CurrentContext = cluster
 		r.ValidateCRDB(t, cluster)
 	}
 
@@ -399,7 +415,6 @@ func (r *multiRegion) TestKillingCockroachNode(t *testing.T) {
 		if _, ok := rawConfig.Contexts[cluster]; !ok {
 			t.Fatalf("cluster context '%s' not found in kubeconfig", cluster)
 		}
-		rawConfig.CurrentContext = cluster
 		r.ValidateCRDB(t, cluster)
 	}
 	r.ValidateMultiRegionSetup(t)
@@ -439,8 +454,6 @@ func (r *multiRegion) TestClusterScaleUp(t *testing.T, cloudProvider infra.Cloud
 		if _, ok := rawConfig.Contexts[cluster]; !ok {
 			t.Fatalf("cluster context '%s' not found in kubeconfig", cluster)
 		}
-		rawConfig.CurrentContext = cluster
-
 		r.ValidateCRDB(t, cluster)
 	}
 	// Get helm chart paths.

--- a/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
+++ b/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
@@ -38,6 +38,8 @@ func TestOperatorInMultiRegion(t *testing.T) {
 			provider = infra.ProviderKind
 		case "gcp":
 			provider = infra.ProviderGCP
+		case "openshift":
+			provider = infra.ProviderOpenShift
 		default:
 			t.Fatalf("Unsupported provider override: %s", p)
 		}
@@ -73,8 +75,15 @@ func TestOperatorInMultiRegion(t *testing.T) {
 			t.Fatalf("Unsupported provider: %s", provider)
 		}
 
-		// Use t.Cleanup for guaranteed cleanup even on test timeout/panic.
+		// Set PRESERVE_INFRA_ON_FAILURE=true to keep clusters alive after a
+		// test failure (or always, for validation runs). By default teardown runs.
+		preserveInfra := os.Getenv("PRESERVE_INFRA_ON_FAILURE") == "true"
+
 		t.Cleanup(func() {
+			if preserveInfra {
+				t.Logf("PRESERVE_INFRA_ON_FAILURE=true: skipping infrastructure teardown for provider: %s", provider)
+				return
+			}
 			t.Logf("Starting infrastructure cleanup for provider: %s", provider)
 			cloudProvider.TeardownInfra(t)
 			t.Logf("Completed infrastructure cleanup for provider: %s", provider)
@@ -101,10 +110,13 @@ func TestOperatorInMultiRegion(t *testing.T) {
 			}
 
 			t.Run(name, func(t *testing.T) {
-				// Add immediate cleanup trigger if this individual test fails
 				defer func() {
 					if t.Failed() {
 						testFailed = true
+						if preserveInfra {
+							t.Logf("PRESERVE_INFRA_ON_FAILURE=true: preserving infrastructure after failure in test %s", name)
+							return
+						}
 						t.Logf("Test %s failed, triggering immediate infrastructure cleanup", name)
 						cloudProvider.TeardownInfra(t)
 						t.Logf("Infrastructure cleanup completed due to test failure")

--- a/tests/e2e/operator/region.go
+++ b/tests/e2e/operator/region.go
@@ -528,7 +528,7 @@ func (r *Region) CleanupResources(t *testing.T) {
 				"validatingwebhookconfiguration/cockroach-webhook-config",
 				"priorityclass/cockroach-operator",
 			} {
-				_ = k8s.RunKubectlE(t, kubectlOptions, "delete", resource, "--ignore-not-found")
+				_ = k8s.RunKubectlE(t, clusterOptions, "delete", resource, "--ignore-not-found")
 			}
 		}
 		if r.IsCertManager {
@@ -565,8 +565,6 @@ func HelmChartPaths() (helmChartPath string, operatorChartPath string) {
 // We place other clusters' regions first so their join addresses are tried first,
 // allowing the current cluster to join the existing cluster immediately.
 func (r *Region) createOperatorRegions(index int, nodes int, customDomains map[int]string) []map[string]interface{} {
-	regions := make([]map[string]interface{}, 0, len(r.Clusters))
-
 	// OpenShift is deployed on GCP; the cockroach operator webhook only supports
 	// "aws", "gcp", "azure", and "k3d" as cloudProvider values.
 	cloudProvider := r.Provider
@@ -574,11 +572,7 @@ func (r *Region) createOperatorRegions(index int, nodes int, customDomains map[i
 		cloudProvider = "gcp"
 	}
 
-	for i := 0; i < len(r.Clusters); i++ {
-		if i > index {
-			break
-		}
-
+	buildRegion := func(i int) map[string]interface{} {
 		region := map[string]interface{}{
 			"code":          r.RegionCodes[i],
 			"cloudProvider": cloudProvider,
@@ -600,7 +594,8 @@ func (r *Region) createOperatorRegions(index int, nodes int, customDomains map[i
 
 	regions := make([]map[string]interface{}, 0, index+1)
 
-	// Add all preceding regions first so their join addresses are tried first.
+	// Add all preceding regions first so their join addresses are tried first,
+	// allowing the current cluster to join the existing cluster immediately.
 	for i := 0; i < index; i++ {
 		regions = append(regions, buildRegion(i))
 	}
@@ -836,13 +831,23 @@ func (r *Region) BaseRegionConfig(cluster string, index int) map[string]interfac
 	if len(r.RegionCodes) > index {
 		code = r.RegionCodes[index]
 	}
+	// OpenShift runs on GCP; the operator webhook only accepts "gcp" (not "openshift").
+	cloudProvider := r.Provider
+	if cloudProvider == "openshift" {
+		cloudProvider = "gcp"
+	}
 	region := map[string]interface{}{
 		"code":          code,
-		"cloudProvider": r.Provider,
+		"cloudProvider": cloudProvider,
 		"nodes":         r.NodeCount,
 		"namespace":     r.Namespace[cluster],
 	}
 	if domain, ok := CustomDomains[index]; ok {
+		// For single-region OpenShift use cluster.local — the built-in DNS already
+		// handles it and forwarding cluster1.local causes join RPC failures.
+		if r.Provider == "openshift" && !r.IsMultiRegion {
+			domain = "cluster.local"
+		}
 		region["domain"] = domain
 	}
 	return region
@@ -922,8 +927,9 @@ func (r *Region) InstallChartsWithAdvancedConfig(t *testing.T, cluster string, i
 	k8s.CreateNamespace(t, kubectlOptions, r.Namespace[cluster])
 
 	// create CA Secret.
-	err := k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", customCASecret, "--from-file=ca.crt",
-		"--from-file=ca.key")
+	err := k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", customCASecret,
+		"--from-file="+filepath.Join(r.certDir, "ca.crt"),
+		"--from-file="+filepath.Join(r.certDir, "ca.key"))
 	require.NoError(t, err)
 
 	// Create encryption key secret if encryption is enabled
@@ -955,8 +961,14 @@ func (r *Region) InstallChartsWithAdvancedConfig(t *testing.T, cluster string, i
 	}
 
 	// Build helm values
+	clusterDomain := CustomDomains[index]
+	// For single-region OpenShift use cluster.local — the built-in DNS already
+	// handles it and cluster1.local causes join RPC DNS failures.
+	if r.Provider == "openshift" && !r.IsMultiRegion {
+		clusterDomain = "cluster.local"
+	}
 	helmValues := PatchHelmValues(map[string]string{
-		"cockroachdb.clusterDomain":             CustomDomains[index],
+		"cockroachdb.clusterDomain":             clusterDomain,
 		"cockroachdb.tls.selfSigner.caProvided": "true",
 		"cockroachdb.tls.selfSigner.caSecret":   customCASecret,
 	})
@@ -1340,7 +1352,13 @@ func (r *Region) ValidatePCR(t *testing.T, cfg *AdvancedValidationConfig) {
 	// Step 4a: Generate external connection URI for replication
 	// Following: https://www.cockroachlabs.com/docs/stable/set-up-physical-cluster-replication#step-4-start-replication
 	t.Log("Generating connection URI for primary cluster using cockroach encode-uri...")
-	primaryHost := fmt.Sprintf("cockroachdb-public.%s.svc.%s:26257", primaryNamespace, CustomDomains[0])
+	pcrDomain := CustomDomains[0]
+	// For single-region OpenShift use cluster.local — the built-in DNS handles it
+	// and cluster1.local causes DNS lookup failures when connecting across namespaces.
+	if r.Provider == "openshift" && !r.IsMultiRegion {
+		pcrDomain = "cluster.local"
+	}
+	primaryHost := fmt.Sprintf("cockroachdb-public.%s.svc.%s:26257", primaryNamespace, pcrDomain)
 	primaryConnString := fmt.Sprintf("postgresql://%s:%s@%s", "pcr_source", "repl_password_123", primaryHost)
 	t.Logf("Primary connection string format: postgresql://pcr_source:***@%s", primaryHost)
 

--- a/tests/e2e/operator/region.go
+++ b/tests/e2e/operator/region.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"github.com/cockroachdb/helm-charts/tests/testutil"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/stretchr/testify/require"
@@ -102,7 +104,6 @@ func (r *Region) InstallCharts(t *testing.T, cluster string, index int) {
 	if _, ok := rawConfig.Contexts[cluster]; !ok {
 		t.Fatal()
 	}
-	rawConfig.CurrentContext = cluster
 
 	// Setup kubectl options for this cluster.
 	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
@@ -228,8 +229,7 @@ func (r *Region) ValidateCRDB(t *testing.T, cluster string) {
 	cfg, err := config.GetConfigWithContext(cluster)
 	require.NoError(t, err)
 	// Get current context name.
-	kubeConfig, rawConfig := r.GetCurrentContext(t)
-	rawConfig.CurrentContext = cluster
+	kubeConfig, _ := r.GetCurrentContext(t)
 	// Setup kubectl options for this cluster.
 	namespaceName := r.Namespace[cluster]
 	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, namespaceName)
@@ -320,8 +320,7 @@ func (r *Region) ValidateMultiRegionSetup(t *testing.T) {
 	// Validate multi-region setup.
 	for _, cluster := range r.Clusters {
 		// Get the current context name.
-		kubeConfig, rawConfig := r.GetCurrentContext(t)
-		rawConfig.CurrentContext = cluster
+		kubeConfig, _ := r.GetCurrentContext(t)
 		kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
 
 		pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
@@ -487,9 +486,11 @@ func (r *Region) EnsureKubeConfigPath() (string, error) {
 // Any failure in doing so might cause issues in other tests as some of the
 // cluster resources are tied to the namespace.
 func (r *Region) CleanupResources(t *testing.T) {
+	kubeConfig, _ := r.GetCurrentContext(t)
 	for cluster, namespace := range r.Namespace {
-		kubectlOptions := k8s.NewKubectlOptions(cluster, "", namespace)
-		certManagerK8sOptions := k8s.NewKubectlOptions(cluster, "", testutil.CertManagerNamespace)
+		kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, namespace)
+		certManagerK8sOptions := k8s.NewKubectlOptions(cluster, kubeConfig, testutil.CertManagerNamespace)
+		clusterOptions := k8s.NewKubectlOptions(cluster, kubeConfig, "")
 
 		deleteFlags := []string{"--wait", "--debug"}
 		// On OpenShift the self-signer-cleaner pre-delete hook pod is blocked by
@@ -558,6 +559,11 @@ func HelmChartPaths() (helmChartPath string, operatorChartPath string) {
 
 // createOperatorRegions returns the appropriate regions config
 // required while installing CockroachDb charts.
+// The operator determines the current cluster's domain via Status.Region, which
+// is set from the node's topology.kubernetes.io/region label (matched to the
+// cloudRegion helm value as a fallback on non-cloud providers like Kind).
+// We place other clusters' regions first so their join addresses are tried first,
+// allowing the current cluster to join the existing cluster immediately.
 func (r *Region) createOperatorRegions(index int, nodes int, customDomains map[int]string) []map[string]interface{} {
 	regions := make([]map[string]interface{}, 0, len(r.Clusters))
 
@@ -579,7 +585,6 @@ func (r *Region) createOperatorRegions(index int, nodes int, customDomains map[i
 			"nodes":         nodes,
 			"namespace":     r.Namespace[r.Clusters[i]],
 		}
-
 		if len(r.Clusters) > i && r.Clusters[i] != "" {
 			if domain, ok := customDomains[i]; ok {
 				// For single-region OpenShift, use cluster.local — the DNS
@@ -590,9 +595,18 @@ func (r *Region) createOperatorRegions(index int, nodes int, customDomains map[i
 				region["domain"] = domain
 			}
 		}
-
-		regions = append(regions, region)
+		return region
 	}
+
+	regions := make([]map[string]interface{}, 0, index+1)
+
+	// Add all preceding regions first so their join addresses are tried first.
+	for i := 0; i < index; i++ {
+		regions = append(regions, buildRegion(i))
+	}
+
+	// Add the current cluster's region last.
+	regions = append(regions, buildRegion(index))
 
 	return regions
 }
@@ -693,4 +707,854 @@ func PatchHelmValues(inputValues map[string]string) map[string]string {
 	}
 
 	return inputValues
+}
+
+const (
+	defaultWALFailoverPath  = "/cockroach/cockroach-wal-failover"
+	defaultEncryptionSecret = "cmek-key-secret"
+)
+
+// AdvancedValidationConfig aggregates validation knobs for advanced feature assertions.
+type AdvancedValidationConfig struct {
+	WALFailover      WALFailoverValidation
+	EncryptionAtRest EncryptionAtRestValidation
+	PCR              PCRValidation
+}
+
+// WALFailoverValidation captures WAL failover expectations.
+type WALFailoverValidation struct {
+	CustomPath string
+}
+
+// EncryptionAtRestValidation captures encryption validation expectations.
+type EncryptionAtRestValidation struct {
+	SecretName string
+	// OldKeyExpected is the substring expected in the --enterprise-encryption old-key field.
+	// Defaults to "old-key=plain" (initial encryption setup). For key rotation use "old-key=/etc/cockroach-key/".
+	OldKeyExpected string
+}
+
+// PCRValidation captures virtual cluster replication validation inputs.
+type PCRValidation struct {
+	Cluster          string
+	PrimaryNamespace string
+	StandbyNamespace string
+}
+
+// DefaultAdvancedValidationConfig returns default validation values used when a test does not override them.
+func DefaultAdvancedValidationConfig() AdvancedValidationConfig {
+	return AdvancedValidationConfig{
+		WALFailover: WALFailoverValidation{
+			CustomPath: defaultWALFailoverPath,
+		},
+		EncryptionAtRest: EncryptionAtRestValidation{
+			SecretName:     defaultEncryptionSecret,
+			OldKeyExpected: "old-key=plain",
+		},
+	}
+}
+
+func mergeValidationConfig(cfg *AdvancedValidationConfig) AdvancedValidationConfig {
+	merged := DefaultAdvancedValidationConfig()
+	if cfg == nil {
+		return merged
+	}
+
+	if cfg.WALFailover.CustomPath != "" {
+		merged.WALFailover = cfg.WALFailover
+	}
+	if cfg.EncryptionAtRest.SecretName != "" {
+		merged.EncryptionAtRest.SecretName = cfg.EncryptionAtRest.SecretName
+	}
+	if cfg.EncryptionAtRest.OldKeyExpected != "" {
+		merged.EncryptionAtRest.OldKeyExpected = cfg.EncryptionAtRest.OldKeyExpected
+	}
+	if cfg.PCR.Cluster != "" || cfg.PCR.PrimaryNamespace != "" || cfg.PCR.StandbyNamespace != "" {
+		merged.PCR = cfg.PCR
+	}
+
+	return merged
+}
+
+// AssignRandomNamespace assigns a randomized namespace for the given cluster using the default prefix.
+func (r *Region) AssignRandomNamespace(cluster string) string {
+	return r.AssignRandomNamespaceWithPrefix(cluster, Namespace)
+}
+
+// AssignRandomNamespaceWithPrefix assigns a randomized namespace for the given cluster using the provided prefix.
+func (r *Region) AssignRandomNamespaceWithPrefix(cluster string, prefix string) string {
+	if prefix == "" {
+		prefix = Namespace
+	}
+	if r.Namespace == nil {
+		r.Namespace = make(map[string]string)
+	}
+	name := fmt.Sprintf("%s-%s", prefix, strings.ToLower(random.UniqueId()))
+	r.Namespace[cluster] = name
+	return name
+}
+
+// AssignRandomNamespacesWithPrefix assigns randomized namespaces for all tracked clusters.
+func (r *Region) AssignRandomNamespacesWithPrefix(prefix string) {
+	for _, cluster := range r.Clusters {
+		r.AssignRandomNamespaceWithPrefix(cluster, prefix)
+	}
+}
+
+// RequireCACertificate creates a CA certificate for the current test and returns a cleanup closure.
+func (r *Region) RequireCACertificate(t *testing.T) func() {
+	err := r.CreateCACertificate(t)
+	require.NoError(t, err)
+	return func() {
+		r.CleanUpCACertificate(t)
+	}
+}
+
+// SetupSingleClusterWithCA prepares a single cluster for advanced tests and returns a cleanup closure.
+func (r *Region) SetupSingleClusterWithCA(t *testing.T, cluster string) func() {
+	r.AssignRandomNamespace(cluster)
+	cleanupCA := r.RequireCACertificate(t)
+	return func() {
+		r.CleanupResources(t)
+		cleanupCA()
+	}
+}
+
+// SetupMultiClusterWithCA prepares all clusters for advanced tests and returns a cleanup closure.
+func (r *Region) SetupMultiClusterWithCA(t *testing.T) func() {
+	r.AssignRandomNamespacesWithPrefix(Namespace)
+	cleanupCA := r.RequireCACertificate(t)
+	return func() {
+		r.CleanupResources(t)
+		cleanupCA()
+	}
+}
+
+// BaseRegionConfig returns a baseline region configuration map for the provided cluster and index.
+func (r *Region) BaseRegionConfig(cluster string, index int) map[string]interface{} {
+	code := fmt.Sprintf("region-%d", index)
+	if len(r.RegionCodes) > index {
+		code = r.RegionCodes[index]
+	}
+	region := map[string]interface{}{
+		"code":          code,
+		"cloudProvider": r.Provider,
+		"nodes":         r.NodeCount,
+		"namespace":     r.Namespace[cluster],
+	}
+	if domain, ok := CustomDomains[index]; ok {
+		region["domain"] = domain
+	}
+	return region
+}
+
+// EncryptionAtRestConfig returns a reusable encryption configuration map with optional overrides.
+// When an override value is nil or empty string, the key is omitted from the config entirely.
+// This matters because the operator uses *string with omitempty — a nil/absent keySecretName
+// is interpreted as "plain" (unencrypted), while an empty string is not the same as nil.
+func (r *Region) EncryptionAtRestConfig(secretName string, overrides map[string]interface{}) map[string]interface{} {
+	if secretName == "" {
+		secretName = "cmek-key-secret"
+	}
+	config := map[string]interface{}{
+		"platform":      "UNKNOWN_KEY_TYPE",
+		"keySecretName": secretName,
+	}
+	for k, v := range overrides {
+		if v == nil || v == "" {
+			// Delete the key so it is omitted from JSON (nil pointer in operator = "plain").
+			delete(config, k)
+		} else {
+			config[k] = v
+		}
+	}
+	return config
+}
+
+// BuildEncryptionRegions creates a slice containing a single region entry with encryption settings applied.
+func (r *Region) BuildEncryptionRegions(cluster string, index int, encryptionOverrides map[string]interface{}) []map[string]interface{} {
+	region := r.BaseRegionConfig(cluster, index)
+	region["encryptionAtRest"] = r.EncryptionAtRestConfig("", encryptionOverrides)
+	return []map[string]interface{}{region}
+}
+
+// AdvancedInstallConfig holds configuration for advanced feature installations
+type AdvancedInstallConfig struct {
+	// WAL Failover configuration
+	WALFailoverEnabled bool
+	WALFailoverSize    string
+
+	// Encryption at Rest configuration
+	EncryptionEnabled      bool
+	EncryptionKeySecret    string
+	EncryptionKeySecretName string // defaults to "cmek-key-secret" if empty
+
+	// Virtual Cluster configuration (for PCR)
+	VirtualClusterMode string // "primary", "standby", or ""
+
+	// Custom helm values to merge
+	CustomValues map[string]string
+
+	// Custom regions configuration (for encryption)
+	CustomRegions []map[string]interface{}
+
+	// Skip operator installation (for second virtual cluster)
+	SkipOperatorInstall bool
+}
+
+// InstallChartsWithAdvancedConfig installs CockroachDB with advanced features configuration
+func (r *Region) InstallChartsWithAdvancedConfig(t *testing.T, cluster string, index int, config AdvancedInstallConfig) {
+	// Get the current context name.
+	kubeConfig, rawConfig := r.GetCurrentContext(t)
+
+	// Get helm chart paths.
+	helmChartPath, _ := HelmChartPaths()
+
+	// Verify if a cluster exists in the contexts.
+	if _, ok := rawConfig.Contexts[cluster]; !ok {
+		t.Fatal()
+	}
+
+	// Setup kubectl options for this cluster.
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+
+	// Create a namespace.
+	k8s.CreateNamespace(t, kubectlOptions, r.Namespace[cluster])
+
+	// create CA Secret.
+	err := k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", customCASecret, "--from-file=ca.crt",
+		"--from-file=ca.key")
+	require.NoError(t, err)
+
+	// Create encryption key secret if encryption is enabled
+	if config.EncryptionEnabled && config.EncryptionKeySecret != "" {
+		encryptionSecretName := config.EncryptionKeySecretName
+		if encryptionSecretName == "" {
+			encryptionSecretName = "cmek-key-secret"
+		}
+
+		// Use --from-literal with the base64-encoded key string. Kubernetes base64-encodes
+		// secret values for storage, so the pod receives the original base64 string when
+		// the secret is mounted — which the init container then decodes to get the raw key.
+		err = k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", encryptionSecretName,
+			fmt.Sprintf("--from-literal=StoreKeyData=%s", config.EncryptionKeySecret))
+		require.NoError(t, err)
+
+		// Verify secret was created with data
+		secretSize, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+			"get", "secret", encryptionSecretName,
+			"-o", "jsonpath={.data.StoreKeyData}")
+		require.NoError(t, err)
+		require.True(t, len(secretSize) > 0, "Secret StoreKeyData should be >0")
+		t.Logf("Created encryption secret %s with size: %d bytes", encryptionSecretName, len(secretSize))
+	}
+
+	// Install the operator when it is not skipped and not already marked as installed.
+	if !config.SkipOperatorInstall && !r.IsOperatorInstalled {
+		InstallCockroachDBEnterpriseOperator(t, kubectlOptions, r.RegionCodes[index])
+	}
+
+	// Build helm values
+	helmValues := PatchHelmValues(map[string]string{
+		"cockroachdb.clusterDomain":             CustomDomains[index],
+		"cockroachdb.tls.selfSigner.caProvided": "true",
+		"cockroachdb.tls.selfSigner.caSecret":   customCASecret,
+	})
+
+	// Add WAL failover configuration
+	if config.WALFailoverEnabled {
+		helmValues["cockroachdb.crdbCluster.walFailoverSpec.status"] = "enable"
+		helmValues["cockroachdb.crdbCluster.walFailoverSpec.size"] = config.WALFailoverSize
+		helmValues["cockroachdb.crdbCluster.walFailoverSpec.name"] = "datadir-wal-failover"
+		helmValues["cockroachdb.crdbCluster.walFailoverSpec.path"] = "/cockroach/cockroach-wal-failover"
+	}
+
+	// Add virtual cluster configuration
+	if config.VirtualClusterMode != "" {
+		helmValues["cockroachdb.crdbCluster.virtualCluster.mode"] = config.VirtualClusterMode
+	}
+
+	// Merge custom values
+	for k, v := range config.CustomValues {
+		helmValues[k] = v
+	}
+
+	// Determine which regions configuration to use
+	var regionsConfig interface{}
+	if config.CustomRegions != nil {
+		regionsConfig = config.CustomRegions
+	} else {
+		regionsConfig = r.OperatorRegions(index, r.NodeCount)
+	}
+
+	// Helm install cockroach CR with configuration
+	crdbOptions := &helm.Options{
+		KubectlOptions: kubectlOptions,
+		SetValues:      helmValues,
+		SetJsonValues: map[string]string{
+			"cockroachdb.crdbCluster.regions": MustMarshalJSON(regionsConfig),
+		},
+		ExtraArgs: helmExtraArgs,
+	}
+
+	helm.Install(t, crdbOptions, helmChartPath, ReleaseName)
+
+	serviceName := "cockroachdb-public"
+	k8s.WaitUntilServiceAvailable(t, kubectlOptions, serviceName, 30, 5*time.Second)
+}
+
+// ValidateWALFailover verifies that WAL failover is properly configured by checking the --wal-failover flag and PVC.
+// Pass nil config to rely on defaults or provide a pointer with overrides through AdvancedValidationConfig.WALFailover.
+func (r *Region) ValidateWALFailover(t *testing.T, cluster string, cfg *AdvancedValidationConfig) {
+	validationConfig := mergeValidationConfig(cfg)
+	expectedPath := validationConfig.WALFailover.CustomPath
+	if expectedPath == "" {
+		expectedPath = defaultWALFailoverPath
+	}
+
+	kubeConfig, _ := r.GetCurrentContext(t)
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+
+	// Get CockroachDB pods
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+
+	podName := pods[0].Name
+
+	// 1. Verify cockroach start command contains --wal-failover flag with custom path
+	t.Logf("Verifying cockroach start command contains --wal-failover flag with path %s...", expectedPath)
+	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+	require.NoError(t, err)
+	expectedFlag := fmt.Sprintf("--wal-failover=path=%s", expectedPath)
+	require.Contains(t, podCommand, expectedFlag,
+		"Pod command should contain %s", expectedFlag)
+	t.Logf("Cockroach start command contains --wal-failover flag with path %s", expectedPath)
+
+	// 2. Verify COCKROACH_WAL_FAILOVER environment variable is set
+	t.Log("Verifying COCKROACH_WAL_FAILOVER environment variable...")
+	walFailoverEnv, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].env[?(@.name=='COCKROACH_WAL_FAILOVER')].value}")
+	if err == nil && walFailoverEnv != "" {
+		t.Logf("COCKROACH_WAL_FAILOVER environment variable is set to: %s", walFailoverEnv)
+	}
+
+	// 3. Verify WAL failover PVC exists with correct naming convention
+	t.Log("Verifying WAL failover PVC exists...")
+	pvcs, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pvc", "-o", "jsonpath={.items[*].metadata.name}")
+	require.NoError(t, err)
+	t.Logf("Found PVCs: %s", pvcs)
+	// PVC should follow the pattern: datadir-wal-failover-cockroachdb-{index}
+	// The name prefix comes from walFailoverSpec.name which we set to "datadir-wal-failover"
+	require.Contains(t, pvcs, "datadir-wal-failover", "WAL failover PVC should exist with correct naming")
+	t.Log("WAL failover PVC exists with correct naming convention")
+
+	// 4. Verify WAL failover volume is mounted in the pod
+	t.Log("Verifying WAL failover volume is mounted...")
+	volumes, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pod", podName, "-o", "jsonpath={.spec.volumes[*].name}")
+	require.NoError(t, err)
+	// The volume name is always "wal-failover" regardless of the custom path or PVC name
+	require.Contains(t, volumes, "wal-failover", "WAL failover volume should be mounted")
+	t.Log("WAL failover volume is properly mounted")
+
+	// 5. Verify the custom WAL failover path exists in the container
+	t.Logf("Verifying custom WAL failover path %s exists in container...", expectedPath)
+	_, err = k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"exec", podName, "-c", "cockroachdb", "--",
+		"ls", "-la", expectedPath)
+	require.NoError(t, err)
+	t.Logf("Custom WAL failover path %s exists in container", expectedPath)
+
+	t.Log("WAL failover validation completed successfully")
+}
+
+// GenerateEncryptionKey generates a 256-bit AES encryption key and returns base64 encoded value
+func (r *Region) GenerateEncryptionKey(t *testing.T) string {
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "store.key")
+
+	// Generate 256-bit AES key using cockroach gen encryption-key
+	cmd := shell.Command{
+		Command:    "cockroach",
+		Args:       []string{"gen", "encryption-key", "--size", "256", "store.key"},
+		WorkingDir: tempDir,
+	}
+
+	_, err := shell.RunCommandAndGetOutputE(t, cmd)
+	require.NoError(t, err)
+
+	// Read the generated key file
+	keyBytes, err := os.ReadFile(keyPath)
+	require.NoError(t, err)
+
+	// Base64 encode the key (removing any newlines)
+	storeKeyB64 := base64.StdEncoding.EncodeToString(keyBytes)
+	storeKeyB64 = strings.ReplaceAll(storeKeyB64, "\n", "")
+
+	return storeKeyB64
+}
+
+// ValidateEncryptionAtRest verifies that encryption at rest is properly configured by checking flags and encryption status.
+// Pass nil config to rely on defaults or provide overrides via AdvancedValidationConfig.EncryptionAtRest.
+func (r *Region) ValidateEncryptionAtRest(t *testing.T, cluster string, cfg *AdvancedValidationConfig) {
+	kubeConfig, _ := r.GetCurrentContext(t)
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+
+	// Get CockroachDB pods
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+
+	podName := pods[0].Name
+
+	validationConfig := mergeValidationConfig(cfg)
+	secretName := validationConfig.EncryptionAtRest.SecretName
+	if secretName == "" {
+		secretName = defaultEncryptionSecret
+	}
+
+	// 1. Assert CR spec has encryptionAtRest set, which means --enterprise-encryption
+	// must be present in the pod start command.
+	t.Log("Verifying encryptionAtRest is set in the CrdbCluster CR spec...")
+	crEncryption, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "crdbcluster", "cockroachdb",
+		"-o", "jsonpath={.spec.regions[*].encryptionAtRest.keySecretName}")
+	require.NoError(t, err)
+	require.NotEmpty(t, crEncryption, "CrdbCluster CR spec should have encryptionAtRest.keySecretName set")
+	t.Logf("CrdbCluster CR spec has encryptionAtRest set with keySecretName: %s", crEncryption)
+
+	// 2. Verify the encryption key secret exists and has data
+	t.Logf("Verifying encryption key secret %s...", secretName)
+	secretSize, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "secret", secretName,
+		"-o", "jsonpath={.data.StoreKeyData}")
+	require.NoError(t, err)
+	require.True(t, len(secretSize) > 0, "Secret StoreKeyData should not be empty")
+	t.Logf("Encryption key secret %s exists with data", secretName)
+
+	// 3. Verify cockroach start command contains encryption flags
+	t.Log("Verifying cockroach start command contains encryption flags...")
+	podSpec, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+	require.NoError(t, err)
+	require.Contains(t, podSpec, "--enterprise-encryption", "Pod command should contain --enterprise-encryption flag")
+	t.Log("Cockroach start command contains encryption flags")
+
+	// 4. Verify all required fields of the --enterprise-encryption flag are present.
+	// Required fields per CockroachDB docs: path, key, old-key.
+	require.Contains(t, podSpec, "path=cockroach-data", "Encryption flag should contain path=cockroach-data")
+	require.Contains(t, podSpec, "key=/etc/cockroach-key/", "Encryption flag should contain key path")
+	oldKeyExpected := validationConfig.EncryptionAtRest.OldKeyExpected
+	require.Contains(t, podSpec, oldKeyExpected, "Encryption flag should contain %s", oldKeyExpected)
+	t.Log("Encryption flag verified: path, key, and old-key are all present")
+
+	// 5. Verify encryption algorithm via node metrics.
+	// rocksdb.encryption.algorithm: 0=Plaintext, 1=AES-128-CTR, 2=AES-192-CTR, 3=AES-256-CTR
+	t.Log("Verifying encryption algorithm via node metrics...")
+	encAlgorithm, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"exec", podName, "-c", "cockroachdb", "--",
+		"/cockroach/cockroach", "sql",
+		"--certs-dir=/cockroach/cockroach-certs",
+		"--host=localhost:26257",
+		"-e", "SET allow_unsafe_internals = true; SELECT value FROM crdb_internal.node_metrics WHERE name = 'rocksdb.encryption.algorithm';")
+	require.NoError(t, err)
+	require.Contains(t, encAlgorithm, "3", "rocksdb.encryption.algorithm should be 3 (AES-256-CTR)")
+	t.Logf("Encryption algorithm verified: AES-256-CTR (value=3)")
+
+	t.Log("Encryption at rest validation completed successfully")
+}
+
+// generateLocalTenantURI creates local connection URI for connecting to same cluster's tenants
+// Returns: postgresql://root:root@localhost:26257?options=-ccluster%3D<cluster>
+func generateLocalTenantURI(cluster string) string {
+	return fmt.Sprintf("postgresql://root:root@localhost:26257?options=-ccluster%%3D%s", cluster)
+}
+
+// generateExternalConnectionURI creates external connection URI using cockroach encode-uri
+// This is used for cross-cluster connections (e.g., replication from primary to standby)
+// Format: cockroach encode-uri 'postgresql://USERNAME:PASSWORD@HOST' [flags]
+func generateExternalConnectionURI(t *testing.T, kubectlOpts *k8s.KubectlOptions, pod string, connString string) string {
+	output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOpts,
+		"exec", pod, "-c", "cockroachdb", "--",
+		"/cockroach/cockroach", "encode-uri",
+		connString, // Format: postgresql://user:pass@host:port
+		"--ca-cert=/cockroach/cockroach-certs/ca.crt",
+		"--inline")
+	require.NoError(t, err)
+	return strings.TrimSpace(output)
+}
+
+// Helper function to execute SQL on a specific virtual cluster
+func execSQLOnVC(t *testing.T, kubectlOpts *k8s.KubectlOptions, pod string, vcURI string, database string, sql string) (string, error) {
+	args := []string{
+		"exec", pod, "-c", "cockroachdb", "--",
+		"/cockroach/cockroach", "sql",
+		"--certs-dir=/cockroach/cockroach-certs",
+		"--url", vcURI,
+	}
+	if database != "" {
+		args = append(args, "--database="+database)
+	}
+	args = append(args, "-e", sql)
+
+	return k8s.RunKubectlAndGetOutputE(t, kubectlOpts, args...)
+}
+
+// ValidatePCR validates PCR by verifying virtual cluster configuration and testing failover/failback connections.
+// Provide the cluster and namespaces through AdvancedValidationConfig.PCR.
+func (r *Region) ValidatePCR(t *testing.T, cfg *AdvancedValidationConfig) {
+	validationConfig := mergeValidationConfig(cfg)
+	cluster := validationConfig.PCR.Cluster
+	primaryNamespace := validationConfig.PCR.PrimaryNamespace
+	standbyNamespace := validationConfig.PCR.StandbyNamespace
+
+	require.NotEmpty(t, cluster, "PCR validation requires a cluster context")
+	require.NotEmpty(t, primaryNamespace, "PCR validation requires a primary namespace")
+	require.NotEmpty(t, standbyNamespace, "PCR validation requires a standby namespace")
+
+	kubeConfig, _ := r.GetCurrentContext(t)
+
+	// Get primary and standby pods
+	primaryKubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, primaryNamespace)
+	standbyKubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, standbyNamespace)
+
+	primaryPods := k8s.ListPods(t, primaryKubectlOptions, metav1.ListOptions{
+		LabelSelector: LabelSelector,
+	})
+	require.True(t, len(primaryPods) > 0, "No primary pods found")
+
+	standbyPods := k8s.ListPods(t, standbyKubectlOptions, metav1.ListOptions{
+		LabelSelector: LabelSelector,
+	})
+	require.True(t, len(standbyPods) > 0, "No standby pods found")
+
+	primaryPod := primaryPods[0].Name
+	standbyPod := standbyPods[0].Name
+
+	// Step 1: Setup primary cluster for PCR
+	t.Log("==================================================")
+	t.Log("Step 1: Setting up primary cluster for Physical Cluster Replication")
+	t.Log("==================================================")
+
+	// Generate local connection URIs for primary
+	primarySystemURI := generateLocalTenantURI("system")
+	t.Logf("Connecting to primary system tenant at: %s", primarySystemURI)
+
+	// Enable rangefeed for PCR (required for replication)
+	t.Log("Enabling rangefeed on primary cluster (required for PCR)...")
+	_, err := execSQLOnVC(t, primaryKubectlOptions, primaryPod, primarySystemURI, "", "SET CLUSTER SETTING kv.rangefeed.enabled = true")
+	require.NoError(t, err)
+	t.Log("✓ Rangefeed enabled on primary cluster")
+
+	// With --virtualized flag, the 'main' virtual cluster is created automatically
+	// We just need to verify it exists and ensure it's in SHARED mode
+	t.Log("Verifying main virtual cluster exists on primary (automatically created with --virtualized flag)...")
+	primaryVCs, err := execSQLOnVC(t, primaryKubectlOptions, primaryPod, primarySystemURI, "", "SHOW VIRTUAL CLUSTERS")
+	require.NoError(t, err)
+	require.Contains(t, primaryVCs, "main", "Primary should have main virtual cluster")
+	t.Logf("✓ Main virtual cluster exists on primary\n%s", primaryVCs)
+
+	// Ensure the service is started in SHARED mode
+	t.Log("Ensuring main virtual cluster service is in SHARED mode...")
+	_, err = execSQLOnVC(t, primaryKubectlOptions, primaryPod, primarySystemURI, "", "ALTER VIRTUAL CLUSTER main START SERVICE SHARED")
+	if err != nil && !strings.Contains(err.Error(), "already") {
+		t.Logf("Note: Service start returned: %v", err)
+	}
+	t.Log("✓ Main virtual cluster service is running in SHARED mode")
+
+	// Wait for main virtual cluster service to be ready in SHARED mode
+	t.Log("Waiting for main virtual cluster service readiness on primary...")
+	_, err = retry.DoWithRetryE(t, "wait for main virtual cluster service to be ready in SHARED mode",
+		24, 5*time.Second,
+		func() (string, error) {
+			out, execErr := execSQLOnVC(t, primaryKubectlOptions, primaryPod, primarySystemURI, "", "SHOW VIRTUAL CLUSTERS")
+			if execErr != nil {
+				return "", execErr
+			}
+			if !strings.Contains(out, "shared") {
+				return "", fmt.Errorf("main virtual cluster service not yet in SHARED mode: %s", out)
+			}
+			return out, nil
+		})
+	require.NoError(t, err, "main virtual cluster service did not reach SHARED mode")
+	t.Log("✓ Main virtual cluster service is ready in SHARED mode")
+
+	// Create replication user on primary with required permissions
+	t.Log("Creating replication user on primary cluster...")
+	createUserSQL := fmt.Sprintf("CREATE USER IF NOT EXISTS %s WITH PASSWORD '%s'", "pcr_source", "repl_password_123")
+	_, err = execSQLOnVC(t, primaryKubectlOptions, primaryPod, primarySystemURI, "", createUserSQL)
+	require.NoError(t, err)
+	t.Log("✓ Created user: pcr_source")
+
+	t.Log("Granting admin privileges to pcr_source...")
+	_, err = execSQLOnVC(t, primaryKubectlOptions, primaryPod, primarySystemURI, "", "GRANT admin TO pcr_source")
+	require.NoError(t, err)
+	t.Log("✓ Granted admin privileges to pcr_source")
+
+	t.Log("Primary cluster setup complete!")
+
+	// Step 2: Setup standby cluster
+	t.Log("")
+	t.Log("==================================================")
+	t.Log("Step 2: Setting up standby cluster")
+	t.Log("==================================================")
+
+	// Generate local connection URI for standby
+	standbySystemURI := generateLocalTenantURI("system")
+	t.Logf("Connecting to standby system tenant at: %s", standbySystemURI)
+
+	// Enable rangefeed on standby cluster
+	t.Log("Enabling rangefeed on standby cluster...")
+	_, err = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "SET CLUSTER SETTING kv.rangefeed.enabled = true")
+	require.NoError(t, err)
+	t.Log("✓ Rangefeed enabled on standby cluster")
+
+	// Verify standby was initialized with --virtualized-empty (no main VC yet)
+	t.Log("Verifying standby cluster state (should have no main virtual cluster yet)...")
+	standbyVCsInitial, err := execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "SHOW VIRTUAL CLUSTERS")
+	require.NoError(t, err)
+	t.Logf("Standby virtual clusters before replication:\n%s", standbyVCsInitial)
+	t.Log("✓ Standby initialized with --virtualized-empty (no main tenant yet)")
+
+	// Create admin user on standby
+	t.Log("Creating admin user on standby cluster...")
+	createAdminSQL := fmt.Sprintf("CREATE USER IF NOT EXISTS %s WITH PASSWORD '%s'", "pcr_admin", "admin_password_123")
+	_, err = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", createAdminSQL)
+	require.NoError(t, err)
+	_, err = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "GRANT admin TO pcr_admin")
+	require.NoError(t, err)
+	t.Log("✓ Created user pcr_admin with admin privileges")
+	t.Log("Standby cluster setup complete!")
+
+	// Step 4: Set up replication stream from standby to primary
+	t.Log("")
+	t.Log("==================================================")
+	t.Log("Step 4: Creating replication stream from primary to standby")
+	t.Log("==================================================")
+
+	// Step 4a: Generate external connection URI for replication
+	// Following: https://www.cockroachlabs.com/docs/stable/set-up-physical-cluster-replication#step-4-start-replication
+	t.Log("Generating connection URI for primary cluster using cockroach encode-uri...")
+	primaryHost := fmt.Sprintf("cockroachdb-public.%s.svc.%s:26257", primaryNamespace, CustomDomains[0])
+	primaryConnString := fmt.Sprintf("postgresql://%s:%s@%s", "pcr_source", "repl_password_123", primaryHost)
+	t.Logf("Primary connection string format: postgresql://pcr_source:***@%s", primaryHost)
+
+	// Use encode-uri to generate the proper connection string with certificates
+	encodedPrimaryURI := generateExternalConnectionURI(t, standbyKubectlOptions, standbyPod, primaryConnString)
+	t.Logf("✓ Generated encoded connection URI for replication")
+
+	// Step 4b: Create external connection on standby (as per documentation)
+	t.Log("Creating external connection on standby cluster...")
+	createExternalConnSQL := fmt.Sprintf("CREATE EXTERNAL CONNECTION IF NOT EXISTS primary_replication AS '%s'", encodedPrimaryURI)
+	_, err = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", createExternalConnSQL)
+	require.NoError(t, err)
+	t.Log("✓ External connection 'primary_replication' created on standby")
+
+	// Step 4c: Create the replication stream using the external connection name
+	t.Log("Creating replication stream on standby cluster using external connection...")
+	t.Log("This will create the main virtual cluster on standby and start replicating data from primary")
+	createReplicationCmd := "CREATE VIRTUAL CLUSTER main FROM REPLICATION OF main ON 'external://primary_replication'"
+	t.Logf("Executing: %s", createReplicationCmd)
+
+	output, err := execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", createReplicationCmd)
+	if err != nil && !strings.Contains(err.Error(), "already exists") && !strings.Contains(output, "already exists") {
+		t.Logf("ERROR: Replication stream creation failed: %v", err)
+		t.Logf("Output: %s", output)
+		// Debug: Check what tenants exist on primary
+		t.Log("Debugging: Checking virtual clusters on primary...")
+		tenantsOutput, _ := execSQLOnVC(t, primaryKubectlOptions, primaryPod, primarySystemURI, "", "SHOW VIRTUAL CLUSTERS")
+		t.Logf("Virtual clusters on primary:\n%s", tenantsOutput)
+		require.NoError(t, err, "Failed to create replication stream")
+	} else {
+		t.Log("✓ Replication stream created successfully!")
+		t.Log("✓ Main virtual cluster now exists on standby and is replicating from primary")
+	}
+
+	// Wait for replication stream to be active on standby
+	t.Log("Waiting for initial replication stream to become active on standby...")
+	_, err = retry.DoWithRetryE(t, "wait for replication stream to become active on standby",
+		36, 10*time.Second,
+		func() (string, error) {
+			out, execErr := execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "SHOW VIRTUAL CLUSTERS")
+			if execErr != nil {
+				return "", execErr
+			}
+			if !strings.Contains(out, "replicat") {
+				return "", fmt.Errorf("replication stream not yet active: %s", out)
+			}
+			return out, nil
+		})
+	require.NoError(t, err, "replication stream did not become active on standby")
+	t.Log("✓ Initial replication sync complete")
+
+	// Step 5: Verify replication status
+	t.Log("")
+	t.Log("==================================================")
+	t.Log("Step 5: Verifying replication status")
+	t.Log("==================================================")
+
+	t.Log("Checking virtual clusters on standby (should now include main)...")
+	standbyVCsStatus, err := execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "SHOW VIRTUAL CLUSTERS")
+	require.NoError(t, err)
+	require.Contains(t, standbyVCsStatus, "main", "Standby should now have main virtual cluster after replication setup")
+	t.Logf("Virtual clusters on standby:\n%s", standbyVCsStatus)
+	t.Log("✓ Main virtual cluster exists on standby with replication status")
+
+	t.Log("Replication verification complete!")
+
+	// Step 6: Test read-only access on standby using a separate reader virtual cluster
+	// Following: https://www.cockroachlabs.com/docs/stable/read-from-standby
+	t.Log("")
+	t.Log("==================================================")
+	t.Log("Step 6: Testing read-only access on standby cluster")
+	t.Log("==================================================")
+
+	// Step 6a: Create a reader virtual cluster for read-only access
+	// This is the recommended approach per documentation
+	t.Log("Creating a reader virtual cluster on standby for read-only access...")
+	t.Log("This allows read queries without affecting the replication stream")
+	createReaderSQL := `CREATE VIRTUAL CLUSTER "main-reader" FROM REPLICATION OF main ON 'external://primary_replication' WITH READ VIRTUAL CLUSTER`
+	_, err = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", createReaderSQL)
+	if err != nil && !strings.Contains(err.Error(), "already exists") {
+		t.Logf("Note: Reader VC creation returned: %v", err)
+	}
+	t.Log("✓ Reader virtual cluster 'main-reader' created")
+
+	// Step 6b: Start the reader service in SHARED mode
+	t.Log("Starting reader virtual cluster service in SHARED mode...")
+	_, err = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", `ALTER VIRTUAL CLUSTER "main-reader" START SERVICE SHARED`)
+	if err != nil && !strings.Contains(err.Error(), "already") {
+		t.Logf("Note: Service start returned: %v (may already be started)", err)
+	}
+	t.Log("✓ Reader service started in SHARED mode")
+
+	// Wait for reader virtual cluster service to be ready in SHARED mode
+	t.Log("Waiting for reader virtual cluster service to be ready in SHARED mode...")
+	_, err = retry.DoWithRetryE(t, "wait for main-reader virtual cluster service to be ready in SHARED mode",
+		36, 10*time.Second,
+		func() (string, error) {
+			out, execErr := execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "SHOW VIRTUAL CLUSTERS")
+			if execErr != nil {
+				return "", execErr
+			}
+			if !strings.Contains(out, "main-reader") || !strings.Contains(out, "shared") {
+				return "", fmt.Errorf("main-reader service not yet in SHARED mode: %s", out)
+			}
+			return out, nil
+		})
+	require.NoError(t, err, "main-reader virtual cluster service did not reach SHARED mode")
+
+	// Step 6c: Verify reader virtual cluster exists
+	t.Log("Verifying reader virtual cluster status...")
+	readerVCsStatus, err := execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "SHOW VIRTUAL CLUSTERS")
+	require.NoError(t, err)
+	require.Contains(t, readerVCsStatus, "main-reader", "Standby should have main-reader virtual cluster")
+	t.Logf("Virtual clusters on standby:\n%s", readerVCsStatus)
+	t.Log("✓ Reader virtual cluster is ready")
+
+	// Step 6d: Read from the reader virtual cluster
+	t.Log("Attempting to read replicated data from reader virtual cluster...")
+	readerURI := generateLocalTenantURI("main-reader")
+	readFromStandby, err := execSQLOnVC(t, standbyKubectlOptions, standbyPod, readerURI, "bank", "SELECT id, balance FROM accounts ORDER BY id")
+	if err != nil {
+		t.Logf("Warning: Read from standby reader failed (may need more time): %v", err)
+		// Try reading directly from main VC as fallback
+		t.Log("Trying to read from main virtual cluster instead...")
+		standbyMainURI := generateLocalTenantURI("main")
+		readFromStandby, err = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbyMainURI, "bank", "SELECT id, balance FROM accounts ORDER BY id")
+		if err != nil {
+			t.Logf("Warning: Read from main VC also failed: %v", err)
+		}
+	}
+
+	if err == nil {
+		require.Contains(t, readFromStandby, "1000", "Should be able to read replicated data from standby")
+		require.Contains(t, readFromStandby, "250", "Should be able to read replicated data from standby")
+		t.Log("✓ Successfully read replicated data from standby reader!")
+		t.Logf("Data from standby reader:\n%s", readFromStandby)
+	}
+
+	t.Log("Read-only access test complete!")
+
+	// Step 7: Test failover (cutover)
+	t.Log("")
+	t.Log("==================================================")
+	t.Log("Step 7: Testing failover (promoting standby to primary)")
+	t.Log("==================================================")
+
+	// Stop the service first (if running in SHARED mode)
+	t.Log("Stopping main virtual cluster service on standby before cutover...")
+	_, _ = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "ALTER VIRTUAL CLUSTER main STOP SERVICE")
+	t.Log("✓ Service stopped")
+
+	time.Sleep(5 * time.Second)
+
+	// Complete replication to latest - this makes the standby writable
+	t.Log("Completing replication to latest (this promotes standby to be writable)...")
+	_, err = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "ALTER VIRTUAL CLUSTER main COMPLETE REPLICATION TO LATEST")
+	if err != nil {
+		t.Logf("Note: Cutover command returned: %v", err)
+	}
+	t.Log("✓ Replication completed to latest")
+
+	// Wait for cutover to complete
+	t.Log("Waiting for cutover to complete (15 seconds)...")
+	time.Sleep(15 * time.Second)
+
+	// Step 8: Start the service after cutover
+	t.Log("")
+	t.Log("==================================================")
+	t.Log("Step 8: Starting service on promoted standby")
+	t.Log("==================================================")
+
+	t.Log("Starting main virtual cluster service after cutover...")
+	_, err = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "ALTER VIRTUAL CLUSTER main START SERVICE SHARED")
+	if err != nil {
+		t.Logf("Note: Service start returned: %v (may already be started)", err)
+	}
+	t.Log("✓ Service started, standby is now the primary and can accept writes")
+
+	//time.Sleep(10 * time.Second)
+
+	// Step 9: Verify promoted standby can serve read/write traffic
+	//t.Log("")
+	//t.Log("==================================================")
+	//t.Log("Step 9: Verifying promoted standby can handle read/write traffic")
+	//t.Log("==================================================")
+	//
+	//// Check virtual cluster status
+	//t.Log("Checking virtual cluster status after cutover...")
+	//standbyVCsFinal, err := execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "SHOW VIRTUAL CLUSTERS")
+	//require.NoError(t, err)
+	//t.Logf("Virtual clusters on promoted standby:\n%s", standbyVCsFinal)
+	//t.Log("✓ Virtual cluster status looks good")
+
+	// Step 10: Cleanup note
+	//t.Log("")
+	//t.Log("==================================================")
+	//t.Log("Step 10: Cleanup")
+	//t.Log("==================================================")
+	//t.Log("Note: Reader virtual cluster 'main-reader' can be dropped if no longer needed")
+	//t.Log("Command: DROP VIRTUAL CLUSTER main-reader")
+	//
+	//t.Log("")
+	//t.Log("==================================================")
+	//t.Log("PCR Validation Complete!")
+	//t.Log("==================================================")
+	//t.Log("✓ Successfully tested:")
+	//t.Log("  - Virtual cluster setup with --virtualized flag on primary")
+	//t.Log("  - Virtual cluster setup with --virtualized-empty flag on standby")
+	//t.Log("  - User creation and permissions (pcr_source, pcr_admin)")
+	//t.Log("  - External connection creation")
+	//t.Log("  - Replication stream creation using external connection")
+	//t.Log("  - Reader virtual cluster for read-only access")
+	//t.Log("  - Read-only access to standby via reader VC")
+	//t.Log("  - Failover (cutover) to standby")
+	//t.Log("  - Read/write operations on promoted standby")
+	//t.Log("==================================================")
 }

--- a/tests/e2e/operator/region.go
+++ b/tests/e2e/operator/region.go
@@ -81,6 +81,10 @@ type Region struct {
 	VirtualClusterModePrimary bool
 	VirtualClusterModeStandby bool
 	IsOperatorInstalled       bool
+
+	// certDir is the per-test temp directory holding ca.crt/ca.key.
+	// Populated by CreateCACertificate; cleaned up automatically by t.TempDir().
+	certDir string
 }
 
 // InstallCharts Installs both Operator and CockroachDB charts by providing custom CA secret
@@ -107,6 +111,35 @@ func (r *Region) InstallCharts(t *testing.T, cluster string, index int) {
 	// Create a namespace.
 	k8s.CreateNamespace(t, kubectlOptions, r.Namespace[cluster])
 
+	// Apply OpenShift SCC bindings before pod creation.
+	// Grants anyuid SCC to all service accounts in the namespace via a ClusterRoleBinding.
+	// Uses kubectl apply (idempotent) so re-running against an existing cluster is safe.
+	if r.Provider == "openshift" {
+		bindingName := fmt.Sprintf("cockroach-anyuid-%s", r.Namespace[cluster])
+		group := fmt.Sprintf("system:serviceaccounts:%s", r.Namespace[cluster])
+		manifest := fmt.Sprintf(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: %s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: %s
+`, bindingName, group)
+		tmpFile, err := os.CreateTemp("", "scc-binding-*.yaml")
+		require.NoError(t, err, "[openshift] failed to create temp file for SCC binding")
+		defer os.Remove(tmpFile.Name())
+		_, err = tmpFile.WriteString(manifest)
+		require.NoError(t, err, "[openshift] failed to write SCC binding manifest")
+		require.NoError(t, tmpFile.Close(), "[openshift] failed to close SCC binding temp file")
+		require.NoError(t, k8s.RunKubectlE(t, kubectlOptions, "apply", "-f", tmpFile.Name()),
+			"[openshift] failed to apply ClusterRoleBinding %s for %s", bindingName, group)
+	}
+
 	if r.IsCertManager {
 		testutil.InstallCertManager(t, certManagerK8sOptions)
 		testutil.InstallTrustManager(t, certManagerK8sOptions, r.Namespace[cluster])
@@ -116,15 +149,19 @@ func (r *Region) InstallCharts(t *testing.T, cluster string, index int) {
 		testutil.CreateBundle(t, kubectlOptions, testutil.CASecretName, testutil.CAConfigMapName)
 	} else {
 		// create CA Secret.
-		err := k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", customCASecret, "--from-file=ca.crt",
-			"--from-file=ca.key")
+		err := k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", customCASecret,
+			"--from-file=ca.crt="+filepath.Join(r.certDir, "ca.crt"),
+			"--from-file=ca.key="+filepath.Join(r.certDir, "ca.key"))
 		require.NoError(t, err)
 	}
 
 	// Setup kubectl options for this cluster.
 	kubectlOptions = k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
 	if !r.IsOperatorInstalled {
-		InstallCockroachDBEnterpriseOperator(t, kubectlOptions)
+		// Pass the actual cluster region so the operator's cloudRegion is set
+		// correctly. The operator webhook rejects CrdbClusters whose region codes
+		// don't match the operator's configured cloudRegion.
+		InstallCockroachDBEnterpriseOperator(t, kubectlOptions, r.RegionCodes[index])
 	}
 
 	if r.IsCertManager {
@@ -154,6 +191,20 @@ func (r *Region) InstallCharts(t *testing.T, cluster string, index int) {
 			"cockroachdb.clusterDomain":                   CustomDomains[index],
 			"cockroachdb.crdbCluster.virtualCluster.mode": "standby",
 		})
+	}
+
+	// OpenShift-specific overrides.
+	if r.Provider == "openshift" {
+		// Use standard-csi storage class (GCP default on OpenShift).
+		crdbOp["cockroachdb.crdbCluster.dataStore.volumeClaimTemplate.spec.storageClassName"] = "standard-csi"
+		// For single-region, use the default cluster.local domain. OpenShift's
+		// built-in DNS only serves cluster.local; the custom cluster1.local
+		// forwarding approach causes i/o timeouts for join RPCs. Multi-region
+		// tests that genuinely need separate domains are not affected because
+		// they set IsMultiRegion=true.
+		if !r.IsMultiRegion {
+			crdbOp["cockroachdb.clusterDomain"] = "cluster.local"
+		}
 	}
 
 	// Helm install cockroach CR with operator region config.
@@ -286,9 +337,14 @@ func (r *Region) ValidateMultiRegionSetup(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify regions output
+		// OpenShift runs on GCP; the operator cloudProvider is set to "gcp" for
+		// OpenShift clusters, so region names in CRDB are "gcp-<code>", not "openshift-<code>".
+		cloudProvider := r.Provider
+		if cloudProvider == "openshift" {
+			cloudProvider = "gcp"
+		}
 		for _, clusterRegion := range r.RegionCodes {
-			// For multi-region validation, check for cloud provider prefixed region names
-			expectedRegion := fmt.Sprintf("%s-%s", r.Provider, clusterRegion)
+			expectedRegion := fmt.Sprintf("%s-%s", cloudProvider, clusterRegion)
 			require.Contains(t, stdout, expectedRegion, "Expected region %s to be present in cluster output", expectedRegion)
 		}
 
@@ -329,7 +385,7 @@ func (r *Region) ValidateMultiRegionSetup(t *testing.T) {
 
 		// Verify node count per region matches desired nodes.
 		for _, region := range r.RegionCodes {
-			region = fmt.Sprintf("%s-%s", r.Provider, region)
+			region = fmt.Sprintf("%s-%s", cloudProvider, region)
 			require.Equal(t, r.NodeCount, nodesPerRegion[region],
 				"Region %s has %d nodes, expected %d",
 				region, nodesPerRegion[region], r.NodeCount)
@@ -362,12 +418,15 @@ func (r *Region) ValidateCRDBContainerResources(t *testing.T, kubectlOptions *k8
 	require.NoError(t, err)
 }
 
-// CreateCACertificate creates CA cert and key at the same path.
+// CreateCACertificate creates CA cert and key in an isolated per-test temp
+// directory. Using t.TempDir() avoids races when multiple tests run in
+// parallel and prevents stale files in the working directory.
 func (r *Region) CreateCACertificate(t *testing.T) error {
-	// Create CA secret in all regions.
+	r.certDir = t.TempDir()
+
 	cmd := shell.Command{
 		Command:    "cockroach",
-		Args:       []string{"cert", "create-ca", "--certs-dir=.", "--ca-key=ca.key"},
+		Args:       []string{"cert", "create-ca", "--certs-dir=" + r.certDir, "--ca-key=" + filepath.Join(r.certDir, "ca.key")},
 		WorkingDir: ".",
 		Env:        nil,
 		Logger:     nil,
@@ -378,14 +437,10 @@ func (r *Region) CreateCACertificate(t *testing.T) error {
 	return err
 }
 
-func (r *Region) CleanUpCACertificate(t *testing.T) {
-	cmd := shell.Command{
-		Command:    "rm",
-		Args:       []string{"-rf", "ca.crt", "ca.key"},
-		WorkingDir: ".",
-	}
-
-	shell.RunCommand(t, cmd)
+// CleanUpCACertificate is a no-op: t.TempDir() registered by CreateCACertificate
+// is cleaned up automatically when the test ends.
+func (r *Region) CleanUpCACertificate(_ *testing.T) {
+	r.certDir = ""
 }
 
 // GetCurrentContext gets the current cluster context from KubeConfig.
@@ -436,20 +491,45 @@ func (r *Region) CleanupResources(t *testing.T) {
 		kubectlOptions := k8s.NewKubectlOptions(cluster, "", namespace)
 		certManagerK8sOptions := k8s.NewKubectlOptions(cluster, "", testutil.CertManagerNamespace)
 
+		deleteFlags := []string{"--wait", "--debug"}
+		// On OpenShift the self-signer-cleaner pre-delete hook pod is blocked by
+		// SCC (alpha seccomp annotations are forbidden). Skip hooks so the helm
+		// uninstall doesn't hang waiting for an unschedulable job.
+		if r.Provider == "openshift" {
+			deleteFlags = append(deleteFlags, "--no-hooks")
+		}
 		extraArgs := map[string][]string{
-			"delete": {
-				"--wait",
-				"--debug",
-			},
+			"delete": deleteFlags,
 		}
 		helmOptions := &helm.Options{
 			KubectlOptions: kubectlOptions,
 			ExtraArgs:      extraArgs,
 		}
-		err := helm.DeleteE(t, helmOptions, ReleaseName, true)
-		require.NoError(t, err)
-		err = helm.DeleteE(t, helmOptions, operatorReleaseName, true)
-		require.NoError(t, err)
+		if err := helm.DeleteE(t, helmOptions, ReleaseName, true); err != nil {
+			t.Logf("[cleanup] Warning: helm delete %s: %v", ReleaseName, err)
+		}
+		if err := helm.DeleteE(t, helmOptions, operatorReleaseName, true); err != nil {
+			t.Logf("[cleanup] Warning: helm delete %s: %v", operatorReleaseName, err)
+		}
+		// Delete cluster-scoped resources that survive namespace deletion.
+		// These cause ownership conflicts if left behind for subsequent tests.
+		if r.Provider == "openshift" {
+			bindingName := fmt.Sprintf("cockroach-anyuid-%s", namespace)
+			clusterNodeReader := fmt.Sprintf("cockroachdb-%s-node-reader", namespace)
+			for _, resource := range []string{
+				"clusterrole/cockroach-operator-role",
+				"clusterrole/" + clusterNodeReader,
+				"clusterrolebinding/cockroach-operator-default",
+				"clusterrolebinding/cockroach-operator-rolebinding",
+				"clusterrolebinding/" + clusterNodeReader,
+				"clusterrolebinding/" + bindingName,
+				"mutatingwebhookconfiguration/cockroach-mutating-webhook-config",
+				"validatingwebhookconfiguration/cockroach-webhook-config",
+				"priorityclass/cockroach-operator",
+			} {
+				_ = k8s.RunKubectlE(t, kubectlOptions, "delete", resource, "--ignore-not-found")
+			}
+		}
 		if r.IsCertManager {
 			testutil.DeleteBundle(t, kubectlOptions)
 			testutil.DeleteCAIssuer(t, kubectlOptions, namespace)
@@ -481,6 +561,13 @@ func HelmChartPaths() (helmChartPath string, operatorChartPath string) {
 func (r *Region) createOperatorRegions(index int, nodes int, customDomains map[int]string) []map[string]interface{} {
 	regions := make([]map[string]interface{}, 0, len(r.Clusters))
 
+	// OpenShift is deployed on GCP; the cockroach operator webhook only supports
+	// "aws", "gcp", "azure", and "k3d" as cloudProvider values.
+	cloudProvider := r.Provider
+	if cloudProvider == "openshift" {
+		cloudProvider = "gcp"
+	}
+
 	for i := 0; i < len(r.Clusters); i++ {
 		if i > index {
 			break
@@ -488,13 +575,18 @@ func (r *Region) createOperatorRegions(index int, nodes int, customDomains map[i
 
 		region := map[string]interface{}{
 			"code":          r.RegionCodes[i],
-			"cloudProvider": r.Provider,
+			"cloudProvider": cloudProvider,
 			"nodes":         nodes,
 			"namespace":     r.Namespace[r.Clusters[i]],
 		}
 
 		if len(r.Clusters) > i && r.Clusters[i] != "" {
 			if domain, ok := customDomains[i]; ok {
+				// For single-region OpenShift, use cluster.local — the DNS
+				// operator cannot reliably forward custom domains like cluster1.local.
+				if r.Provider == "openshift" && !r.IsMultiRegion {
+					domain = "cluster.local"
+				}
 				region["domain"] = domain
 			}
 		}
@@ -522,15 +614,25 @@ func VerifyInitCommandInOperatorLogs(t *testing.T, kubectlOptions *k8s.KubectlOp
 	require.Contains(t, logs, expected, "operator logs did not contain expected init command")
 }
 
-func InstallCockroachDBEnterpriseOperator(t *testing.T, kubectlOptions *k8s.KubectlOptions) {
+// InstallCockroachDBEnterpriseOperator installs the cockroach enterprise operator helm chart.
+// An optional cloudRegionOverride can be passed to set the operator's cloudRegion value,
+// which controls which region the operator reconciles. When not specified the chart default
+// ("us-east1") is used. Pass the actual cluster region (e.g. "us-central1") for clusters
+// whose region does not match the chart default.
+func InstallCockroachDBEnterpriseOperator(t *testing.T, kubectlOptions *k8s.KubectlOptions, cloudRegionOverride ...string) {
 	_, operatorChartPath := HelmChartPaths()
+
+	setValues := map[string]string{
+		"numReplicas": "1",
+	}
+	if len(cloudRegionOverride) > 0 && cloudRegionOverride[0] != "" {
+		setValues["cloudRegion"] = cloudRegionOverride[0]
+	}
 
 	operatorOpts := &helm.Options{
 		KubectlOptions: kubectlOptions,
-		SetValues: map[string]string{
-			"numReplicas": "1",
-		},
-		ExtraArgs: helmExtraArgs,
+		SetValues:      setValues,
+		ExtraArgs:      helmExtraArgs,
 	}
 
 	// Install Operator on the cluster.

--- a/tests/e2e/operator/singleRegion/cockroachdb_single_region_advanced_features_test.go
+++ b/tests/e2e/operator/singleRegion/cockroachdb_single_region_advanced_features_test.go
@@ -1,0 +1,590 @@
+package singleRegion
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestWALFailover tests the WAL failover functionality by:
+// 1. Installing CockroachDB with WAL failover enabled with custom path
+// 2. Verifying the cluster is healthy
+// 3. Verifying --wal-failover flag with custom path and PVC mounting
+func (r *singleRegion) TestWALFailover(t *testing.T) {
+	cluster := r.Clusters[0]
+	cleanup := r.SetupSingleClusterWithCA(t, cluster)
+	defer cleanup()
+
+	// Install CockroachDB with WAL failover enabled using common method
+	config := operator.AdvancedInstallConfig{
+		WALFailoverEnabled: true,
+		WALFailoverSize:    "5Gi",
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
+
+	// Validate CockroachDB cluster is healthy
+	r.ValidateCRDB(t, cluster)
+
+	// Validate WAL failover with workload and metrics monitoring
+	r.ValidateWALFailover(t, cluster, nil)
+
+	t.Logf("WAL failover test completed successfully")
+}
+
+// TestWALFailoverDisable tests disabling WAL failover via helm upgrade by:
+// 1. Installing CockroachDB with WAL failover enabled with custom path
+// 2. Verifying WAL failover is configured with custom path
+// 3. Upgrading to disable WAL failover
+// 4. Verifying --wal-failover flag contains disable and prev_path
+func (r *singleRegion) TestWALFailoverDisable(t *testing.T) {
+	cluster := r.Clusters[0]
+	cleanup := r.SetupSingleClusterWithCA(t, cluster)
+	defer cleanup()
+
+	// Step 1: Install CockroachDB with WAL failover enabled
+	t.Log("Installing CockroachDB with WAL failover enabled...")
+	config := operator.AdvancedInstallConfig{
+		WALFailoverEnabled: true,
+		WALFailoverSize:    "5Gi",
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
+
+	// Validate CockroachDB cluster is healthy
+	r.ValidateCRDB(t, cluster)
+
+	// Validate WAL failover is enabled
+	r.ValidateWALFailover(t, cluster, nil)
+
+	// Step 2: Upgrade to disable WAL failover
+	t.Log("Upgrading to disable WAL failover...")
+	kubeConfig, _ := r.GetCurrentContext(t)
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+
+	// Get initial pod timestamps before upgrade
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+	initialTimestamp := pods[0].CreationTimestamp.Time
+
+	// Get helm chart paths
+	helmChartPath, _ := operator.HelmChartPaths()
+
+	// Upgrade with WAL failover disabled
+	disableConfig := operator.PatchHelmValues(map[string]string{
+		"cockroachdb.clusterDomain":                      operator.CustomDomains[0],
+		"cockroachdb.tls.selfSigner.caProvided":          "true",
+		"cockroachdb.tls.selfSigner.caSecret":            "cockroachdb-ca-secret",
+		"cockroachdb.crdbCluster.walFailoverSpec.status": "disable",
+		"cockroachdb.crdbCluster.walFailoverSpec.name":   "datadir-wal-failover",
+		"cockroachdb.crdbCluster.walFailoverSpec.path":   "/cockroach/cockroach-wal-failover",
+	})
+
+	upgradeOptions := &helm.Options{
+		KubectlOptions: kubectlOptions,
+		SetValues:      disableConfig,
+		SetJsonValues: map[string]string{
+			"cockroachdb.crdbCluster.regions": operator.MustMarshalJSON(r.OperatorRegions(0, r.NodeCount)),
+		},
+		ExtraArgs: map[string][]string{
+			"upgrade": {"--reuse-values", "--wait"},
+		},
+	}
+
+	helm.Upgrade(t, upgradeOptions, helmChartPath, operator.ReleaseName)
+
+	// Wait for upgrade to complete using VerifyHelmUpgrade helper
+	err := r.VerifyHelmUpgrade(t, initialTimestamp, kubectlOptions)
+	require.NoError(t, err)
+
+	// Step 3: Verify WAL failover is disabled
+	t.Log("Verifying WAL failover is disabled after upgrade...")
+	pods = k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+
+	podName := pods[0].Name
+
+	// Verify --wal-failover flag now contains "disable" and "prev_path"
+	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+	require.NoError(t, err)
+	require.Contains(t, podCommand, "--wal-failover=disable", "Pod command should contain --wal-failover=disable after disabling")
+	require.Contains(t, podCommand, "prev_path=/cockroach/cockroach-wal-failover", "Pod command should contain prev_path with custom path after disabling")
+
+	// Verify WAL failover PVC still exists (not deleted on disable)
+	pvcs, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pvc", "-o", "jsonpath={.items[*].metadata.name}")
+	require.NoError(t, err)
+	require.Contains(t, pvcs, "datadir-wal-failover", "WAL failover PVC should still exist after disable")
+	t.Logf("PVCs after disable: %s", pvcs)
+
+	t.Log("WAL failover successfully disabled")
+	t.Logf("WAL failover disable test completed successfully")
+}
+
+// TestEncryptionAtRestEnable tests encryption at rest functionality by:
+// 1. Generating a proper 256-bit AES encryption key
+// 2. Creating encryption key secret
+// 3. Installing CockroachDB with encryption at rest enabled
+// 4. Verifying the cluster is healthy and encryption is active
+func (r *singleRegion) TestEncryptionAtRestEnable(t *testing.T) {
+	cluster := r.Clusters[0]
+	cleanup := r.SetupSingleClusterWithCA(t, cluster)
+	defer cleanup()
+
+	// Generate proper 256-bit AES encryption key
+	t.Log("Generating 256-bit AES encryption key...")
+	encryptionKeyB64 := r.GenerateEncryptionKey(t)
+	t.Logf("Generated encryption key (base64 length: %d)", len(encryptionKeyB64))
+
+	// Configure encryption at rest regions
+	encryptionRegions := r.BuildEncryptionRegions(cluster, 0, nil)
+
+	// Install CockroachDB with encryption at rest enabled using common method
+	config := operator.AdvancedInstallConfig{
+		EncryptionEnabled:   true,
+		EncryptionKeySecret: encryptionKeyB64,
+		CustomRegions:       encryptionRegions,
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
+
+	// Validate CockroachDB cluster is healthy
+	r.ValidateCRDB(t, cluster)
+
+	// Validate encryption at rest is active
+	r.ValidateEncryptionAtRest(t, cluster, nil)
+
+	// Additional validation: Verify key and old-key in the encryption flag
+	kubeConfig, _ := r.GetCurrentContext(t)
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+	podName := pods[0].Name
+
+	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+	require.NoError(t, err)
+
+	// Verify encryption flag format: key should point to the secret, old-key should be "plain" for initial setup
+	require.Contains(t, podCommand, "key=/etc/cockroach-key/", "Encryption flag should contain key path")
+	require.Contains(t, podCommand, "old-key=plain", "Encryption flag should have old-key=plain for initial setup")
+	t.Logf("Verified encryption flag format with key and old-key=plain")
+
+	t.Logf("Encryption at rest enable test completed successfully")
+}
+
+// TestEncryptionAtRestDisable tests transitioning from encrypted to plaintext by:
+// 1. Installing CockroachDB with encryption at rest enabled
+// 2. Verifying encryption is active
+// 3. Upgrading to use plaintext (setting keySecretName to nil and oldKeySecretName to existing secret)
+// 4. Verifying --enterprise-encryption flag still exists but now points to "plain" (plaintext)
+// Note: Once encryption is enabled, you must always include the --enterprise-encryption flag.
+// To disable encryption, keep encryptionAtRest enabled but
+// set keySecretName to nil/empty and oldKeySecretName to the existing secret.
+func (r *singleRegion) TestEncryptionAtRestDisable(t *testing.T) {
+	cluster := r.Clusters[0]
+	cleanup := r.SetupSingleClusterWithCA(t, cluster)
+	defer cleanup()
+
+	// Step 1: Install CockroachDB with encryption at rest enabled
+	t.Log("Installing CockroachDB with encryption at rest enabled...")
+	encryptionKeyB64 := r.GenerateEncryptionKey(t)
+	t.Logf("Generated encryption key (base64 length: %d)", len(encryptionKeyB64))
+
+	// Configure encryption at rest regions
+	encryptionRegions := r.BuildEncryptionRegions(cluster, 0, nil)
+
+	config := operator.AdvancedInstallConfig{
+		EncryptionEnabled:   true,
+		EncryptionKeySecret: encryptionKeyB64,
+		CustomRegions:       encryptionRegions,
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
+
+	// Validate CockroachDB cluster is healthy
+	r.ValidateCRDB(t, cluster)
+
+	// Validate encryption at rest is active
+	r.ValidateEncryptionAtRest(t, cluster, nil)
+
+	// Step 2: Trigger plaintext transition via helm upgrade.
+	// Setting keySecretName absent (nil in operator = "plain") and oldKeySecretName to the
+	// current key secret tells the operator to transition to plaintext mode.
+	t.Log("Upgrading CrdbCluster to configure plaintext transition...")
+	kubeConfig, _ := r.GetCurrentContext(t)
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+	helmChartPath, _ := operator.HelmChartPaths()
+
+	// Get initial pod timestamps before upgrade
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+	initialTimestamp := pods[0].CreationTimestamp.Time
+
+	// keySecretName="" is deleted from the map by EncryptionAtRestConfig (nil/empty → omit from JSON).
+	// An absent keySecretName is interpreted by the operator as "plain" (no new key).
+	// oldKeySecretName tells the operator to reference the previous key during the transition.
+	regions := r.BuildEncryptionRegions(cluster, 0, map[string]interface{}{
+		"keySecretName":    "",
+		"oldKeySecretName": "cmek-key-secret",
+	})
+
+	upgradeOptions := &helm.Options{
+		KubectlOptions: kubectlOptions,
+		SetJsonValues: map[string]string{
+			"cockroachdb.crdbCluster.regions": operator.MustMarshalJSON(regions),
+		},
+		ExtraArgs: map[string][]string{
+			"upgrade": {"--reuse-values", "--wait"},
+		},
+	}
+
+	helm.Upgrade(t, upgradeOptions, helmChartPath, operator.ReleaseName)
+
+	err := r.VerifyHelmUpgrade(t, initialTimestamp, kubectlOptions)
+	require.NoError(t, err)
+
+	// Step 3: Verify the CrdbCluster CR spec was correctly updated.
+	// The authoritative signal for "disable EAR" is the CR spec:
+	//   - keySecretName must be absent (operator interprets nil as "plain")
+	//   - oldKeySecretName must reference the previous key secret
+	// This validation works regardless of the pod-level rolling restart state.
+	t.Log("Verifying CrdbCluster CR spec reflects plaintext transition...")
+	crEncryption, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "crdbcluster", "cockroachdb",
+		"-o", "jsonpath={.spec.regions[*].encryptionAtRest}")
+	require.NoError(t, err)
+	require.Contains(t, crEncryption, "cmek-key-secret",
+		"CrdbCluster CR should reference the old key secret for the plaintext transition")
+	require.NotContains(t, crEncryption, `"keySecretName"`,
+		"CrdbCluster CR should not have keySecretName set (absent = operator uses plain)")
+	t.Logf("CrdbCluster CR spec correctly updated for plaintext transition: %s", crEncryption)
+
+	// Step 4: Verify pod command reflects plaintext transition.
+	t.Log("Verifying transition to plaintext after upgrade...")
+	pods = k8s.ListPods(t, kubectlOptions, metav1.ListOptions{LabelSelector: operator.LabelSelector})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+	podName := pods[0].Name
+
+	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+	require.NoError(t, err)
+	require.Contains(t, podCommand, "--enterprise-encryption",
+		"Pod command should still contain --enterprise-encryption flag (required once encryption is enabled)")
+	require.Contains(t, podCommand, "key=plain",
+		"Encryption flag should have key=plain for plaintext mode")
+	require.Contains(t, podCommand, "old-key=/etc/cockroach-key/",
+		"Encryption flag should have old-key pointing to the previous encrypted key")
+	t.Logf("Verified encryption flag format with key=plain and old-key pointing to encrypted key")
+
+	t.Log("Encryption at rest disable test completed successfully")
+}
+
+// TestEncryptionAtRestModifySecret tests rotating the encryption key by:
+// 1. Installing CockroachDB with encryption at rest enabled
+// 2. Verifying encryption is active
+// 3. Generating a new encryption key and creating a new secret
+// 4. Upgrading with keySecretName pointing to new secret and oldKeySecretName to existing secret
+// 5. Verifying encryption still works with rotated key
+// Note: Key rotation requires setting keySecretName to the new key and oldKeySecretName to the old key.
+func (r *singleRegion) TestEncryptionAtRestModifySecret(t *testing.T) {
+	cluster := r.Clusters[0]
+	cleanup := r.SetupSingleClusterWithCA(t, cluster)
+	defer cleanup()
+
+	// Step 1: Install CockroachDB with encryption at rest enabled
+	t.Log("Installing CockroachDB with encryption at rest enabled...")
+	encryptionKeyB64 := r.GenerateEncryptionKey(t)
+	t.Logf("Generated initial encryption key (base64 length: %d)", len(encryptionKeyB64))
+
+	// Configure encryption at rest regions
+	encryptionRegions := r.BuildEncryptionRegions(cluster, 0, nil)
+
+	config := operator.AdvancedInstallConfig{
+		EncryptionEnabled:   true,
+		EncryptionKeySecret: encryptionKeyB64,
+		CustomRegions:       encryptionRegions,
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
+
+	// Validate CockroachDB cluster is healthy
+	r.ValidateCRDB(t, cluster)
+
+	// Validate encryption at rest is active
+	r.ValidateEncryptionAtRest(t, cluster, nil)
+
+	// Step 2: Generate new encryption key and create new secret
+	t.Log("Generating new encryption key and creating new secret...")
+	kubeConfig, _ := r.GetCurrentContext(t)
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+
+	newEncryptionKeyB64 := r.GenerateEncryptionKey(t)
+	t.Logf("Generated new encryption key (base64 length: %d)", len(newEncryptionKeyB64))
+
+	// Create new secret using --from-literal with the base64-encoded key string.
+	// Kubernetes base64-encodes secret values for storage, so the pod receives the
+	// original base64 string when mounted — which the init container then decodes.
+	err := k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", "cmek-key-secret-new",
+		fmt.Sprintf("--from-literal=StoreKeyData=%s", newEncryptionKeyB64))
+	require.NoError(t, err)
+
+	t.Log("Created new encryption key secret: cmek-key-secret-new")
+
+	// Get initial pod timestamps before upgrade
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+	initialTimestamp := pods[0].CreationTimestamp.Time
+
+	// Step 3: Configure regions with key rotation - new key in keySecretName, old key in oldKeySecretName
+	t.Log("Upgrading with key rotation configuration...")
+	helmChartPath, _ := operator.HelmChartPaths()
+
+	// Configure regions with both new and old keys for rotation
+	rotationRegions := r.BuildEncryptionRegions(cluster, 0, map[string]interface{}{
+		"keySecretName":    "cmek-key-secret-new",
+		"oldKeySecretName": "cmek-key-secret",
+	})
+
+	upgradeOptions := &helm.Options{
+		KubectlOptions: kubectlOptions,
+		SetJsonValues: map[string]string{
+			"cockroachdb.crdbCluster.regions": operator.MustMarshalJSON(rotationRegions),
+		},
+		ExtraArgs: map[string][]string{
+			"upgrade": {"--reuse-values", "--wait"},
+		},
+	}
+
+	helm.Upgrade(t, upgradeOptions, helmChartPath, operator.ReleaseName)
+
+	// Wait for pods to restart and key rotation to complete using VerifyHelmUpgrade helper
+	err = r.VerifyHelmUpgrade(t, initialTimestamp, kubectlOptions)
+	require.NoError(t, err)
+
+	// Step 4: Verify encryption is still active with new key
+	t.Log("Verifying encryption at rest is still active with new key...")
+
+	// Validate CockroachDB cluster is healthy
+	r.ValidateCRDB(t, cluster)
+
+	// Validate encryption at rest is still active. After key rotation old-key points to
+	// the previous key path rather than "plain".
+	r.ValidateEncryptionAtRest(t, cluster, &operator.AdvancedValidationConfig{
+		EncryptionAtRest: operator.EncryptionAtRestValidation{
+			SecretName:     "cmek-key-secret-new",
+			OldKeyExpected: "old-key=/etc/cockroach-key/",
+		},
+	})
+
+	// Verify new secret exists and is being used
+	newSecretData, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "secret", "cmek-key-secret-new", "-o", "jsonpath={.data.StoreKeyData}")
+	require.NoError(t, err)
+	t.Logf("New secret key length: %d", len(newSecretData))
+
+	// Verify old secret still exists (referenced in oldKeySecretName)
+	oldSecretData, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "secret", "cmek-key-secret", "-o", "jsonpath={.data.StoreKeyData}")
+	require.NoError(t, err)
+	t.Logf("Old secret key length: %d", len(oldSecretData))
+
+	// Verify pod command contains encryption flag with both key references
+	pods = k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+	podName := pods[0].Name
+
+	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+	require.NoError(t, err)
+	require.Contains(t, podCommand, "--enterprise-encryption", "Pod command should contain --enterprise-encryption flag")
+
+	// Verify encryption flag format: key should point to new secret, old-key should point to old secret
+	require.Contains(t, podCommand, "key=/etc/cockroach-key/", "Encryption flag should contain new key path")
+	require.Contains(t, podCommand, "old-key=/etc/cockroach-key/", "Encryption flag should contain old key path for rotation")
+	t.Logf("Verified encryption flag format with both new key and old-key during rotation")
+	t.Logf("Encryption flag after key rotation: %s", podCommand)
+
+	t.Log("Encryption at rest successfully working with rotated key")
+	t.Logf("Encryption at rest modify secret test completed successfully")
+}
+
+// TestWALFailoverWithEncryption tests WAL failover with encryption at rest by:
+// 1. Installing CockroachDB with both WAL failover and encryption at rest enabled
+// 2. Verifying the cluster is healthy
+// 3. Verifying --wal-failover flag with custom path
+// 4. Verifying --enterprise-encryption flag includes WAL path encryption
+// Note: When WAL failover is enabled with encryption at rest, the WAL path must also be encrypted.
+func (r *singleRegion) TestWALFailoverWithEncryption(t *testing.T) {
+	cluster := r.Clusters[0]
+	cleanup := r.SetupSingleClusterWithCA(t, cluster)
+	defer cleanup()
+
+	// Step 1: Generate encryption key
+	t.Log("Generating 256-bit AES encryption key...")
+	encryptionKeyB64 := r.GenerateEncryptionKey(t)
+	t.Logf("Generated encryption key (base64 length: %d)", len(encryptionKeyB64))
+
+	// Configure encryption at rest regions
+	encryptionRegions := r.BuildEncryptionRegions(cluster, 0, nil)
+
+	// Install CockroachDB with both WAL failover and encryption enabled
+	config := operator.AdvancedInstallConfig{
+		WALFailoverEnabled:  true,
+		WALFailoverSize:     "5Gi",
+		EncryptionEnabled:   true,
+		EncryptionKeySecret: encryptionKeyB64,
+		CustomRegions:       encryptionRegions,
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
+
+	// Validate CockroachDB cluster is healthy
+	r.ValidateCRDB(t, cluster)
+
+	// Step 2: Verify WAL failover is configured
+	t.Log("Verifying WAL failover configuration...")
+	kubeConfig, _ := r.GetCurrentContext(t)
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+	podName := pods[0].Name
+
+	// Verify --wal-failover flag exists
+	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+	require.NoError(t, err)
+	require.Contains(t, podCommand, "--wal-failover=path=/cockroach/cockroach-wal-failover",
+		"Pod command should contain --wal-failover flag with custom path")
+
+	// Step 3: Verify encryption is configured for both data store and WAL path
+	t.Log("Verifying encryption is configured for data store and WAL path...")
+	// Encryption flag is part of the command
+	require.Contains(t, podCommand, "--enterprise-encryption",
+		"Pod command should contain --enterprise-encryption flag")
+
+	// The encryption flag should reference the WAL failover path
+	// Format: --enterprise-encryption=path=cockroach-data,key=...,old-key=plain;path=/cockroach/cockroach-wal-failover,key=...,old-key=plain
+	require.Contains(t, podCommand, "cockroach-data",
+		"Encryption flag should include data store path")
+	require.Contains(t, podCommand, "/cockroach/cockroach-wal-failover",
+		"Encryption flag should include WAL failover path for encryption")
+
+	// Verify encryption flag format: both data and WAL paths should have key=/etc/cockroach-key/ and old-key=plain
+	require.Contains(t, podCommand, "key=/etc/cockroach-key/", "Encryption flag should contain key path for both data and WAL")
+	require.Contains(t, podCommand, "old-key=plain", "Encryption flag should have old-key=plain for initial setup")
+	t.Logf("Verified encryption flag format with key and old-key=plain for both data store and WAL path")
+
+	// Step 4: Verify encryption algorithm via node metrics.
+	// rocksdb.encryption.algorithm: 0=Plaintext, 1=AES-128-CTR, 2=AES-192-CTR, 3=AES-256-CTR
+	t.Log("Verifying encryption algorithm via node metrics...")
+	encAlgorithm, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"exec", podName, "-c", "cockroachdb", "--",
+		"/cockroach/cockroach", "sql",
+		"--certs-dir=/cockroach/cockroach-certs",
+		"--host=localhost:26257",
+		"-e", "SET allow_unsafe_internals = true; SELECT value FROM crdb_internal.node_metrics WHERE name = 'rocksdb.encryption.algorithm';")
+	require.NoError(t, err)
+	require.Contains(t, encAlgorithm, "3", "rocksdb.encryption.algorithm should be 3 (AES-256-CTR)")
+	t.Logf("Encryption algorithm verified: AES-256-CTR (value=3)")
+
+	// Verify both PVCs exist
+	pvcs, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pvc", "-o", "jsonpath={.items[*].metadata.name}")
+	require.NoError(t, err)
+	require.Contains(t, pvcs, "datadir", "Data PVC should exist")
+	require.Contains(t, pvcs, "datadir-wal-failover", "WAL failover PVC should exist")
+
+	t.Log("WAL failover with encryption at rest test completed successfully")
+	t.Logf("Verified both data store and WAL path are encrypted")
+}
+
+// TestPCR tests Physical Cluster Replication by:
+// 1. Installing a primary virtual cluster
+// 2. Installing a standby virtual cluster in separate namespace
+// 3. Creating replication stream between primary and standby
+// 4. Running workload on primary
+// 5. Verifying cutover to standby
+func (r *singleRegion) TestPCR(t *testing.T) {
+	cluster := r.Clusters[0]
+
+	// Create CA certificate once for both clusters
+	cleanupCA := r.RequireCACertificate(t)
+	defer cleanupCA()
+
+	var (
+		primaryNamespace string
+		standbyNamespace string
+	)
+
+	// Step 1: Install primary virtual cluster
+	t.Log("Installing primary virtual cluster...")
+	primaryNamespace = fmt.Sprintf("%s-primary-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
+	r.Namespace[cluster] = primaryNamespace
+
+	primaryConfig := operator.AdvancedInstallConfig{
+		VirtualClusterMode: "primary",
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, primaryConfig)
+
+	r.VirtualClusterModePrimary = true
+	r.ValidateCRDB(t, cluster)
+	r.VirtualClusterModePrimary = false
+
+	// Step 2: Install standby virtual cluster in separate namespace
+	t.Log("Installing standby virtual cluster...")
+	standbyNamespace = fmt.Sprintf("%s-standby-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
+	r.Namespace[cluster] = standbyNamespace
+
+	standbyConfig := operator.AdvancedInstallConfig{
+		VirtualClusterMode:  "standby",
+		SkipOperatorInstall: true,
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, standbyConfig)
+
+	r.VirtualClusterModeStandby = true
+	r.ValidateCRDB(t, cluster)
+	r.VirtualClusterModeStandby = false
+
+	// Register cleanup for both namespaces before ValidatePCR so namespaces are
+	// always removed even if ValidatePCR fails early via require.* / t.FailNow.
+	kubeConfig, _ := r.GetCurrentContext(t)
+	defer func() {
+		r.Namespace[cluster] = primaryNamespace
+		r.CleanupResources(t)
+	}()
+	defer func() {
+		kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, standbyNamespace)
+		k8s.DeleteNamespace(t, kubectlOptions, standbyNamespace)
+	}()
+
+	// Step 3: Set up replication and test failover/failback
+	r.ValidatePCR(t, &operator.AdvancedValidationConfig{
+		PCR: operator.PCRValidation{
+			Cluster:          cluster,
+			PrimaryNamespace: primaryNamespace,
+			StandbyNamespace: standbyNamespace,
+		},
+	})
+
+	t.Logf("PCR (Physical Cluster Replication) test completed successfully")
+}
+

--- a/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
+++ b/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
@@ -38,6 +38,8 @@ func TestOperatorInSingleRegion(t *testing.T) {
 			provider = infra.ProviderKind
 		case "gcp":
 			provider = infra.ProviderGCP
+		case "openshift":
+			provider = infra.ProviderOpenShift
 		default:
 			t.Fatalf("Unsupported provider override: %s", p)
 		}
@@ -72,8 +74,15 @@ func TestOperatorInSingleRegion(t *testing.T) {
 			t.Fatalf("Unsupported provider: %s", provider)
 		}
 
-		// Use t.Cleanup for guaranteed cleanup even on test timeout/panic
+		// Set PRESERVE_INFRA_ON_FAILURE=true to keep the cluster alive after a
+		// test failure for debugging. By default teardown always runs.
+		preserveInfra := os.Getenv("PRESERVE_INFRA_ON_FAILURE") == "true"
+
 		t.Cleanup(func() {
+			if preserveInfra {
+				t.Logf("PRESERVE_INFRA_ON_FAILURE=true: skipping infrastructure teardown for provider: %s", provider)
+				return
+			}
 			t.Logf("Starting infrastructure cleanup for provider: %s", provider)
 			cloudProvider.TeardownInfra(t)
 			t.Logf("Completed infrastructure cleanup for provider: %s", provider)
@@ -102,10 +111,13 @@ func TestOperatorInSingleRegion(t *testing.T) {
 			}
 
 			t.Run(name, func(t *testing.T) {
-				// Add immediate cleanup trigger if this individual test fails
 				defer func() {
 					if t.Failed() {
 						testFailed = true
+						if preserveInfra {
+							t.Logf("PRESERVE_INFRA_ON_FAILURE=true: preserving infrastructure after failure in test %s", name)
+							return
+						}
 						t.Logf("Test %s failed, triggering immediate infrastructure cleanup", name)
 						cloudProvider.TeardownInfra(t)
 						t.Logf("Infrastructure cleanup completed due to test failure")
@@ -219,8 +231,34 @@ func (r *singleRegion) TestHelmInstallVirtualCluster(t *testing.T) {
 	}
 	defer r.CleanupResources(t)
 	defer func() {
-		kubectlOptions := k8s.NewKubectlOptions("", "", standByNamespace)
-		k8s.DeleteNamespace(t, kubectlOptions, standByNamespace)
+		if standByNamespace == "" {
+			return
+		}
+		cluster := r.Clusters[0]
+		kubectlOptions := k8s.NewKubectlOptions(cluster, "", standByNamespace)
+		// Helm-delete the cockroachdb release from the standby namespace first so
+		// that CrdbCluster finalizers are removed before we delete the namespace.
+		// On OpenShift, skip pre-delete hooks (self-signer-cleaner is blocked by SCC).
+		deleteFlags := []string{"--wait", "--debug"}
+		if r.Provider == "openshift" {
+			deleteFlags = append(deleteFlags, "--no-hooks")
+		}
+		if err := helm.DeleteE(t, &helm.Options{
+			KubectlOptions: kubectlOptions,
+			ExtraArgs:      map[string][]string{"delete": deleteFlags},
+		}, operator.ReleaseName, true); err != nil {
+			t.Logf("[cleanup] Warning: helm delete %s in standby namespace %s: %v", operator.ReleaseName, standByNamespace, err)
+		}
+		// Remove the OpenShift SCC ClusterRoleBinding created for the standby namespace.
+		if r.Provider == "openshift" {
+			bindingName := fmt.Sprintf("cockroach-anyuid-%s", standByNamespace)
+			_ = k8s.RunKubectlE(t, kubectlOptions, "delete", "clusterrolebinding/"+bindingName, "--ignore-not-found")
+		}
+		// Delete the standby namespace. Use kubectl directly with --ignore-not-found
+		// so cleanup doesn't fail the test if the namespace was already removed.
+		if err := k8s.RunKubectlE(t, kubectlOptions, "delete", "namespace", standByNamespace, "--ignore-not-found"); err != nil {
+			t.Logf("[cleanup] Warning: delete standby namespace %s: %v", standByNamespace, err)
+		}
 	}()
 	defer r.CleanUpCACertificate(t)
 
@@ -459,8 +497,6 @@ func (r *singleRegion) TestClusterScaleUp(t *testing.T, cloudProvider infra.Clou
 	helmChartPath, _ := operator.HelmChartPaths()
 	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
 	r.NodeCount += 1
-
-	// Check if scaling is supported by the cloud provider.
 	if cloudProvider.CanScale() {
 		t.Logf("Scaling node pool for provider: %s", r.Provider)
 		cloudProvider.ScaleNodePool(t, r.RegionCodes[0], r.NodeCount, 0)

--- a/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
+++ b/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
@@ -71,20 +71,12 @@ func TestOperatorInSingleRegion(t *testing.T) {
 			t.Fatalf("Unsupported provider: %s", provider)
 		}
 
-		// Set PRESERVE_INFRA_ON_FAILURE=true to keep the cluster alive after a
-		// test failure for debugging. By default teardown always runs.
-		preserveInfra := os.Getenv("PRESERVE_INFRA_ON_FAILURE") == "true"
-
 		skipCleanup := os.Getenv("SKIP_CLEANUP") == "true" ||
 			os.Getenv("REUSE_INFRA") == "true" ||
 			os.Getenv("INFRA_ONLY") == "true"
 
 		// Use t.Cleanup for guaranteed cleanup even on test timeout/panic
 		t.Cleanup(func() {
-			if preserveInfra {
-				t.Logf("PRESERVE_INFRA_ON_FAILURE=true: skipping infrastructure teardown for provider: %s", provider)
-				return
-			}
 			t.Logf("Starting infrastructure cleanup for provider: %s", provider)
 			if skipCleanup {
 				t.Logf("Skipping infrastructure teardown (SKIP_CLEANUP/REUSE_INFRA/INFRA_ONLY is set)")
@@ -137,10 +129,6 @@ func TestOperatorInSingleRegion(t *testing.T) {
 				defer func() {
 					if t.Failed() {
 						testFailed = true
-						if preserveInfra {
-							t.Logf("PRESERVE_INFRA_ON_FAILURE=true: preserving infrastructure after failure in test %s", name)
-							return
-						}
 						t.Logf("Test %s failed, triggering immediate infrastructure cleanup", name)
 						if skipCleanup {
 							t.Logf("Skipping infrastructure teardown (SKIP_CLEANUP/REUSE_INFRA/INFRA_ONLY is set)")

--- a/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
+++ b/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
@@ -18,9 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Environment variable name to check if running in nightly mode
-const isNightlyEnvVar = "isNightly"
-
 type singleRegion struct {
 	operator.OperatorUseCases
 	operator.Region
@@ -56,7 +53,7 @@ func TestOperatorInSingleRegion(t *testing.T) {
 		providerRegion.Region = operator.Region{
 			IsMultiRegion: false,
 			NodeCount:     3,
-			ReusingInfra:  false,
+			ReusingInfra:  os.Getenv("REUSE_INFRA") == "true",
 		}
 		providerRegion.Clients = make(map[string]client.Client)
 		providerRegion.Namespace = make(map[string]string)
@@ -78,27 +75,53 @@ func TestOperatorInSingleRegion(t *testing.T) {
 		// test failure for debugging. By default teardown always runs.
 		preserveInfra := os.Getenv("PRESERVE_INFRA_ON_FAILURE") == "true"
 
+		skipCleanup := os.Getenv("SKIP_CLEANUP") == "true" ||
+			os.Getenv("REUSE_INFRA") == "true" ||
+			os.Getenv("INFRA_ONLY") == "true"
+
+		// Use t.Cleanup for guaranteed cleanup even on test timeout/panic
 		t.Cleanup(func() {
 			if preserveInfra {
 				t.Logf("PRESERVE_INFRA_ON_FAILURE=true: skipping infrastructure teardown for provider: %s", provider)
 				return
 			}
 			t.Logf("Starting infrastructure cleanup for provider: %s", provider)
-			cloudProvider.TeardownInfra(t)
+			if skipCleanup {
+				t.Logf("Skipping infrastructure teardown (SKIP_CLEANUP/REUSE_INFRA/INFRA_ONLY is set)")
+			} else {
+				cloudProvider.TeardownInfra(t)
+			}
 			t.Logf("Completed infrastructure cleanup for provider: %s", provider)
 		})
 
 		// Set up infrastructure for this provider once.
 		cloudProvider.SetUpInfra(t)
 
-		testCases := map[string]func(*testing.T){
-			"TestHelmInstall":               providerRegion.TestHelmInstall,
-			"TestHelmInstallVirtualCluster": providerRegion.TestHelmInstallVirtualCluster,
-			"TestHelmUpgrade":               providerRegion.TestHelmUpgrade,
-			"TestClusterRollingRestart":     providerRegion.TestClusterRollingRestart,
-			"TestKillingCockroachNode":      providerRegion.TestKillingCockroachNode,
-			"TestClusterScaleUp":            func(t *testing.T) { providerRegion.TestClusterScaleUp(t, cloudProvider) },
-			"TestInstallWithCertManager":    providerRegion.TestInstallWithCertManager,
+		// When INFRA_ONLY=true, stop here — clusters are left running for manual test runs.
+		if os.Getenv("INFRA_ONLY") == "true" {
+			t.Logf("INFRA_ONLY=true: skipping tests, infrastructure is ready")
+			return
+		}
+
+		testCases := make(map[string]func(*testing.T))
+
+		// Run only advanced test cases when TEST_ADVANCED_FEATURES is enabled
+		if os.Getenv("TEST_ADVANCED_FEATURES") == "true" {
+			testCases["TestWALFailover"] = providerRegion.TestWALFailover
+			testCases["TestWALFailoverDisable"] = providerRegion.TestWALFailoverDisable
+			testCases["TestEncryptionAtRestEnable"] = providerRegion.TestEncryptionAtRestEnable
+			testCases["TestEncryptionAtRestDisable"] = providerRegion.TestEncryptionAtRestDisable
+			testCases["TestEncryptionAtRestModifySecret"] = providerRegion.TestEncryptionAtRestModifySecret
+			testCases["TestWALFailoverWithEncryption"] = providerRegion.TestWALFailoverWithEncryption
+			testCases["TestPCR"] = providerRegion.TestPCR
+		} else {
+			testCases["TestHelmInstall"] = providerRegion.TestHelmInstall
+			testCases["TestHelmInstallVirtualCluster"] = providerRegion.TestHelmInstallVirtualCluster
+			testCases["TestHelmUpgrade"] = providerRegion.TestHelmUpgrade
+			testCases["TestClusterRollingRestart"] = providerRegion.TestClusterRollingRestart
+			testCases["TestKillingCockroachNode"] = providerRegion.TestKillingCockroachNode
+			testCases["TestClusterScaleUp"] = func(t *testing.T) { providerRegion.TestClusterScaleUp(t, cloudProvider) }
+			testCases["TestInstallWithCertManager"] = providerRegion.TestInstallWithCertManager
 		}
 
 		// Run tests sequentially within a provider.
@@ -119,7 +142,11 @@ func TestOperatorInSingleRegion(t *testing.T) {
 							return
 						}
 						t.Logf("Test %s failed, triggering immediate infrastructure cleanup", name)
-						cloudProvider.TeardownInfra(t)
+						if skipCleanup {
+							t.Logf("Skipping infrastructure teardown (SKIP_CLEANUP/REUSE_INFRA/INFRA_ONLY is set)")
+						} else {
+							cloudProvider.TeardownInfra(t)
+						}
 						t.Logf("Infrastructure cleanup completed due to test failure")
 					}
 				}()
@@ -154,7 +181,6 @@ func (r *singleRegion) TestHelmInstall(t *testing.T) {
 	if _, ok := rawConfig.Contexts[cluster]; !ok {
 		t.Fatalf("cluster context '%s' not found in kubeconfig", cluster)
 	}
-	rawConfig.CurrentContext = cluster
 	r.ValidateCRDB(t, cluster)
 }
 
@@ -218,7 +244,6 @@ func (r *singleRegion) TestHelmInstallVirtualCluster(t *testing.T) {
 			if _, ok := rawConfig.Contexts[cluster]; !ok {
 				t.Fatalf("cluster context '%s' not found in kubeconfig", cluster)
 			}
-			rawConfig.CurrentContext = cluster
 
 			r.ValidateCRDB(t, cluster)
 
@@ -288,7 +313,6 @@ func (r *singleRegion) TestHelmUpgrade(t *testing.T) {
 	if _, ok := rawConfig.Contexts[cluster]; !ok {
 		t.Fatalf("cluster context '%s' not found in kubeconfig", cluster)
 	}
-	rawConfig.CurrentContext = cluster
 
 	// Validate CockroachDB cluster.
 	r.ValidateCRDB(t, cluster)
@@ -356,7 +380,6 @@ func (r *singleRegion) TestClusterRollingRestart(t *testing.T) {
 	if _, ok := rawConfig.Contexts[cluster]; !ok {
 		t.Fatalf("cluster context '%s' not found in kubeconfig", cluster)
 	}
-	rawConfig.CurrentContext = cluster
 
 	// Validate CockroachDB cluster.
 	r.ValidateCRDB(t, cluster)
@@ -435,7 +458,6 @@ func (r *singleRegion) TestKillingCockroachNode(t *testing.T) {
 	if _, ok := rawConfig.Contexts[cluster]; !ok {
 		t.Fatalf("cluster context '%s' not found in kubeconfig", cluster)
 	}
-	rawConfig.CurrentContext = cluster
 
 	// Validate CockroachDB cluster.
 	r.ValidateCRDB(t, cluster)
@@ -459,7 +481,6 @@ func (r *singleRegion) TestKillingCockroachNode(t *testing.T) {
 	if _, ok := rawConfig.Contexts[cluster]; !ok {
 		t.Fatalf("cluster context '%s' not found in kubeconfig", cluster)
 	}
-	rawConfig.CurrentContext = cluster
 
 	// Validate CockroachDB cluster.
 	r.ValidateCRDB(t, cluster)
@@ -488,7 +509,6 @@ func (r *singleRegion) TestClusterScaleUp(t *testing.T, cloudProvider infra.Clou
 	if _, ok := rawConfig.Contexts[cluster]; !ok {
 		t.Fatalf("cluster context '%s' not found in kubeconfig", cluster)
 	}
-	rawConfig.CurrentContext = cluster
 
 	// Validate CockroachDB cluster.
 	r.ValidateCRDB(t, cluster)
@@ -544,7 +564,5 @@ func (r *singleRegion) TestInstallWithCertManager(t *testing.T) {
 	if _, ok := rawConfig.Contexts[cluster]; !ok {
 		t.Fatalf("cluster context '%s' not found in kubeconfig", cluster)
 	}
-	rawConfig.CurrentContext = cluster
 	r.ValidateCRDB(t, cluster)
-
 }

--- a/tests/kind/dev-multi-cluster.sh
+++ b/tests/kind/dev-multi-cluster.sh
@@ -272,10 +272,12 @@ remove_control_plane_taint() {
     echo "Control-plane nodes are now schedulable"
 }
 
-# Pull images that don't exist locally and import them into the Kind cluster.
+# Pull images directly into each Kind node using crictl to avoid import-date naming issues.
+# Using "kind load docker-image" causes digest-only images to be stored with a date-based
+# name (import-YYYY-MM-DD) in containerd, which breaks pod image lookups.
 import_container_images() {
     local cluster_name="$1"
-    echo "Pulling and importing required container images..."
+    echo "Pulling required container images directly into Kind nodes..."
 
     for image in "${REQUIRED_IMAGES[@]}"; do
         # Skip empty image names
@@ -285,20 +287,14 @@ import_container_images() {
 
         echo "Processing image: $image"
 
-        # Pull image if it doesn't exist locally
-        if ! docker image inspect "$image" >/dev/null 2>&1; then
-            echo "Pulling image: $image"
-            if ! docker pull "$image"; then
-                echo "Warning: Failed to pull image $image, skipping..."
-                continue
+        # Pull image directly inside each node using crictl.
+        # This stores the image with the correct reference name in containerd.
+        for node in $("${KIND_PATH}" get nodes --name "${cluster_name}" 2>/dev/null); do
+            echo "Pulling $image on node $node..."
+            if ! docker exec "$node" crictl pull "$image"; then
+                echo "Warning: Failed to pull image $image on node $node"
             fi
-        fi
-
-        # Load image into Kind cluster one by one to avoid bulk loading issues
-        echo "Loading image $image into cluster $cluster_name..."
-        if ! "${KIND_PATH}" load docker-image "$image" --name "${cluster_name}"; then
-            echo "Warning: Failed to load image $image into cluster $cluster_name"
-        fi
+        done
     done
 
     echo "Finished importing container images"

--- a/tests/testutil/cert-manager.go
+++ b/tests/testutil/cert-manager.go
@@ -196,6 +196,8 @@ spec:
 
 // DeleteBundle deletes the bundle.
 func DeleteBundle(t *testing.T, kubectlOptions *k8s.KubectlOptions) {
-	k8s.RunKubectl(t, kubectlOptions, "delete", "-f", bundleYaml)
+	if err := k8s.RunKubectlE(t, kubectlOptions, "delete", "bundle", CAConfigMapName, "--ignore-not-found"); err != nil {
+		t.Logf("[cleanup] Warning: delete bundle: %v", err)
+	}
 	_ = os.Remove(bundleYaml)
 }


### PR DESCRIPTION
Adds OpenShift as a supported cloud provider in the e2e operator test framework,
enabling the full operator test suite to run on OpenShift clusters provisioned
on GCP via `openshift-install`, for both single-region and multi-region setups.

JIRA: https://cockroachlabs.atlassian.net/browse/CRDB-53890

TODO:
- Change `defaultOpenShiftProjectID` from `"cockroach-shreyaskm"` to `"helm-testing"` in `openshift.go` to match the GCP provider default and avoid accidental provisioning into a personal project when `GCP_PROJECT_ID` is unset.