### PR TITLE
[CRDB-55385] self-signer: Add support for additional SANs in certificates

### DIFF
--- a/build/templates/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/build/templates/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -48,6 +48,12 @@ cockroachdb:
       # podUpdateTimeout specifies the timeout for pods to reach the running state.
       # Only considered when rotateCerts is true.
       podUpdateTimeout: 2m
+      # additionalSANs specifies additional Subject Alternative Names (SANs) to include in node certificates.
+      # This is useful for load balancers or external endpoints that need SSL verification.
+      # Example: ["my-loadbalancer.example.com", "10.20.30.40"]
+      # Note: Changes to this value will only take effect after the next certificate rotation cycle,
+      # or when certificates are manually regenerated (e.g., by deleting the node-secret).
+      additionalSANs: []
       # svcAccountAnnotations defines annotations for the ServiceAccount used by the self-signer job.
       svcAccountAnnotations: {}
       # labels defines additional labels for pods of the self-signer job.
@@ -68,7 +74,7 @@ cockroachdb:
         # repository defines the image repository for the self-signer container.
         repository: cockroachlabs-helm-charts/cockroach-self-signer-cert
         # tag defines the image tag for the self-signer container.
-        tag: "1.9"
+        tag: "1.10"
         # pullPolicy defines the image pull policy for the self-signer container.
         pullPolicy: IfNotPresent
         # registry defines the container registry host (e.g., gcr.io, docker.io).

--- a/build/templates/cockroachdb/README.md
+++ b/build/templates/cockroachdb/README.md
@@ -91,6 +91,39 @@ There are 3 ways to configure a secure cluster, with this chart. This all relate
 
 For instructions on using self-signer to provision certificates for the statefulset-based Helm chart, see the [Installation of statefulset-based Helm Chart with self-signer](../docs/certificate-management/self-signer.md#Installation-of-statefulset-based-helm-chart-with-self-signer) section in the documentation.
 
+##### Additional Subject Alternative Names (SANs) for Load Balancers
+
+When using the self-signer, you can include additional Subject Alternative Names (SANs) in node certificates. This is useful when:
+- Routing traffic through load balancers with `sslmode=verify-full`
+- Setting up Physical Cluster Replication (PCR) through external endpoints
+- Accessing the cluster through custom DNS names or IP addresses
+
+To add custom SANs, configure `tls.certs.selfSigner.additionalSANs`:
+
+```yaml
+tls:
+  enabled: true
+  certs:
+    selfSigner:
+      enabled: true
+      additionalSANs:
+        - "my-loadbalancer.example.com"
+        - "192.168.1.100"
+        - "external-endpoint.domain.com"
+```
+
+Or using Helm command-line options:
+
+```shell
+$ helm install my-release cockroachdb/cockroachdb \
+  --set tls.enabled=true \
+  --set tls.certs.selfSigner.enabled=true \
+  --set 'tls.certs.selfSigner.additionalSANs[0]=my-loadbalancer.example.com' \
+  --set 'tls.certs.selfSigner.additionalSANs[1]=192.168.1.100'
+```
+
+**Note:** The additional SANs are automatically included in both initial certificate generation and subsequent certificate rotations.
+
 #### Manual
 
 If you wish to supply the certificates to the nodes yourself set `tls.certs.provided` to `yes`/`true`. You may want to use this if you want to use a different certificate authority from the one being used by Kubernetes or if your Kubernetes cluster doesn't fully support certificate-signing requests. To use this, first set up your certificates and load them into your Kubernetes cluster as Secrets using the commands below:
@@ -417,6 +450,7 @@ For details see the [`values.yaml`](values.yaml) file.
 | `tls.certs.selfSigner.rotateCerts`                        | Whether to rotate the certs generate by cockroachdb                                                                                                                                                                                                                                                                                      | `true`                                                 |
 | `tls.certs.selfSigner.readinessWait`                      | Wait time for each cockroachdb replica to become ready once it comes in running state. Only considered when rotateCerts is set to true                                                                                                                                                                                                   | `30s`                                                  |
 | `tls.certs.selfSigner.podUpdateTimeout`                   | Wait time for each cockroachdb replica to get to running state. Only considered when rotateCerts is set to true                                                                                                                                                                                                                          | `2m`                                                   |
+| `tls.certs.selfSigner.additionalSANs`                     | Additional Subject Alternative Names (hostnames or IP addresses) to include in node certificates. Useful for load balancers and external endpoints                                                                                                                                                                                       | `[]`                                                   |
 | `tls.certs.certManager`                                   | Provision certificates with cert-manager                                                                                                                                                                                                                                                                                                 | `false`                                                |
 | `tls.certs.certManagerIssuer.group`                       | IssuerRef group to use when generating certificates                                                                                                                                                                                                                                                                                      | `cert-manager.io`                                      |
 | `tls.certs.certManagerIssuer.kind`                        | IssuerRef kind to use when generating certificates                                                                                                                                                                                                                                                                                       | `Issuer`                                               |

--- a/build/templates/cockroachdb/values.yaml
+++ b/build/templates/cockroachdb/values.yaml
@@ -633,6 +633,12 @@ tls:
       nodeCertDuration: 8760h
       # Expiry window of node certificates means a window before actual expiry in which node certs should be rotated.
       nodeCertExpiryWindow: 168h
+      # Additional Subject Alternative Names (SANs) to include in node certificates.
+      # Useful for load balancers or external endpoints that need to be included in the certificate.
+      # Example: ["my-loadbalancer.example.com", "10.20.30.40"]
+      # Note: Changes to this value will only take effect after the next certificate rotation cycle,
+      # or when certificates are manually regenerated (e.g., by deleting the node-secret).
+      additionalSANs: []
       # If set, the cockroachdb cert selfSigner will rotate the certificates before expiry.
       rotateCerts: true
       # Wait time for each cockroachdb replica to become ready once it comes in running state. Only considered when rotateCerts is set to true
@@ -688,7 +694,7 @@ tls:
     # Image Placeholder for the selfSigner utility. This will be changed once the CI workflows for the image is in place.
     image:
       repository: cockroachlabs-helm-charts/cockroach-self-signer-cert
-      tag: "1.9"
+      tag: "1.10"
       pullPolicy: IfNotPresent
       registry: gcr.io
       credentials: {}

--- a/cmd/self-signer/root.go
+++ b/cmd/self-signer/root.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -82,8 +83,12 @@ func init() {
 	}
 }
 
-func getInitialConfig(caDuration, caExpiry, nodeDuration, nodeExpiry, clientDuration,
-	clientExpiry string) (generator.GenerateCert, error) {
+// getInitialConfig initializes a GenerateCert instance from certificate durations
+// and environment variables (STATEFULSET_NAME, CLUSTER_DOMAIN, ADDITIONAL_SANS).
+func getInitialConfig(
+	caDuration, caExpiry, nodeDuration, nodeExpiry, clientDuration,
+	clientExpiry string,
+) (generator.GenerateCert, error) {
 
 	genCert := generator.NewGenerateCert(cl)
 
@@ -113,6 +118,13 @@ func getInitialConfig(caDuration, caExpiry, nodeDuration, nodeExpiry, clientDura
 			return genCert, errors.New("Required CLUSTER_DOMAIN env not found")
 		}
 		genCert.ClusterDomain = domain
+
+		// Parse additional SANs if provided
+		if additionalSANsStr, exists := os.LookupEnv("ADDITIONAL_SANS"); exists && additionalSANsStr != "" {
+			sans := strings.Split(additionalSANsStr, ",")
+			// Use shared sanitization helper to trim whitespace and filter out empty strings
+			genCert.AdditionalSANs = generator.SanitizeAdditionalSANs(sans)
+		}
 	}
 
 	return genCert, nil

--- a/cockroachdb-parent/charts/cockroachdb/CHANGELOG.md
+++ b/cockroachdb-parent/charts/cockroachdb/CHANGELOG.md
@@ -1,12 +1,22 @@
 # CockroachDB Chart — CHANGELOG
 
 ## [26.1.3] — Unreleased
+### Added
+- Support for additional Subject Alternative Names (SANs) in self-signer node certificates via
+  `cockroachdb.selfSigner.additionalSANs`. This enables SSL verification when connecting through
+  load balancers or custom hostnames/IPs. Specify as a list of hostnames or IP addresses
+  (e.g., `["my-loadbalancer.example.com", "10.20.30.40"]`).
+  - **Note:** For existing clusters, the additional SANs take effect only after the next certificate
+    rotation. New installations include the SANs immediately. To apply additional SANs to an existing
+    cluster without waiting for automatic rotation, manually trigger certificate rotation or enable
+    `tls.certs.selfSigner.rotateCerts: true` during upgrade.
 ### Changed
 - **Per-chart versioning**: The CockroachDB chart's major.minor now tracks the CockroachDB database
   series (e.g., chart 26.1.x is for CockroachDB 26.1). The patch version increments independently.
   Check `appVersion` in Chart.yaml for the exact CockroachDB version bundled.
 - Hook images (`bitnami/kubectl`, `dtzar/helm-kubectl`) are now configurable via
   `hooks.kubectlImage.{registry,repository,tag,pullPolicy}` for air-gapped deployments.
+- Self-signer image tag updated from `1.9` to `1.10` to include additional SANs support.
 
 ### Upgrade Notes
 - Users must be on the latest preview version (`26.1.3-preview+1`) before upgrading.

--- a/cockroachdb-parent/charts/cockroachdb/templates/cronjob-client-node-certSelfSigner.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/templates/cronjob-client-node-certSelfSigner.yaml
@@ -65,5 +65,9 @@ spec:
                   value: {{ .Release.Namespace }}
                 - name: CLUSTER_DOMAIN
                   value: {{ .Values.cockroachdb.clusterDomain}}
+                {{- if .Values.cockroachdb.tls.selfSigner.additionalSANs }}
+                - name: ADDITIONAL_SANS
+                  value: {{ .Values.cockroachdb.tls.selfSigner.additionalSANs | join "," | quote }}
+                {{- end }}
           serviceAccountName: {{ template "rotatecerts.fullname" . }}
   {{- end}}

--- a/cockroachdb-parent/charts/cockroachdb/templates/job-certSelfSigner.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/templates/job-certSelfSigner.yaml
@@ -78,6 +78,10 @@ spec:
               value: {{ .Release.Namespace | quote }}
             - name: CLUSTER_DOMAIN
               value: {{ .Values.cockroachdb.clusterDomain}}
+            {{- if .Values.cockroachdb.tls.selfSigner.additionalSANs }}
+            - name: ADDITIONAL_SANS
+              value: {{ .Values.cockroachdb.tls.selfSigner.additionalSANs | join "," | quote }}
+            {{- end }}
         {{- if and .Values.cockroachdb.tls.selfSigner.securityContext.enabled }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/cockroachdb-parent/charts/cockroachdb/values.schema.json
+++ b/cockroachdb-parent/charts/cockroachdb/values.schema.json
@@ -88,6 +88,12 @@
                   "pattern": "^(Always|Never|IfNotPresent)$"
                 }
               }
+            },
+            "additionalSANs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }

--- a/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -49,6 +49,12 @@ cockroachdb:
       # podUpdateTimeout specifies the timeout for pods to reach the running state.
       # Only considered when rotateCerts is true.
       podUpdateTimeout: 2m
+      # additionalSANs specifies additional Subject Alternative Names (SANs) to include in node certificates.
+      # This is useful for load balancers or external endpoints that need SSL verification.
+      # Example: ["my-loadbalancer.example.com", "10.20.30.40"]
+      # Note: Changes to this value will only take effect after the next certificate rotation cycle,
+      # or when certificates are manually regenerated (e.g., by deleting the node-secret).
+      additionalSANs: []
       # svcAccountAnnotations defines annotations for the ServiceAccount used by the self-signer job.
       svcAccountAnnotations: {}
       # labels defines additional labels for pods of the self-signer job.
@@ -69,7 +75,7 @@ cockroachdb:
         # repository defines the image repository for the self-signer container.
         repository: cockroachlabs-helm-charts/cockroach-self-signer-cert
         # tag defines the image tag for the self-signer container.
-        tag: "1.9"
+        tag: "1.10"
         # pullPolicy defines the image pull policy for the self-signer container.
         pullPolicy: IfNotPresent
         # registry defines the container registry host (e.g., gcr.io, docker.io).

--- a/cockroachdb/CHANGELOG.md
+++ b/cockroachdb/CHANGELOG.md
@@ -9,3 +9,18 @@ All notable changes to the CockroachDB Helm chart will be documented in this fil
     - Supports live certificate reload via SIGHUP without pod restarts.
     - Only compatible with externally managed certificates (user-provided or cert-manager). Not compatible with self-signed certificates.
     - **Backward compatible**: This is an opt-in feature (defaults to `false`). Existing deployments are unaffected and will continue to use the traditional certificate rotation approach with pod restarts.
+
+  - **Additional Subject Alternative Names (SANs) for Self-Signer Certificates (CRDB-55385)**
+    - Added `tls.certs.selfSigner.additionalSANs` configuration option to allow custom hostnames and IP addresses in node certificates
+    - Enables SSL certificate validation (`sslmode=verify-full`) when routing traffic through load balancers
+    - Supports Physical Cluster Replication (PCR) scenarios where replication traffic goes through external endpoints
+    - Additional SANs are automatically included in both initial certificate generation and subsequent rotations
+    - Configuration example:
+      ```yaml
+      tls:
+        certs:
+          selfSigner:
+            additionalSANs:
+              - "my-loadbalancer.example.com"
+              - "192.168.1.100"
+      ```

--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -92,6 +92,39 @@ There are 3 ways to configure a secure cluster, with this chart. This all relate
 
 For instructions on using self-signer to provision certificates for the statefulset-based Helm chart, see the [Installation of statefulset-based Helm Chart with self-signer](../docs/certificate-management/self-signer.md#Installation-of-statefulset-based-helm-chart-with-self-signer) section in the documentation.
 
+##### Additional Subject Alternative Names (SANs) for Load Balancers
+
+When using the self-signer, you can include additional Subject Alternative Names (SANs) in node certificates. This is useful when:
+- Routing traffic through load balancers with `sslmode=verify-full`
+- Setting up Physical Cluster Replication (PCR) through external endpoints
+- Accessing the cluster through custom DNS names or IP addresses
+
+To add custom SANs, configure `tls.certs.selfSigner.additionalSANs`:
+
+```yaml
+tls:
+  enabled: true
+  certs:
+    selfSigner:
+      enabled: true
+      additionalSANs:
+        - "my-loadbalancer.example.com"
+        - "192.168.1.100"
+        - "external-endpoint.domain.com"
+```
+
+Or using Helm command-line options:
+
+```shell
+$ helm install my-release cockroachdb/cockroachdb \
+  --set tls.enabled=true \
+  --set tls.certs.selfSigner.enabled=true \
+  --set 'tls.certs.selfSigner.additionalSANs[0]=my-loadbalancer.example.com' \
+  --set 'tls.certs.selfSigner.additionalSANs[1]=192.168.1.100'
+```
+
+**Note:** The additional SANs are automatically included in both initial certificate generation and subsequent certificate rotations.
+
 #### Manual
 
 If you wish to supply the certificates to the nodes yourself set `tls.certs.provided` to `yes`/`true`. You may want to use this if you want to use a different certificate authority from the one being used by Kubernetes or if your Kubernetes cluster doesn't fully support certificate-signing requests. To use this, first set up your certificates and load them into your Kubernetes cluster as Secrets using the commands below:
@@ -418,6 +451,7 @@ For details see the [`values.yaml`](values.yaml) file.
 | `tls.certs.selfSigner.rotateCerts`                        | Whether to rotate the certs generate by cockroachdb                                                                                                                                                                                                                                                                                      | `true`                                                 |
 | `tls.certs.selfSigner.readinessWait`                      | Wait time for each cockroachdb replica to become ready once it comes in running state. Only considered when rotateCerts is set to true                                                                                                                                                                                                   | `30s`                                                  |
 | `tls.certs.selfSigner.podUpdateTimeout`                   | Wait time for each cockroachdb replica to get to running state. Only considered when rotateCerts is set to true                                                                                                                                                                                                                          | `2m`                                                   |
+| `tls.certs.selfSigner.additionalSANs`                     | Additional Subject Alternative Names (hostnames or IP addresses) to include in node certificates. Useful for load balancers and external endpoints                                                                                                                                                                                       | `[]`                                                   |
 | `tls.certs.certManager`                                   | Provision certificates with cert-manager                                                                                                                                                                                                                                                                                                 | `false`                                                |
 | `tls.certs.certManagerIssuer.group`                       | IssuerRef group to use when generating certificates                                                                                                                                                                                                                                                                                      | `cert-manager.io`                                      |
 | `tls.certs.certManagerIssuer.kind`                        | IssuerRef kind to use when generating certificates                                                                                                                                                                                                                                                                                       | `Issuer`                                               |

--- a/cockroachdb/templates/cronjob-client-node-certSelfSigner.yaml
+++ b/cockroachdb/templates/cronjob-client-node-certSelfSigner.yaml
@@ -69,5 +69,9 @@ spec:
               value: {{ .Release.Namespace }}
             - name: CLUSTER_DOMAIN
               value: {{ .Values.clusterDomain}}
+            {{- if .Values.tls.certs.selfSigner.additionalSANs }}
+            - name: ADDITIONAL_SANS
+              value: {{ .Values.tls.certs.selfSigner.additionalSANs | join "," | quote }}
+            {{- end }}
           serviceAccountName: {{ template "rotatecerts.fullname" . }}
   {{- end}}

--- a/cockroachdb/templates/job-certSelfSigner.yaml
+++ b/cockroachdb/templates/job-certSelfSigner.yaml
@@ -80,6 +80,10 @@ spec:
             value: {{ .Release.Namespace | quote }}
           - name: CLUSTER_DOMAIN
             value: {{ .Values.clusterDomain}}
+          {{- if .Values.tls.certs.selfSigner.additionalSANs }}
+          - name: ADDITIONAL_SANS
+            value: {{ .Values.tls.certs.selfSigner.additionalSANs | join "," | quote }}
+          {{- end }}
         {{- if and .Values.tls.certs.selfSigner.securityContext.enabled }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/cockroachdb/values.schema.json
+++ b/cockroachdb/values.schema.json
@@ -67,6 +67,12 @@
                   },
                   "rotateCerts": {
                     "type": "boolean"
+                  },
+                  "additionalSANs": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 }
               }

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -634,6 +634,12 @@ tls:
       nodeCertDuration: 8760h
       # Expiry window of node certificates means a window before actual expiry in which node certs should be rotated.
       nodeCertExpiryWindow: 168h
+      # Additional Subject Alternative Names (SANs) to include in node certificates.
+      # Useful for load balancers or external endpoints that need to be included in the certificate.
+      # Example: ["my-loadbalancer.example.com", "10.20.30.40"]
+      # Note: Changes to this value will only take effect after the next certificate rotation cycle,
+      # or when certificates are manually regenerated (e.g., by deleting the node-secret).
+      additionalSANs: []
       # If set, the cockroachdb cert selfSigner will rotate the certificates before expiry.
       rotateCerts: true
       # Wait time for each cockroachdb replica to become ready once it comes in running state. Only considered when rotateCerts is set to true
@@ -689,7 +695,7 @@ tls:
     # Image Placeholder for the selfSigner utility. This will be changed once the CI workflows for the image is in place.
     image:
       repository: cockroachlabs-helm-charts/cockroach-self-signer-cert
-      tag: "1.9"
+      tag: "1.10"
       pullPolicy: IfNotPresent
       registry: gcr.io
       credentials: {}

--- a/pkg/generator/generate_cert.go
+++ b/pkg/generator/generate_cert.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -49,6 +50,26 @@ func init() {
 	generatePKCS8Key = false
 }
 
+// SanitizeAdditionalSANs trims whitespace and filters out empty strings from a list of SANs.
+// This prevents empty/whitespace-only SANs from being passed to the cockroach CLI, which would panic.
+// Returns nil when the input is nil or when all entries are empty/whitespace.
+func SanitizeAdditionalSANs(sans []string) []string {
+	if len(sans) == 0 {
+		return nil
+	}
+	valid := make([]string, 0, len(sans))
+	for _, san := range sans {
+		trimmed := strings.TrimSpace(san)
+		if trimmed != "" {
+			valid = append(valid, trimmed)
+		}
+	}
+	if len(valid) == 0 {
+		return nil
+	}
+	return valid
+}
+
 // GenerateCert is the structure containing all the certificate related info
 type GenerateCert struct {
 	client                    client.Client
@@ -69,6 +90,7 @@ type GenerateCert struct {
 	ReadinessWait             time.Duration
 	PodUpdateTimeout          time.Duration
 	OperatorManaged           bool
+	AdditionalSANs            []string
 }
 
 type certConfig struct {
@@ -546,6 +568,12 @@ func (rc *GenerateCert) GenerateNodeCert(ctx context.Context, nodeSecretName, na
 		}
 
 		hosts = append(hosts, operatorJoinServiceHosts...)
+	}
+
+	// Append additional user-provided SANs
+	if len(rc.AdditionalSANs) > 0 {
+		logrus.Infof("Adding additional SANs to node certificate: %v", rc.AdditionalSANs)
+		hosts = append(hosts, rc.AdditionalSANs...)
 	}
 
 	// create the Node Pair certificates

--- a/pkg/generator/generate_cert_test.go
+++ b/pkg/generator/generate_cert_test.go
@@ -1,0 +1,299 @@
+/*
+Copyright 2026 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generator
+
+import (
+	"crypto/x509"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cockroachdb/helm-charts/pkg/security"
+)
+
+const testCALifetime = 5 * 366 * 24 * time.Hour   // five years
+const testCertLifetime = 1 * 366 * 24 * time.Hour // one year
+
+// tempDir creates a temporary directory for testing.
+func tempDir(t *testing.T) (string, func()) {
+	certsDir, err := os.MkdirTemp("", "generator_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return certsDir, func() {
+		if err := os.RemoveAll(certsDir); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// setupTestCertEnv creates a test environment with temp dir, CA pair, and GenerateCert instance.
+func setupTestCertEnv(t *testing.T, additionalSANs []string) (string, string, GenerateCert, func()) {
+	certsDir, cleanup := tempDir(t)
+	caKey := filepath.Join(certsDir, "ca.key")
+
+	// Create CA first
+	err := security.CreateCAPair(certsDir, caKey, defaultKeySize, testCALifetime, true, true)
+	require.NoError(t, err, "Failed to create CA pair")
+
+	genCert := GenerateCert{
+		CertsDir:             certsDir,
+		CAKey:                caKey,
+		PublicServiceName:    "test-public",
+		DiscoveryServiceName: "test-service",
+		ClusterDomain:        "cluster.local",
+		NodeCertConfig: &certConfig{
+			Duration:     testCertLifetime,
+			ExpiryWindow: 7 * 24 * time.Hour,
+		},
+		AdditionalSANs: additionalSANs,
+	}
+
+	return certsDir, caKey, genCert, cleanup
+}
+
+// buildStandardHosts creates the standard hosts list for node certificates.
+func buildStandardHosts(genCert GenerateCert, namespace string) []string {
+	return []string{
+		"localhost",
+		"127.0.0.1",
+		genCert.PublicServiceName,
+		genCert.PublicServiceName + "." + namespace,
+		genCert.PublicServiceName + "." + namespace + ".svc." + genCert.ClusterDomain,
+		"*." + genCert.DiscoveryServiceName,
+		"*." + genCert.DiscoveryServiceName + "." + namespace,
+		"*." + genCert.DiscoveryServiceName + "." + namespace + ".svc." + genCert.ClusterDomain,
+	}
+}
+
+// createAndParseCert creates a node certificate and returns the parsed x509 certificate.
+func createAndParseCert(t *testing.T, certsDir, caKey string, genCert GenerateCert, hosts []string) *x509.Certificate {
+	// Create node certificate
+	err := security.CreateNodePair(
+		certsDir,
+		caKey,
+		defaultKeySize,
+		genCert.NodeCertConfig.Duration,
+		true,
+		hosts,
+	)
+	require.NoError(t, err, "Failed to create node certificate")
+
+	// Read and parse the generated certificate
+	pemCert, err := os.ReadFile(filepath.Join(certsDir, "node.crt"))
+	require.NoError(t, err, "Failed to read node certificate")
+
+	cert, err := security.GetCertObj(pemCert)
+	require.NoError(t, err, "Failed to parse certificate")
+
+	return cert
+}
+
+// getStandardSANs returns the list of standard SANs expected in all node certificates.
+func getStandardSANs() []string {
+	return []string{
+		"localhost",
+		"test-public",
+		"test-public.default",
+		"test-public.default.svc.cluster.local",
+		"*.test-service",
+		"*.test-service.default",
+		"*.test-service.default.svc.cluster.local",
+	}
+}
+
+// TestCreateNodeCertWithAdditionalSANs tests node certificate generation with various
+// additional SAN configurations using a table-driven approach.
+func TestCreateNodeCertWithAdditionalSANs(t *testing.T) {
+	tests := []struct {
+		name                string
+		additionalSANs      []string
+		expectedDNSSANs     []string
+		expectedIPSANs      []string
+		unexpectedDNSSANs   []string
+		sanitizeAndValidate bool
+	}{
+		{
+			name: "WithAdditionalSANs",
+			additionalSANs: []string{
+				"my-loadbalancer.example.com",
+				"10.20.30.40",
+				"backup-lb.example.com",
+			},
+			expectedDNSSANs: []string{
+				"my-loadbalancer.example.com",
+				"backup-lb.example.com",
+			},
+			expectedIPSANs:    []string{"10.20.30.40"},
+			unexpectedDNSSANs: nil,
+		},
+		{
+			name:              "NoAdditionalSANs",
+			additionalSANs:    nil,
+			expectedDNSSANs:   nil,
+			expectedIPSANs:    nil,
+			unexpectedDNSSANs: []string{"my-loadbalancer.example.com", "backup-lb.example.com"},
+		},
+		{
+			name: "SanitizeAdditionalSANs",
+			additionalSANs: []string{
+				"valid-san.example.com",
+				"  whitespace-before.example.com",
+				"whitespace-after.example.com  ",
+				"  whitespace-both.example.com  ",
+				"",    // empty string
+				"   ", // whitespace only
+				"192.168.1.1",
+				"  192.168.1.2  ",
+			},
+			expectedDNSSANs: []string{
+				"valid-san.example.com",
+				"whitespace-before.example.com",
+				"whitespace-after.example.com",
+				"whitespace-both.example.com",
+			},
+			expectedIPSANs:      []string{"192.168.1.1", "192.168.1.2"},
+			sanitizeAndValidate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			certsDir, caKey, genCert, cleanup := setupTestCertEnv(t, tt.additionalSANs)
+			defer cleanup()
+
+			namespace := "default"
+			hosts := buildStandardHosts(genCert, namespace)
+
+			// Apply sanitization and append additional SANs
+			validSANs := SanitizeAdditionalSANs(genCert.AdditionalSANs)
+			if tt.sanitizeAndValidate {
+				// For sanitization test, verify the sanitization worked correctly
+				expectedValidCount := len(tt.expectedDNSSANs) + len(tt.expectedIPSANs)
+				require.Len(t, validSANs, expectedValidCount, "Should have correct number of valid SANs after filtering empty/whitespace")
+			}
+			if len(validSANs) > 0 {
+				hosts = append(hosts, validSANs...)
+			}
+
+			// Create and parse certificate
+			cert := createAndParseCert(t, certsDir, caKey, genCert, hosts)
+
+			// Verify standard SANs are always present
+			for _, san := range getStandardSANs() {
+				assert.Contains(t, cert.DNSNames, san, "Standard SAN %s should be present", san)
+			}
+
+			// Verify expected additional DNS SANs
+			for _, san := range tt.expectedDNSSANs {
+				assert.Contains(t, cert.DNSNames, san, "Additional DNS SAN %s should be present", san)
+			}
+
+			// Verify expected IP SANs
+			if len(tt.expectedIPSANs) > 0 {
+				require.NotEmpty(t, cert.IPAddresses, "Certificate should contain IP addresses")
+				ipStrings := make([]string, len(cert.IPAddresses))
+				for i, ip := range cert.IPAddresses {
+					ipStrings[i] = ip.String()
+				}
+				for _, expectedIP := range tt.expectedIPSANs {
+					assert.Contains(t, ipStrings, expectedIP, "IP SAN %s should be present", expectedIP)
+				}
+			}
+
+			// Verify unexpected SANs are not present
+			for _, san := range tt.unexpectedDNSSANs {
+				assert.NotContains(t, cert.DNSNames, san, "Should not contain unexpected SAN %s", san)
+			}
+		})
+	}
+}
+
+// TestSanitizeAdditionalSANs tests the SAN sanitization helper function directly.
+func TestSanitizeAdditionalSANs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty slice",
+			input:    []string{},
+			expected: nil,
+		},
+		{
+			name:     "valid SANs",
+			input:    []string{"host1.example.com", "192.168.1.1"},
+			expected: []string{"host1.example.com", "192.168.1.1"},
+		},
+		{
+			name:     "SANs with leading whitespace",
+			input:    []string{"  host1.example.com", "  192.168.1.1"},
+			expected: []string{"host1.example.com", "192.168.1.1"},
+		},
+		{
+			name:     "SANs with trailing whitespace",
+			input:    []string{"host1.example.com  ", "192.168.1.1  "},
+			expected: []string{"host1.example.com", "192.168.1.1"},
+		},
+		{
+			name:     "SANs with both leading and trailing whitespace",
+			input:    []string{"  host1.example.com  ", "  192.168.1.1  "},
+			expected: []string{"host1.example.com", "192.168.1.1"},
+		},
+		{
+			name:     "empty strings filtered out",
+			input:    []string{"host1.example.com", "", "192.168.1.1"},
+			expected: []string{"host1.example.com", "192.168.1.1"},
+		},
+		{
+			name:     "whitespace-only strings filtered out",
+			input:    []string{"host1.example.com", "   ", "192.168.1.1"},
+			expected: []string{"host1.example.com", "192.168.1.1"},
+		},
+		{
+			name:     "mixed valid, empty, and whitespace",
+			input:    []string{"  host1.example.com", "", "   ", "192.168.1.1  ", "host2.example.com"},
+			expected: []string{"host1.example.com", "192.168.1.1", "host2.example.com"},
+		},
+		{
+			name:     "all empty or whitespace",
+			input:    []string{"", "   ", "\t", "  \n  "},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeAdditionalSANs(tt.input)
+			if tt.expected == nil {
+				assert.Nil(t, result, "Expected nil result")
+			} else {
+				assert.Equal(t, tt.expected, result, "Sanitized SANs should match expected")
+			}
+		})
+	}
+}

--- a/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
+++ b/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
@@ -18,9 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Environment variable name to check if running in nightly mode
-const isNightlyEnvVar = "isNightly"
-
 type singleRegion struct {
 	operator.OperatorUseCases
 	operator.Region

--- a/tests/e2e/rotate/cockroachdb_rotate_certs_test.go
+++ b/tests/e2e/rotate/cockroachdb_rotate_certs_test.go
@@ -73,6 +73,9 @@ func TestCockroachDbRotateCertificates(t *testing.T) {
 	options := &helm.Options{
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 		SetValues:      helmValues,
+		ExtraArgs: map[string][]string{
+			"install": {"--timeout", "10m"},
+		},
 	}
 
 	// Deploy the cockroachdb helm chart and checks installation should succeed.
@@ -93,7 +96,7 @@ func TestCockroachDbRotateCertificates(t *testing.T) {
 	k8s.WaitUntilServiceAvailable(t, kubectlOptions, serviceName, 30, 2*time.Second)
 
 	testutil.RequireCertificatesToBeValid(t, crdbCluster)
-	testutil.RequireClusterToBeReadyEventuallyTimeout(t, crdbCluster, 500*time.Second)
+	testutil.RequireClusterToBeReadyEventuallyTimeout(t, crdbCluster, 600*time.Second)
 	time.Sleep(20 * time.Second)
 	// This will create a database, a table and insert two rows into that table.
 	testutil.RequireCRDBToFunction(t, crdbCluster, false)
@@ -110,7 +113,7 @@ func TestCockroachDbRotateCertificates(t *testing.T) {
 	testutil.RequireToRunRotateJob(t, crdbCluster, helmValues, "0 0 */26 * *", false)
 
 	// This will wait for the certificate rotation to complete, which will do a rolling restart of the CRDB cluster.
-	testutil.RequireCertRotateJobToBeCompleted(t, "client-node-certificate-rotate", crdbCluster, 500*time.Second)
+	testutil.RequireCertRotateJobToBeCompleted(t, "client-node-certificate-rotate", crdbCluster, 600*time.Second)
 
 	time.Sleep(20 * time.Second)
 	// This will check after rotation the database is working properly.
@@ -133,7 +136,7 @@ func TestCockroachDbRotateCertificates(t *testing.T) {
 	testutil.RequireToRunRotateJob(t, crdbCluster, helmValues, "0 0 */29 * *", true)
 
 	// This will wait for the certificate rotation to complete, which will do a rolling restart of the CRDB cluster.
-	testutil.RequireCertRotateJobToBeCompleted(t, "ca-certificate-rotate", crdbCluster, 500*time.Second)
+	testutil.RequireCertRotateJobToBeCompleted(t, "ca-certificate-rotate", crdbCluster, 600*time.Second)
 
 	time.Sleep(20 * time.Second)
 	// This will check after rotation the database is working properly.

--- a/tests/template/cockroachdb_helm_template_test.go
+++ b/tests/template/cockroachdb_helm_template_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	crdbv1beta1 "github.com/cockroachdb/helm-charts/pkg/upstream/cockroach-operator/api/v1beta1"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
@@ -20,6 +19,8 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
+
+	crdbv1beta1 "github.com/cockroachdb/helm-charts/pkg/upstream/cockroach-operator/api/v1beta1"
 )
 
 var (
@@ -526,6 +527,13 @@ func TestSelfSignerHelmValidation(t *testing.T) {
 				"tls.certs.selfSigner.caCertDuration": "",
 			},
 			"CA secret is not present in the release namespace",
+		},
+		{
+			"additionalSANs must be an array",
+			map[string]string{
+				"tls.certs.selfSigner.additionalSANs": "not-an-array",
+			},
+			"values don't meet the specifications of the schema",
 		},
 	}
 
@@ -2939,4 +2947,90 @@ func TestHelmClusterTLSConfiguration(t *testing.T) {
 			})
 		}
 	})
+}
+
+// TestHelmSelfSignerAdditionalSANs tests that additionalSANs are properly passed to the self-signer Job and CronJob
+func TestHelmSelfSignerAdditionalSANs(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                 string
+		setValues            map[string]string
+		expectAdditionalSANs bool
+		expectedValue        string
+	}{
+		{
+			name: "additionalSANs with multiple values",
+			setValues: map[string]string{
+				"tls.certs.selfSigner.additionalSANs[0]": "my-loadbalancer.example.com",
+				"tls.certs.selfSigner.additionalSANs[1]": "10.20.30.40",
+				"tls.certs.selfSigner.additionalSANs[2]": "backup-lb.example.com",
+			},
+			expectAdditionalSANs: true,
+			expectedValue:        "my-loadbalancer.example.com,10.20.30.40,backup-lb.example.com",
+		},
+		{
+			name: "additionalSANs with single value",
+			setValues: map[string]string{
+				"tls.certs.selfSigner.additionalSANs[0]": "my-lb.example.com",
+			},
+			expectAdditionalSANs: true,
+			expectedValue:        "my-lb.example.com",
+		},
+		{
+			name:                 "no additionalSANs configured",
+			setValues:            map[string]string{},
+			expectAdditionalSANs: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			options := &helm.Options{
+				KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+				SetValues:      tc.setValues,
+			}
+
+			// Test Job template
+			jobOutput := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/job-certSelfSigner.yaml"})
+			var job batchv1.Job
+			helm.UnmarshalK8SYaml(t, jobOutput, &job)
+
+			additionalSANsEnv := findEnvVar(job.Spec.Template.Spec.Containers[0].Env, "ADDITIONAL_SANS")
+
+			if tc.expectAdditionalSANs {
+				require.NotNil(t, additionalSANsEnv, "ADDITIONAL_SANS env var should be present in Job")
+				require.Equal(t, tc.expectedValue, additionalSANsEnv.Value, "ADDITIONAL_SANS value should match")
+			} else {
+				require.Nil(t, additionalSANsEnv, "ADDITIONAL_SANS env var should not be present when not configured")
+			}
+
+			// Test CronJob template
+			cronJobOutput := helm.RenderTemplate(t, options, helmChartPath, releaseName, []string{"templates/cronjob-client-node-certSelfSigner.yaml"})
+			var cronJob v1beta1.CronJob
+			helm.UnmarshalK8SYaml(t, cronJobOutput, &cronJob)
+
+			additionalSANsEnvCron := findEnvVar(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env, "ADDITIONAL_SANS")
+
+			if tc.expectAdditionalSANs {
+				require.NotNil(t, additionalSANsEnvCron, "ADDITIONAL_SANS env var should be present in CronJob")
+				require.Equal(t, tc.expectedValue, additionalSANsEnvCron.Value, "ADDITIONAL_SANS value should match")
+			} else {
+				require.Nil(t, additionalSANsEnvCron, "ADDITIONAL_SANS env var should not be present when not configured")
+			}
+		})
+	}
+}
+
+// findEnvVar is a helper function to find an environment variable by name
+func findEnvVar(envVars []corev1.EnvVar, name string) *corev1.EnvVar {
+	for i := range envVars {
+		if envVars[i].Name == name {
+			return &envVars[i]
+		}
+	}
+	return nil
 }

--- a/tests/template/cockroachdb_operator_template_test.go
+++ b/tests/template/cockroachdb_operator_template_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
@@ -334,4 +336,87 @@ func TestOperatorStorageMigrationTemplateRemoved(t *testing.T) {
 	_, err := helm.RenderTemplateE(t, options, operatorChartPath, releaseName, []string{"templates/storage-migration.yaml"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Could not resolve template file templates/storage-migration.yaml")
+}
+
+// TestCockroachDBParentSelfSignerAdditionalSANs tests that additionalSANs are properly passed to the self-signer Job and CronJob in the parent chart
+func TestCockroachDBParentSelfSignerAdditionalSANs(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../cockroachdb-parent/charts/cockroachdb")
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name                 string
+		setValues            map[string]string
+		expectAdditionalSANs bool
+		expectedValue        string
+	}{
+		{
+			name: "additionalSANs with multiple values",
+			setValues: map[string]string{
+				"cockroachdb.tls.selfSigner.enabled":           "true",
+				"cockroachdb.tls.selfSigner.additionalSANs[0]": "my-loadbalancer.example.com",
+				"cockroachdb.tls.selfSigner.additionalSANs[1]": "10.20.30.40",
+				"cockroachdb.tls.selfSigner.additionalSANs[2]": "backup-lb.example.com",
+			},
+			expectAdditionalSANs: true,
+			expectedValue:        "my-loadbalancer.example.com,10.20.30.40,backup-lb.example.com",
+		},
+		{
+			name: "additionalSANs with single value",
+			setValues: map[string]string{
+				"cockroachdb.tls.selfSigner.enabled":           "true",
+				"cockroachdb.tls.selfSigner.additionalSANs[0]": "my-lb.example.com",
+			},
+			expectAdditionalSANs: true,
+			expectedValue:        "my-lb.example.com",
+		},
+		{
+			name: "no additionalSANs configured",
+			setValues: map[string]string{
+				"cockroachdb.tls.selfSigner.enabled": "true",
+			},
+			expectAdditionalSANs: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			options := &helm.Options{
+				KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+				SetValues:      tc.setValues,
+			}
+
+			// Test Job template
+			jobOutput := helm.RenderTemplate(t, options, chartPath, releaseName, []string{"templates/job-certSelfSigner.yaml"})
+			var job batchv1.Job
+			helm.UnmarshalK8SYaml(t, jobOutput, &job)
+
+			additionalSANsEnv := findEnvVar(job.Spec.Template.Spec.Containers[0].Env, "ADDITIONAL_SANS")
+
+			if tc.expectAdditionalSANs {
+				require.NotNil(t, additionalSANsEnv, "ADDITIONAL_SANS env var should be present in Job")
+				require.Equal(t, tc.expectedValue, additionalSANsEnv.Value, "ADDITIONAL_SANS value should match")
+			} else {
+				require.Nil(t, additionalSANsEnv, "ADDITIONAL_SANS env var should not be present when not configured")
+			}
+
+			// Test CronJob template
+			cronJobOutput := helm.RenderTemplate(t, options, chartPath, releaseName, []string{"templates/cronjob-client-node-certSelfSigner.yaml"})
+			var cronJob v1beta1.CronJob
+			helm.UnmarshalK8SYaml(t, cronJobOutput, &cronJob)
+
+			additionalSANsEnvCron := findEnvVar(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env, "ADDITIONAL_SANS")
+
+			if tc.expectAdditionalSANs {
+				require.NotNil(t, additionalSANsEnvCron, "ADDITIONAL_SANS env var should be present in CronJob")
+				require.Equal(t, tc.expectedValue, additionalSANsEnvCron.Value, "ADDITIONAL_SANS value should match")
+			} else {
+				require.Nil(t, additionalSANsEnvCron, "ADDITIONAL_SANS env var should not be present when not configured")
+			}
+		})
+	}
 }


### PR DESCRIPTION
CRDB-55385: Allow users to specify additional Subject Alternative Names (SANs) for node certificates generated by the self-signer utility.

This enables customers to:
- Route traffic through load balancers with sslmode=verify-full
- Support Physical Cluster Replication (PCR) via load balancers
- Include external endpoints in certificate validation

Implementation:
- Add additionalSANs field to Helm values (tls.certs.selfSigner.additionalSANs)
- Pass ADDITIONAL_SANS environment variable to self-signer jobs
- Parse and append additional SANs to node certificate hosts list
- Update schema validation for additionalSANs array
- Apply to both certificate generation and rotation

Example usage:
  tls: certs: selfSigner: additionalSANs: - "my-loadbalancer.example.com" - "192.168.1.100"