### PR TITLE
e2e: add AWS infrastructure support for single/multi-region testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,13 @@ test/single-cluster/up: bin/k3d
 test/multi-cluster/down: bin/k3d
 	 ./tests/k3d/dev-multi-cluster.sh down
 
+test/nightly-e2e/advanced/single-region: bin/cockroach bin/kubectl bin/helm build/self-signer bin/kind
+	@PATH="$(PWD)/bin:${PATH}" PROVIDER=kind TEST_ADVANCED_FEATURES=true go test -timeout 90m -v -test.run TestOperatorInSingleRegion ./tests/e2e/operator/singleRegion/... || (echo "Advanced single-region tests failed with exit code $$?" && exit 1)
+
+test/nightly-e2e/advanced/multi-region: bin/cockroach bin/kubectl bin/helm build/self-signer bin/kind
+	@PATH="$(PWD)/bin:${PATH}" PROVIDER=kind TEST_ADVANCED_FEATURES=true go test -timeout 90m -v -test.run TestOperatorInMultiRegion ./tests/e2e/operator/multiRegion/... || (echo "Advanced multi-region tests failed with exit code $$?" && exit 1)
+
+
 test/lint: bin/helm ## lint the helm chart
 	@build/lint.sh && \
 	bin/helm lint cockroachdb && \

--- a/Makefile
+++ b/Makefile
@@ -124,10 +124,10 @@ test/e2e/%: bin/cockroach bin/kubectl bin/helm build/self-signer test/cluster/up
 	exit $${EXIT_CODE:-0}
 
 test/e2e/multi-region: bin/cockroach bin/kubectl bin/helm  build/self-signer bin/k3d bin/kind
-	@PATH="$(PWD)/bin:${PATH}" go test -timeout 60m -v -test.run TestOperatorInMultiRegion ./tests/e2e/operator/multiRegion/... || (echo "Multi region tests failed with exit code $$?" && exit 1)
+	@PATH="$(PWD)/bin:${PATH}" go test -timeout 90m -v -test.run TestOperatorInMultiRegion ./tests/e2e/operator/multiRegion/... || (echo "Multi region tests failed with exit code $$?" && exit 1)
 
 test/e2e/single-region: bin/cockroach bin/kubectl bin/helm build/self-signer bin/k3d bin/kind
-	@PATH="$(PWD)/bin:${PATH}" go test -timeout 60m -v -test.run TestOperatorInSingleRegion ./tests/e2e/operator/singleRegion/... || (echo "Single region tests failed with exit code $$?" && exit 1)
+	@PATH="$(PWD)/bin:${PATH}" go test -timeout 90m -v -test.run TestOperatorInSingleRegion ./tests/e2e/operator/singleRegion/... || (echo "Single region tests failed with exit code $$?" && exit 1)
 
 test/e2e/migrate: bin/cockroach bin/kubectl bin/helm bin/migration-helper build/self-signer test/cluster/up/3
 	@PATH="$(PWD)/bin:${PATH}" go test -timeout 60m -v ./tests/e2e/migrate/... || EXIT_CODE=$$?; \

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.23.8
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
+	github.com/aws/aws-sdk-go v1.44.122
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cockroachdb/cockroach-operator v0.0.0-20250618040001-5a36c88b7231
 	github.com/cockroachdb/errors v1.8.0
 	github.com/google/martian v2.1.1-0.20190517191504-25dcb96d9e51+incompatible
-	github.com/gosimple/slug v1.9.0
 	github.com/gruntwork-io/terratest v0.41.26
 	github.com/jackc/pgx/v4 v4.18.2
 	github.com/jetstack/cert-manager v0.0.0-00010101000000-000000000000
@@ -32,7 +32,6 @@ require (
 
 require (
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
-	github.com/aws/aws-sdk-go v1.44.122 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/boombuler/barcode v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
@@ -95,7 +94,6 @@ require (
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1142,8 +1142,6 @@ github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/gosimple/slug v1.9.0 h1:r5vDcYrFz9BmfIAMC829un9hq7hKM4cHUrsv36LbEqs=
-github.com/gosimple/slug v1.9.0/go.mod h1:AMZ+sOVe65uByN3kgEyf9WEBKBCSS+dJjMX9x4vDJbg=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
@@ -1491,8 +1489,6 @@ github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPH
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be h1:ta7tUOvsPHVHGom5hKW5VXNc2xZIkfCKP8iaqOyYtUQ=
-github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be/go.mod h1:MIDFMn7db1kT65GmV94GzpX9Qdi7N/pQlwb+AN8wh+Q=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=

--- a/tests/e2e/migrate/helm_chart_to_cockroach_enterprise_operator_test.go
+++ b/tests/e2e/migrate/helm_chart_to_cockroach_enterprise_operator_test.go
@@ -10,6 +10,7 @@ import (
 
 	api "github.com/cockroachdb/cockroach-operator/apis/v1alpha1"
 	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/infra"
 	"github.com/cockroachdb/helm-charts/tests/testutil"
 	"github.com/cockroachdb/helm-charts/tests/testutil/migration"
 	"github.com/gruntwork-io/terratest/modules/helm"
@@ -56,6 +57,24 @@ func init() {
 	})
 	if err != nil {
 		panic(err)
+	}
+}
+
+// providerCloudRegion returns the cloud region for the active provider.
+// Local providers (k3d, kind) need an explicit region since topology labels may not be set.
+// Cloud providers (gcp, aws, azure) auto-detect the region from node topology labels,
+// so an empty string is returned to let the operator use those labels directly.
+func providerCloudRegion() string {
+	p := strings.TrimSpace(strings.ToLower(os.Getenv("PROVIDER")))
+	switch p {
+	case "k3d", "": // default to k3d when PROVIDER is unset
+		return infra.RegionCodes[infra.ProviderK3D][0]
+	case "kind":
+		return infra.RegionCodes[infra.ProviderKind][0]
+	case "gcp":
+		return infra.RegionCodes[infra.ProviderGCP][0]
+	default: // aws, azure, openshift, etc. — node topology labels are auto-set by the cloud provider
+		return ""
 	}
 }
 
@@ -145,7 +164,7 @@ func (h *HelmChartToOperator) TestDefaultMigration(t *testing.T) {
 		k8s.RunKubectl(t, kubectlOptions, "delete", "priorityclass", "crdb-critical")
 	}()
 
-	operator.InstallCockroachDBEnterpriseOperator(t, kubectlOptions)
+	operator.InstallCockroachDBEnterpriseOperator(t, kubectlOptions, providerCloudRegion())
 	defer func() {
 		t.Log("Uninstall the cockroachdb enterprise operator")
 		operator.UninstallCockroachDBEnterpriseOperator(t, kubectlOptions)
@@ -263,7 +282,7 @@ func (h *HelmChartToOperator) TestCertManagerMigration(t *testing.T) {
 		k8s.RunKubectl(t, kubectlOptions, "delete", "priorityclass", "crdb-critical")
 	}()
 
-	operator.InstallCockroachDBEnterpriseOperator(t, kubectlOptions)
+	operator.InstallCockroachDBEnterpriseOperator(t, kubectlOptions, providerCloudRegion())
 	defer func() {
 		t.Log("Uninstall the cockroachdb enterprise operator")
 		operator.UninstallCockroachDBEnterpriseOperator(t, kubectlOptions)
@@ -381,7 +400,7 @@ func (h *HelmChartToOperator) TestDedicatedLogsPVCMigration(t *testing.T) {
 		k8s.RunKubectl(t, kubectlOptions, "delete", "priorityclass", "crdb-critical")
 	}()
 
-	operator.InstallCockroachDBEnterpriseOperator(t, kubectlOptions)
+	operator.InstallCockroachDBEnterpriseOperator(t, kubectlOptions, providerCloudRegion())
 	defer func() {
 		t.Log("Uninstall the cockroachdb enterprise operator")
 		operator.UninstallCockroachDBEnterpriseOperator(t, kubectlOptions)
@@ -476,7 +495,7 @@ func (h *HelmChartToOperator) TestPCRPrimaryMigration(t *testing.T) {
 		k8s.RunKubectl(t, kubectlOptions, "delete", "priorityclass", "crdb-critical")
 	}()
 
-	operator.InstallCockroachDBEnterpriseOperator(t, kubectlOptions)
+	operator.InstallCockroachDBEnterpriseOperator(t, kubectlOptions, providerCloudRegion())
 	defer func() {
 		t.Log("Uninstall the cockroachdb enterprise operator")
 		operator.UninstallCockroachDBEnterpriseOperator(t, kubectlOptions)

--- a/tests/e2e/migrate/public_operator_to_cockroach_enterprise_operator_test.go
+++ b/tests/e2e/migrate/public_operator_to_cockroach_enterprise_operator_test.go
@@ -156,7 +156,7 @@ func (o *PublicOperatorToCockroachEnterpriseOperator) TestDefaultMigration(t *te
 	k8s.KubectlApply(t, kubectlOptions, filepath.Join(manifestsDirPath, "rbac.yaml"))
 
 	t.Log("Install the cockroachdb enterprise operator")
-	operator.InstallCockroachDBEnterpriseOperator(t, kubectlOptions)
+	operator.InstallCockroachDBEnterpriseOperator(t, kubectlOptions, providerCloudRegion())
 	defer func() {
 		t.Log("Uninstall the cockroachdb enterprise operator")
 		operator.UninstallCockroachDBEnterpriseOperator(t, kubectlOptions)

--- a/tests/e2e/operator/infra/aws.go
+++ b/tests/e2e/operator/infra/aws.go
@@ -1,0 +1,2901 @@
+// Package infra provides AWS infrastructure provisioning and management for e2e operator tests.
+// It handles EKS cluster creation, networking setup across multiple regions, and resource cleanup
+// using eksctl and the AWS SDK. The implementation supports multi-region testing with cross-region
+// connectivity via VPC peering between region-specific VPCs.
+package infra
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/go-logr/logr"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+)
+
+// ─── AWS CONSTANTS ───────────────────────────────────────────────────────────────
+
+const (
+	awsVPCName             = "cockroachdb-vpc"
+	awsWebhookSGName       = "allow-9443-port-for-webhook"
+	awsInternalSGName      = "allow-internal"
+	awsSubnetSuffix        = "subnet"
+	awsIGWSuffix           = "igw"
+	awsRouteTableSuffix    = "rtb"
+	awsDefaultInstanceType = "m5.xlarge"
+	awsDefaultDiskSize     = 30
+	awsDefaultNodesPerAZ   = 1
+	awsDefaultK8sVersion   = "1.35"
+
+	// EnvKubectlInsecureSkipTLSVerify is the environment variable name used to control
+	// whether TLS certificate verification should be skipped for kubectl and Kubernetes clients.
+	// Set to "true" to skip TLS verification (useful for corporate proxy environments).
+	EnvKubectlInsecureSkipTLSVerify = "KUBECTL_INSECURE_SKIP_TLS_VERIFY"
+)
+
+// ─── MULTI-REGION CONFIGURATION ─────────────────────────────────────────────────
+// Centralized configuration for multi-region testing
+// Modifies these constants to change regions/CIDRs across the entire test suite
+
+const (
+	// Primary region (matches GCP us-east1 geographically)
+	awsRegionPrimary  = "us-east-1" // Virginia
+	awsVPCCIDRPrimary = "172.28.112.0/24"
+	awsPodCIDRPrimary = "172.28.0.0/20"
+
+	// Secondary region (matches GCP us-central1 geographically)
+	awsRegionSecondary  = "us-east-2" // Ohio - closer to primary, lower latency
+	awsVPCCIDRSecondary = "172.28.144.0/24"
+	awsPodCIDRSecondary = "172.28.48.0/20"
+
+	// Optional tertiary region (matches GCP us-west1 geographically)
+	awsRegionTertiary  = "us-west-2" // Oregon
+	awsVPCCIDRTertiary = "172.28.176.0/24"
+	awsPodCIDRTertiary = "172.28.96.0/20"
+)
+
+// AWSClusterSetupConfig holds per-cluster network & EKS settings
+type AWSClusterSetupConfig struct {
+	Region            string
+	SubnetRanges      []string // One per AZ
+	SubnetIDs         []string // Populated by createVPCAndSubnets after subnet creation
+	ClusterName       string
+	AvailabilityZones []string // Populated by createVPCAndSubnets based on available AZs in a region
+}
+
+// Pre-defined configs for each region; index order matches r.Clusters
+// Uses centralized constants defined above for easy modification
+var awsClusterConfigurations = []AWSClusterSetupConfig{
+	{
+		Region:       awsRegionPrimary,
+		SubnetRanges: []string{"172.28.112.0/26", "172.28.112.64/26", "172.28.112.128/26"},
+		ClusterName:  "cockroachdb-east",
+	},
+	{
+		Region:       awsRegionSecondary,
+		SubnetRanges: []string{"172.28.144.0/26", "172.28.144.64/26", "172.28.144.128/26"},
+		ClusterName:  "cockroachdb-central",
+	},
+	{
+		Region:       awsRegionTertiary,
+		SubnetRanges: []string{"172.28.176.0/26", "172.28.176.64/26", "172.28.176.128/26"},
+		ClusterName:  "cockroachdb-west",
+	},
+}
+
+// kubeconfigMutex protects concurrent kubeconfig file updates to prevent corruption
+var kubeconfigMutex sync.Mutex
+
+// AwsRegion wraps operator.Region and manages AWS infrastructure for multi-region testing.
+// Tracks VPCs, security groups, route tables, and VPC peering connections across regions.
+type AwsRegion struct {
+	*operator.Region
+	vpcName               string
+	securityGroupIDs      map[string]string // Map of security group names to IDs
+	vpcPeeringConnections []string          // Tracked VPC peering connection IDs for cleanup
+	routeTableIDs         map[string]string // Map of region-to-route table ID (used for VPC peering routes)
+	clusterConfigs        []AWSClusterSetupConfig // Instance-level copy to avoid shared mutable state
+}
+
+// getResourceTags returns standard tags for AWS resources
+func (r *AwsRegion) getResourceTags(resourceName string) []*ec2.Tag {
+	return []*ec2.Tag{
+		{Key: aws.String("Name"), Value: aws.String(resourceName)},
+		{Key: aws.String("ManagedBy"), Value: aws.String("helm-charts-e2e")},
+		{Key: aws.String("TestRunID"), Value: aws.String(r.TestRunID)},
+	}
+}
+
+// SetUpInfra provisions complete AWS infrastructure for end-to-end testing.
+// Performs a 7-step setup process (~25-30 minutes total):
+// 1. Initialize AWS Sessions - Creates SDK sessions, EC2/EKS clients, logs TestRunID for concurrent test isolation
+// 2. Create VPC and Internet Gateways - VPC with region-specific CIDRs, IGW, tagged with ManagedBy=helm-charts-e2e and TestRunID
+// 3. Create Subnets and Route Tables - 3 subnets across AZs, route table with default route (0.0.0.0/0 → IGW)
+// 3b. Create Security Groups - Webhook SG (TCP 9443 from VPC), Internal SG (all traffic within VPC and from peer VPCs/Pods)
+// 4. Create VPC Peering - Mesh topology between regions, add VPC+Pod CIDR routes, update security groups for cross-region traffic
+// 5. Create EKS Clusters (PARALLEL) - eksctl creates CloudFormation stacks (control plane and node group), verifies TLS connectivity (~20 min parallel vs. 60 min serial)
+// 6. Deploy and Configure CoreDNS - Deploys ConfigMap/RBAC/Deployment, creates NLB service, updates cross-cluster DNS configuration
+//
+// If ReusingInfra is true, returns immediately without creating resources.
+// All resources are tagged with ManagedBy and TestRunID for cleanup and concurrent test isolation.
+func (r *AwsRegion) SetUpInfra(t *testing.T) {
+	if r.ReusingInfra {
+		t.Logf("[%s] Reusing existing infrastructure", ProviderAWS)
+		return
+	}
+
+	// Initialize instance-level cluster configs to avoid shared mutable state
+	r.clusterConfigs = make([]AWSClusterSetupConfig, len(awsClusterConfigurations))
+	copy(r.clusterConfigs, awsClusterConfigurations)
+
+	ctx := context.Background()
+
+	// 1) Create AWS sessions for each region
+	sessions := make(map[string]*session.Session)
+	ec2Clients := make(map[string]*ec2.EC2)
+	eksClients := make(map[string]*eks.EKS)
+
+	for i := range r.Clusters {
+		region := r.clusterConfigs[i].Region
+		if _, exists := sessions[region]; !exists {
+			sess, err := createAWSSession(region)
+			require.NoError(t, err, "failed to create AWS session for region %s", region)
+			sessions[region] = sess
+			ec2Clients[region] = ec2.New(sess)
+			eksClients[region] = eks.New(sess)
+		}
+	}
+
+	// 2) Create VPC in each region
+	r.vpcName = fmt.Sprintf("%s-%s", awsVPCName, strings.ToLower(random.UniqueId()))
+	r.securityGroupIDs = make(map[string]string)
+	r.routeTableIDs = make(map[string]string)
+	r.vpcPeeringConnections = make([]string, 0)
+
+	// Log the test run ID for troubleshooting
+	t.Logf("[%s] Using Test Run ID: %s (for concurrent test isolation)", ProviderAWS, r.TestRunID)
+
+	vpcIDs := make(map[string]string)
+	igwIDs := make(map[string]string)
+
+	for region, ec2Client := range ec2Clients {
+		vpcID, err := r.createVPC(ctx, t, ec2Client, region)
+		require.NoError(t, err, "failed to create VPC in region %s", region)
+		vpcIDs[region] = vpcID
+
+		// Create Internet Gateway for public access
+		igwID, err := r.createInternetGateway(ctx, t, ec2Client, vpcID, region)
+		require.NoError(t, err, "failed to create Internet Gateway in region %s", region)
+		igwIDs[region] = igwID
+	}
+
+	// 3) Create subnets in each region
+	for i, clusterName := range r.Clusters {
+		setup := &r.clusterConfigs[i]
+		setup.ClusterName = clusterName
+		region := setup.Region
+		ec2Client := ec2Clients[region]
+		vpcID := vpcIDs[region]
+
+		// Discover availability zones
+		azs, err := r.discoverAvailabilityZones(ctx, ec2Client, region)
+		require.NoError(t, err, "failed to discover AZs in region %s", region)
+
+		// Use first 3 AZs
+		if len(azs) > 3 {
+			azs = azs[:3]
+		}
+		setup.AvailabilityZones = azs
+
+		// Create subnets
+		subnetIDs, err := r.createSubnets(ctx, t, ec2Client, vpcID, setup)
+		require.NoError(t, err, "failed to create subnets in region %s", region)
+		setup.SubnetIDs = subnetIDs
+
+		// Create a route table and associate with subnets
+		err = r.createRouteTable(ctx, t, ec2Client, vpcID, igwIDs[region], subnetIDs, region)
+		require.NoError(t, err, "failed to create route table in region %s", region)
+	}
+
+	// 3b) Create security groups BEFORE VPC peering (peering setup updates SG rules for cross-region traffic)
+	for region, ec2Client := range ec2Clients {
+		vpcID := vpcIDs[region]
+		err := r.createSecurityGroups(ctx, t, ec2Client, vpcID, region)
+		require.NoError(t, err, "failed to create security groups in region %s", region)
+	}
+
+	// 4) Create VPC Peering Connections between regions (enables cross-region pod communication).
+	// This must happen AFTER route tables and security groups are created, so routes and SG rules can be added.
+	// Creates a mesh topology where all VPCs can communicate with each other.
+	// Similar to GCP's single global VPC model.
+	err := r.createVPCPeeringConnections(ctx, t, ec2Clients, vpcIDs)
+	require.NoError(t, err, "failed to create VPC peering connections")
+
+	// 5) Create EKS clusters in parallel
+	err = r.createEKSClusters(ctx, t, eksClients)
+	require.NoError(t, err, "failed to create EKS clusters")
+	r.ReusingInfra = true
+
+	// 6) Deploy CoreDNS with initial configuration, then update with complete cross-cluster info
+	kubeConfigPath, err := r.EnsureKubeConfigPath()
+	require.NoError(t, err)
+	err = r.deployAndConfigureCoreDNS(t, kubeConfigPath)
+	require.NoError(t, err, "failed to deploy and configure CoreDNS")
+}
+
+// TeardownInfra deletes all AWS resources created by SetUpInfra in reverse dependency order.
+//
+// Performs a cleanup process with retry logic (~8-10 minutes total):
+//
+// 1. Delete EKS Clusters (PARALLEL) - eksctl delete cluster --force --wait, deletes CloudFormation stacks (~10 min parallel)
+// 1b. Delete IAM Roles - Detaches policies and deletes IAM roles created for EBS CSI driver
+// 2. Wait 120 Seconds + Delete Cluster Resources (PARALLEL) - Waits for resource release, then deletes Load Balancers, NAT Gateways, ENIs, Elastic IPs, VPC Endpoints concurrently
+// 3. Revoke Security Group Rules - Revokes all ingress/egress rules including self-referencing to break circular dependencies
+// 4. Delete Security Groups (3 retries, 30s delay) - Handles AWS eventual consistency, retries if resources are still attached (up to 90s)
+// 5. Delete Subnets and Route Tables (3 retries, 30s delay) - Disassociates and deletes, retries for ENI detachment (up to 90s)
+// 6. Delete Internet Gateways - Detaches from VPCs and deletes, queries by ManagedBy and TestRunID tags
+// 6b. Delete VPC Peering Connections - Deletes tracked peering connections and searches by TestRunID tag (must be before VPC deletion)
+// 7. Delete VPCs (3 retries, 20s delay) - Final cleanup, retries for dependency clearing (up to 60s)
+//
+// Error Handling: All steps wrapped in safeExecute() which catches panics, logs errors, and continues cleanup.
+// Retry Strategy: Security groups (3×30s), Subnets/route tables (3×30s), VPCs (3×20s) to handle AWS eventual consistency.
+// Concurrent Test Isolation: All resource queries filter by TestRunID to delete only current test's resources.
+// Designed to be called via t.Cleanup() for guaranteed execution even on test failure, timeout, or panic.
+func (r *AwsRegion) TeardownInfra(t *testing.T) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			t.Logf("[%s] Panic during teardown (continuing cleanup): %v", ProviderAWS, rec)
+		}
+	}()
+
+	t.Logf("[%s] Starting infrastructure teardown", ProviderAWS)
+
+	// Initialize instance-level cluster configs if not already set
+	if r.clusterConfigs == nil {
+		r.clusterConfigs = make([]AWSClusterSetupConfig, len(awsClusterConfigurations))
+		copy(r.clusterConfigs, awsClusterConfigurations)
+	}
+
+	ctx := context.Background()
+
+	// Create AWS sessions for each region
+	sessions := make(map[string]*session.Session)
+	ec2Clients := make(map[string]*ec2.EC2)
+	eksClients := make(map[string]*eks.EKS)
+
+	for i := range r.Clusters {
+		region := r.clusterConfigs[i].Region
+		if _, exists := sessions[region]; !exists {
+			sess, err := createAWSSession(region)
+			if err != nil {
+				t.Logf("[%s] Warning: failed to create AWS session for region %s: %v", ProviderAWS, region, err)
+				continue
+			}
+			sessions[region] = sess
+			ec2Clients[region] = ec2.New(sess)
+			eksClients[region] = eks.New(sess)
+		}
+	}
+
+	safeExecute := func(stepName string, fn func() error) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				t.Logf("[%s] Panic during %s (continuing teardown): %v", ProviderAWS, stepName, rec)
+			}
+		}()
+
+		if err := fn(); err != nil {
+			t.Logf("[%s] Warning: %s failed: %v", ProviderAWS, stepName, err)
+		}
+	}
+
+	// 1) Delete EKS clusters
+	//    - Deletes EBS CSI driver addons first (prevents orphaned addon resources)
+	//    - Then deletes clusters via eksctl (handles nodegroups, CloudFormation stacks)
+	safeExecute("EKS cluster deletion", func() error {
+		return r.deleteEKSClusters(ctx, t)
+	})
+
+	// 1b) Delete IAM roles and OIDC providers
+	//     - Deletes IAM roles created for EBS CSI driver
+	//     - Deletes OIDC identity providers (persist after cluster deletion, accumulate over time)
+	safeExecute("IAM role deletion", func() error {
+		return r.deleteIAMRoles(t)
+	})
+
+	// Wait for cluster resources to be fully released
+	// Cluster deletion is async - ENIs, load balancers, etc. take time to clean up
+	t.Logf("[%s] Waiting for cluster resources to be released (this may take 2-3 minutes)...", ProviderAWS)
+	time.Sleep(120 * time.Second)
+
+	// 2) Delete cluster-related resources in parallel (Load Balancers, NAT Gateways, ENIs, Elastic IPs, VPC Endpoints)
+	safeExecute("cluster resource cleanup", func() error {
+		return r.deleteClusterResources(ctx, t, ec2Clients)
+	})
+
+	// 3) Revoke Security Group rules (self-referencing rules block deletion)
+	safeExecute("Security Group rule revocation", func() error {
+		return retryWithBackoff(t, "security group rules", 3, 30*time.Second, func() error {
+			return r.revokeSecurityGroupRules(ctx, t, ec2Clients)
+		})
+	})
+
+	// 4) Delete security groups (retry for AWS eventual consistency)
+	safeExecute("security group deletion", func() error {
+		return retryWithBackoff(t, "security group", 3, 30*time.Second, func() error {
+			return r.deleteSecurityGroups(ctx, t, ec2Clients)
+		})
+	})
+
+	// 5) Delete route tables and subnets (retry for ENI detachment)
+	safeExecute("route table and subnet deletion", func() error {
+		return retryWithBackoff(t, "subnet", 3, 30*time.Second, func() error {
+			return r.deleteSubnetsAndRouteTables(ctx, t, ec2Clients)
+		})
+	})
+
+	// 6) Delete Internet Gateways
+	safeExecute("Internet Gateway deletion", func() error {
+		return r.deleteInternetGateways(ctx, t, ec2Clients)
+	})
+
+	// 6b) Delete VPC Peering Connections (must be before VPC deletion)
+	safeExecute("VPC peering deletion", func() error {
+		return r.deleteVPCPeeringConnections(ctx, t, ec2Clients)
+	})
+
+	// 7) Delete VPCs (retry for dependency cleanup)
+	safeExecute("VPC deletion", func() error {
+		return retryWithBackoff(t, "VPC", 3, 20*time.Second, func() error {
+			err := r.deleteVPCs(ctx, t, ec2Clients)
+			if err != nil {
+				t.Logf("[%s] VPC deletion failed, will retry if attempts remain", ProviderAWS)
+			}
+			return err
+		})
+	})
+
+	t.Logf("[%s] Infrastructure teardown completed", ProviderAWS)
+}
+
+// ScaleNodePool scales the node pool for an EKS cluster
+func (r *AwsRegion) ScaleNodePool(t *testing.T, region string, nodeCount, index int) {
+	if index >= len(r.Clusters) {
+		t.Fatalf("[%s] Invalid cluster index %d, only have %d clusters", ProviderAWS, index, len(r.Clusters))
+	}
+
+	clusterName := r.Clusters[index]
+	nodegroupName := fmt.Sprintf("%s-nodegroup", clusterName)
+
+	t.Logf("[%s] Scaling node pool '%s' in cluster '%s' (region: %s) to %d nodes",
+		ProviderAWS, nodegroupName, clusterName, region, nodeCount)
+
+	// Scale the nodegroup using eksctl
+	// Also update max nodes to allow scaling beyond the initial maximum
+	cmd := exec.Command("eksctl", "scale", "nodegroup",
+		"--cluster", clusterName,
+		"--name", nodegroupName,
+		"--nodes", fmt.Sprint(nodeCount),
+		"--nodes-max", fmt.Sprint(nodeCount+1), // Allow future scaling
+		"--region", region,
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("[%s] Failed to scale nodegroup: %v\nOutput: %s", ProviderAWS, err, string(output))
+	}
+
+	t.Logf("[%s] Successfully scaled nodegroup. Output: %s", ProviderAWS, string(output))
+
+	// Wait for nodes to become ready
+	t.Logf("[%s] Waiting for nodes to become ready...", ProviderAWS)
+	maxRetries := 30
+	retryInterval := 10 * time.Second
+
+	for i := 0; i < maxRetries; i++ {
+		// Get kubeconfig and check node count
+		kubeconfigCmd := exec.Command("kubectl", "get", "nodes", "--context", clusterName, "--no-headers")
+		output, err := kubeconfigCmd.CombinedOutput()
+		if err != nil {
+			t.Logf("[%s] Retry %d/%d: Error checking nodes: %v", ProviderAWS, i+1, maxRetries, err)
+			time.Sleep(retryInterval)
+			continue
+		}
+
+		// Count ready nodes
+		lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+		readyCount := 0
+		for _, line := range lines {
+			if strings.Contains(line, "Ready") && !strings.Contains(line, "NotReady") {
+				readyCount++
+			}
+		}
+
+		t.Logf("[%s] Ready nodes: %d/%d", ProviderAWS, readyCount, nodeCount)
+
+		if readyCount >= nodeCount {
+			t.Logf("[%s] All %d nodes are ready", ProviderAWS, nodeCount)
+			return
+		}
+
+		time.Sleep(retryInterval)
+	}
+
+	t.Fatalf("[%s] Timed out waiting for nodes to become ready after scaling", ProviderAWS)
+}
+
+func (r *AwsRegion) CanScale() bool {
+	return true
+}
+
+// ─── AWS CLIENT CREATORS ────────────────────────────────────────────────────────
+
+func createAWSSession(region string) (*session.Session, error) {
+	return session.NewSession(&aws.Config{
+		Region: aws.String(region),
+	})
+}
+
+// ─── RESOURCE CREATION ──────────────────────────────────────────────────────────
+
+func (r *AwsRegion) createVPC(
+	ctx context.Context, t *testing.T, client *ec2.EC2, region string,
+) (string, error) {
+	vpcName := fmt.Sprintf("%s-%s", r.vpcName, region)
+
+	// Get region-specific VPC CIDR to avoid overlaps (required for VPC peering)
+	vpcCIDR := r.getVPCCIDR(region)
+
+	// Create VPC
+	createVpcOutput, err := client.CreateVpcWithContext(ctx, &ec2.CreateVpcInput{
+		CidrBlock: aws.String(vpcCIDR),
+		TagSpecifications: []*ec2.TagSpecification{
+			{
+				ResourceType: aws.String("vpc"),
+				Tags:         r.getResourceTags(vpcName),
+			},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	vpcID := *createVpcOutput.Vpc.VpcId
+	t.Logf("[%s] Created VPC %s in region %s", ProviderAWS, vpcID, region)
+
+	// Enable DNS support (required for VPC peering)
+	_, err = client.ModifyVpcAttributeWithContext(ctx, &ec2.ModifyVpcAttributeInput{
+		VpcId:            aws.String(vpcID),
+		EnableDnsSupport: &ec2.AttributeBooleanValue{Value: aws.Bool(true)},
+	})
+	if err != nil {
+		t.Logf("[%s] Warning: failed to enable DNS support for VPC %s: %v", ProviderAWS, vpcID, err)
+	}
+
+	// Enable DNS hostnames (required for VPC peering)
+	_, err = client.ModifyVpcAttributeWithContext(ctx, &ec2.ModifyVpcAttributeInput{
+		VpcId:              aws.String(vpcID),
+		EnableDnsHostnames: &ec2.AttributeBooleanValue{Value: aws.Bool(true)},
+	})
+	if err != nil {
+		t.Logf("[%s] Warning: failed to enable DNS hostnames for VPC %s: %v", ProviderAWS, vpcID, err)
+	}
+
+	return vpcID, nil
+}
+
+func (r *AwsRegion) createInternetGateway(
+	ctx context.Context, t *testing.T, client *ec2.EC2, vpcID, region string,
+) (string, error) {
+	igwName := fmt.Sprintf("%s-%s-%s", r.vpcName, awsIGWSuffix, region)
+
+	createIgwOutput, err := client.CreateInternetGatewayWithContext(ctx, &ec2.CreateInternetGatewayInput{
+		TagSpecifications: []*ec2.TagSpecification{
+			{
+				ResourceType: aws.String("internet-gateway"),
+				Tags:         r.getResourceTags(igwName),
+			},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	igwID := *createIgwOutput.InternetGateway.InternetGatewayId
+	t.Logf("[%s] Created Internet Gateway %s in region %s", ProviderAWS, igwID, region)
+
+	// Attach to VPC
+	_, err = client.AttachInternetGatewayWithContext(ctx, &ec2.AttachInternetGatewayInput{
+		InternetGatewayId: aws.String(igwID),
+		VpcId:             aws.String(vpcID),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return igwID, nil
+}
+
+func (r *AwsRegion) discoverAvailabilityZones(
+	ctx context.Context, client *ec2.EC2, region string,
+) ([]string, error) {
+	output, err := client.DescribeAvailabilityZonesWithContext(ctx, &ec2.DescribeAvailabilityZonesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("region-name"),
+				Values: []*string{aws.String(region)},
+			},
+			{
+				Name:   aws.String("state"),
+				Values: []*string{aws.String("available")},
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var azs []string
+	for _, az := range output.AvailabilityZones {
+		azs = append(azs, *az.ZoneName)
+	}
+
+	return azs, nil
+}
+
+func (r *AwsRegion) createSubnets(
+	ctx context.Context, t *testing.T, client *ec2.EC2, vpcID string, setup *AWSClusterSetupConfig,
+) ([]string, error) {
+	var subnetIDs []string
+
+	for i, az := range setup.AvailabilityZones {
+		if i >= len(setup.SubnetRanges) {
+			break
+		}
+
+		subnetName := fmt.Sprintf("%s-%s-%s", setup.ClusterName, awsSubnetSuffix, az)
+		tags := r.getResourceTags(subnetName)
+		tags = append(tags, &ec2.Tag{
+			Key:   aws.String(fmt.Sprintf("kubernetes.io/cluster/%s", setup.ClusterName)),
+			Value: aws.String("shared"),
+		})
+		createSubnetOutput, err := client.CreateSubnetWithContext(ctx, &ec2.CreateSubnetInput{
+			VpcId:            aws.String(vpcID),
+			CidrBlock:        aws.String(setup.SubnetRanges[i]),
+			AvailabilityZone: aws.String(az),
+			TagSpecifications: []*ec2.TagSpecification{
+				{
+					ResourceType: aws.String("subnet"),
+					Tags:         tags,
+				},
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		subnetID := *createSubnetOutput.Subnet.SubnetId
+		subnetIDs = append(subnetIDs, subnetID)
+		t.Logf("[%s] Created subnet %s in AZ %s", ProviderAWS, subnetID, az)
+
+		// Enable auto-assign public IP
+		_, err = client.ModifySubnetAttributeWithContext(ctx, &ec2.ModifySubnetAttributeInput{
+			SubnetId:            aws.String(subnetID),
+			MapPublicIpOnLaunch: &ec2.AttributeBooleanValue{Value: aws.Bool(true)},
+		})
+		if err != nil {
+			t.Logf("[%s] Warning: failed to enable auto-assign public IP for subnet %s: %v", ProviderAWS, subnetID, err)
+		}
+	}
+
+	return subnetIDs, nil
+}
+
+func (r *AwsRegion) createRouteTable(
+	ctx context.Context,
+	t *testing.T,
+	client *ec2.EC2,
+	vpcID, igwID string,
+	subnetIDs []string,
+	region string,
+) error {
+	rtbName := fmt.Sprintf("%s-%s-%s", r.vpcName, awsRouteTableSuffix, region)
+
+	createRtbOutput, err := client.CreateRouteTableWithContext(ctx, &ec2.CreateRouteTableInput{
+		VpcId: aws.String(vpcID),
+		TagSpecifications: []*ec2.TagSpecification{
+			{
+				ResourceType: aws.String("route-table"),
+				Tags:         r.getResourceTags(rtbName),
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	rtbID := *createRtbOutput.RouteTable.RouteTableId
+	t.Logf("[%s] Created route table %s in region %s", ProviderAWS, rtbID, region)
+
+	// Store route table ID for later use (VPC peering routes)
+	r.routeTableIDs[region] = rtbID
+
+	// Create a route to Internet Gateway
+	_, err = client.CreateRouteWithContext(ctx, &ec2.CreateRouteInput{
+		RouteTableId:         aws.String(rtbID),
+		DestinationCidrBlock: aws.String("0.0.0.0/0"),
+		GatewayId:            aws.String(igwID),
+	})
+	if err != nil {
+		return err
+	}
+
+	// Associate route table with subnets
+	for _, subnetID := range subnetIDs {
+		_, err = client.AssociateRouteTableWithContext(ctx, &ec2.AssociateRouteTableInput{
+			RouteTableId: aws.String(rtbID),
+			SubnetId:     aws.String(subnetID),
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *AwsRegion) createSecurityGroups(
+	ctx context.Context, t *testing.T, client *ec2.EC2, vpcID, region string,
+) error {
+	// Create a webhook security group (port 9443)
+	webhookSGName := fmt.Sprintf("%s-%s-%s", r.vpcName, awsWebhookSGName, region)
+	webhookSG, err := client.CreateSecurityGroupWithContext(ctx, &ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String(webhookSGName),
+		Description: aws.String("Allow port 9443 for webhook"),
+		VpcId:       aws.String(vpcID),
+		TagSpecifications: []*ec2.TagSpecification{
+			{
+				ResourceType: aws.String("security-group"),
+				Tags:         r.getResourceTags(webhookSGName),
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	webhookSGID := *webhookSG.GroupId
+	r.securityGroupIDs[webhookSGName] = webhookSGID
+	t.Logf("[%s] Created security group %s for webhook", ProviderAWS, webhookSGID)
+
+	// Add ingress rule for port 9443
+	_, err = client.AuthorizeSecurityGroupIngressWithContext(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId: aws.String(webhookSGID),
+		IpPermissions: []*ec2.IpPermission{
+			{
+				IpProtocol: aws.String("tcp"),
+				FromPort:   aws.Int64(9443),
+				ToPort:     aws.Int64(9443),
+				IpRanges:   []*ec2.IpRange{{CidrIp: aws.String(DefaultVPCCIDR)}},
+			},
+		},
+	})
+	if err != nil {
+		t.Logf("[%s] Warning: failed to add ingress rule to webhook security group: %v", ProviderAWS, err)
+	}
+
+	// Create an internal security group (all traffic within VPC)
+	internalSGName := fmt.Sprintf("%s-%s-%s", r.vpcName, awsInternalSGName, region)
+	internalSG, err := client.CreateSecurityGroupWithContext(ctx, &ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String(internalSGName),
+		Description: aws.String("Allow all internal traffic"),
+		VpcId:       aws.String(vpcID),
+		TagSpecifications: []*ec2.TagSpecification{
+			{
+				ResourceType: aws.String("security-group"),
+				Tags:         r.getResourceTags(internalSGName),
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	internalSGID := *internalSG.GroupId
+	r.securityGroupIDs[internalSGName] = internalSGID
+	t.Logf("[%s] Created security group %s for internal traffic", ProviderAWS, internalSGID)
+
+	// Add ingress rules for internal traffic
+	_, err = client.AuthorizeSecurityGroupIngressWithContext(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId: aws.String(internalSGID),
+		IpPermissions: []*ec2.IpPermission{
+			{
+				IpProtocol: aws.String("-1"), // All protocols
+				IpRanges:   []*ec2.IpRange{{CidrIp: aws.String(DefaultVPCCIDR)}},
+			},
+		},
+	})
+	if err != nil {
+		t.Logf("[%s] Warning: failed to add ingress rule to internal security group: %v", ProviderAWS, err)
+	}
+
+	return nil
+}
+
+// createVPCPeeringConnections creates VPC peering connections between all regions in a mesh topology.
+// For each pair of regions, it:
+// 1. Creates the peering connection from requester region
+// 2. Accepts the connection in acceptor region
+// 3. Waits for a connection to become active
+// 4. Adds routes for both VPC CIDRs and Pod CIDRs through peering connection
+// 5. Updates security groups to allow traffic from peer VPC and Pod CIDRs
+//
+// This enables cross-region pod communication, similar to GCP's single global VPC model.
+// Requires route tables to be created before calling (uses r.routeTableIDs).
+func (r *AwsRegion) createVPCPeeringConnections(
+	ctx context.Context, t *testing.T, ec2Clients map[string]*ec2.EC2, vpcIDs map[string]string,
+) error {
+	// Get all unique regions
+	regions := make([]string, 0, len(vpcIDs))
+	for region := range vpcIDs {
+		regions = append(regions, region)
+	}
+
+	// Create peering connections in a mesh topology
+	// For 2 regions: A <-> B
+	// For 3 regions: A <-> B, A <-> C, B <-> C
+	for i := 0; i < len(regions); i++ {
+		for j := i + 1; j < len(regions); j++ {
+			regionA := regions[i]
+			regionB := regions[j]
+			vpcA := vpcIDs[regionA]
+			vpcB := vpcIDs[regionB]
+
+			// Create a peering connection from region A to region B
+			peeringConnID, err := r.createVPCPeeringConnection(ctx, t, ec2Clients[regionA], vpcA, vpcB, regionA, regionB)
+			if err != nil {
+				return fmt.Errorf("failed to create VPC peering between %s and %s: %w", regionA, regionB, err)
+			}
+			r.vpcPeeringConnections = append(r.vpcPeeringConnections, peeringConnID)
+
+			// Give AWS a moment to establish the peering connection before accepting
+			time.Sleep(5 * time.Second)
+
+			// Accept the peering connection in region B
+			err = r.acceptVPCPeeringConnection(ctx, t, ec2Clients[regionB], peeringConnID, regionB)
+			if err != nil {
+				return fmt.Errorf("failed to accept VPC peering in %s: %w", regionB, err)
+			}
+
+			// Wait for the peering connection to be active
+			err = r.waitForVPCPeeringActive(ctx, t, ec2Clients[regionA], peeringConnID)
+			if err != nil {
+				return fmt.Errorf("failed waiting for VPC peering to be active: %w", err)
+			}
+
+			// Update route tables in both regions to route through the peering connection
+			err = r.addPeeringRoutes(ctx, t, ec2Clients, peeringConnID, regionA, regionB)
+			if err != nil {
+				return fmt.Errorf("failed to add peering routes: %w", err)
+			}
+
+			// Update security groups to allow cross-VPC traffic
+			err = r.updateSecurityGroupsForPeering(ctx, t, ec2Clients, regionA, regionB)
+			if err != nil {
+				return fmt.Errorf("failed to update security groups for peering: %w", err)
+			}
+
+			t.Logf("[%s] Successfully established VPC peering between %s and %s (connection: %s)",
+				ProviderAWS, regionA, regionB, peeringConnID)
+		}
+	}
+
+	return nil
+}
+
+// getAWSAccountID retrieves the current AWS account ID using STS GetCallerIdentity.
+// Required for cross-region VPC peering within the same account - PeerOwnerId must be specified.
+// Uses the primary region for the STS call (STS is a global service).
+func getAWSAccountID(ctx context.Context) (string, error) {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(awsRegionPrimary), // STS is global, use any valid region
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create AWS session: %w", err)
+	}
+
+	stsClient := sts.New(sess)
+	result, err := stsClient.GetCallerIdentityWithContext(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get caller identity: %w", err)
+	}
+
+	return aws.StringValue(result.Account), nil
+}
+
+// createVPCPeeringConnection creates a VPC peering connection from regionA to regionB.
+// The connection is created in the requester region (regionA) and must be accepted
+// in the acceptor region (regionB) before it becomes active.
+// Requires PeerOwnerId for cross-region peering within the same AWS account.
+func (r *AwsRegion) createVPCPeeringConnection(
+	ctx context.Context, t *testing.T, client *ec2.EC2, vpcA, vpcB, regionA, regionB string,
+) (string, error) {
+	peeringName := fmt.Sprintf("%s-peering-%s-%s", r.vpcName, regionA, regionB)
+
+	// Get AWS account ID for cross-region peering
+	accountID, err := getAWSAccountID(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get AWS account ID: %w", err)
+	}
+
+	output, err := client.CreateVpcPeeringConnectionWithContext(ctx, &ec2.CreateVpcPeeringConnectionInput{
+		VpcId:       aws.String(vpcA),
+		PeerVpcId:   aws.String(vpcB),
+		PeerRegion:  aws.String(regionB),
+		PeerOwnerId: aws.String(accountID), // Required for cross-region peering
+		TagSpecifications: []*ec2.TagSpecification{
+			{
+				ResourceType: aws.String("vpc-peering-connection"),
+				Tags:         r.getResourceTags(peeringName),
+			},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	peeringConnID := *output.VpcPeeringConnection.VpcPeeringConnectionId
+
+	// Check the initial status of the peering connection
+	if output.VpcPeeringConnection.Status != nil {
+		statusCode := aws.StringValue(output.VpcPeeringConnection.Status.Code)
+		statusMsg := aws.StringValue(output.VpcPeeringConnection.Status.Message)
+
+		t.Logf("[%s] Created VPC peering connection %s from %s to %s (status: %s)", ProviderAWS, peeringConnID, regionA, regionB, statusCode)
+
+		if statusMsg != "" {
+			t.Logf("[%s] VPC peering status message: %s", ProviderAWS, statusMsg)
+		}
+
+		// If the peering connection immediately failed, return the error with details
+		if statusCode == "failed" || statusCode == "rejected" {
+			return "", fmt.Errorf("VPC peering connection failed immediately with status %s: %s", statusCode, statusMsg)
+		}
+	} else {
+		t.Logf("[%s] Created VPC peering connection %s from %s to %s", ProviderAWS, peeringConnID, regionA, regionB)
+	}
+
+	return peeringConnID, nil
+}
+
+// acceptVPCPeeringConnection accepts a VPC peering connection request in the acceptor region.
+// Retries for up to 2 minutes to handle propagation delays - cross-region peering connections
+// take time to become visible in the acceptor region after being created in the requester region.
+func (r *AwsRegion) acceptVPCPeeringConnection(
+	ctx context.Context, t *testing.T, client *ec2.EC2, peeringConnID, region string,
+) error {
+	// Retry accepting the peering connection as it may take time to propagate to the acceptor region
+	var lastErr error
+	for i := 0; i < 12; i++ { // Retry for up to 2 minutes
+		_, err := client.AcceptVpcPeeringConnectionWithContext(ctx, &ec2.AcceptVpcPeeringConnectionInput{
+			VpcPeeringConnectionId: aws.String(peeringConnID),
+		})
+		if err == nil {
+			t.Logf("[%s] Accepted VPC peering connection %s in region %s", ProviderAWS, peeringConnID, region)
+			return nil
+		}
+
+		lastErr = err
+		// If the peering connection is not found, wait and retry
+		if strings.Contains(err.Error(), "InvalidVpcPeeringConnectionID.NotFound") {
+			if i == 0 {
+				t.Logf("[%s] VPC peering connection %s not yet visible in %s, waiting for propagation...", ProviderAWS, peeringConnID, region)
+			}
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		// For other errors, fail immediately
+		return err
+	}
+
+	return fmt.Errorf("failed to accept VPC peering connection after retries: %w", lastErr)
+}
+
+// waitForVPCPeeringActive waits for a VPC peering connection to reach active status.
+// After acceptance, the peering connection transitions through the provisioning state before
+// becoming active. Waits up to 5 minutes, polling every 10 seconds.
+func (r *AwsRegion) waitForVPCPeeringActive(
+	ctx context.Context, t *testing.T, client *ec2.EC2, peeringConnID string,
+) error {
+	t.Logf("[%s] Waiting for VPC peering connection %s to become active...", ProviderAWS, peeringConnID)
+
+	for i := 0; i < 30; i++ { // Wait up to 5 minutes
+		output, err := client.DescribeVpcPeeringConnectionsWithContext(ctx, &ec2.DescribeVpcPeeringConnectionsInput{
+			VpcPeeringConnectionIds: []*string{aws.String(peeringConnID)},
+		})
+		if err != nil {
+			return err
+		}
+
+		if len(output.VpcPeeringConnections) == 0 {
+			return fmt.Errorf("VPC peering connection %s not found", peeringConnID)
+		}
+
+		status := *output.VpcPeeringConnections[0].Status.Code
+		if status == "active" {
+			t.Logf("[%s] VPC peering connection %s is now active", ProviderAWS, peeringConnID)
+			return nil
+		}
+
+		if status == "failed" || status == "rejected" || status == "deleted" {
+			return fmt.Errorf("VPC peering connection %s failed with status: %s", peeringConnID, status)
+		}
+
+		time.Sleep(10 * time.Second)
+	}
+
+	return fmt.Errorf("timeout waiting for VPC peering connection %s to become active", peeringConnID)
+}
+
+// addPeeringRoutes adds routes to route tables for VPC peering between two regions.
+// For each region, it adds two routes through the peering connection:
+// 1. Route to peer VPC CIDR (e.g., 172.28.144.0/24) - for VPC infrastructure
+// 2. Route to peer Pod CIDR (e.g., 172.28.48.0/20) - for cross-region pod communication
+//
+// Without Pod CIDR routes, pods in different regions cannot communicate even though
+// VPC peering is active, causing CockroachDB cluster formation to fail.
+//
+// Requires r.routeTableIDs to be populated before calling.
+func (r *AwsRegion) addPeeringRoutes(
+	ctx context.Context,
+	t *testing.T,
+	ec2Clients map[string]*ec2.EC2,
+	peeringConnID, regionA, regionB string,
+) error {
+	// Get VPC CIDRs and Pod CIDRs for routing
+	vpcCIDRA := r.getVPCCIDR(regionA)
+	vpcCIDRB := r.getVPCCIDR(regionB)
+	podCIDRA := r.getPodCIDR(regionA)
+	podCIDRB := r.getPodCIDR(regionB)
+
+	routeTableA := r.routeTableIDs[regionA]
+	routeTableB := r.routeTableIDs[regionB]
+
+	// Add routes in region A to reach region B's VPC and Pods
+	if routeTableA != "" {
+		// Route for VPC CIDR
+		_, err := ec2Clients[regionA].CreateRouteWithContext(ctx, &ec2.CreateRouteInput{
+			RouteTableId:           aws.String(routeTableA),
+			DestinationCidrBlock:   aws.String(vpcCIDRB),
+			VpcPeeringConnectionId: aws.String(peeringConnID),
+		})
+		if err != nil && !strings.Contains(err.Error(), "already exists") {
+			return fmt.Errorf("failed to add VPC route in %s: %w", regionA, err)
+		}
+		t.Logf("[%s] Added VPC route in %s: %s -> %s via %s", ProviderAWS, regionA, vpcCIDRB, regionB, peeringConnID)
+
+		// Route for Pod CIDR (critical for cross-region pod communication)
+		_, err = ec2Clients[regionA].CreateRouteWithContext(ctx, &ec2.CreateRouteInput{
+			RouteTableId:           aws.String(routeTableA),
+			DestinationCidrBlock:   aws.String(podCIDRB),
+			VpcPeeringConnectionId: aws.String(peeringConnID),
+		})
+		if err != nil && !strings.Contains(err.Error(), "already exists") {
+			return fmt.Errorf("failed to add Pod route in %s: %w", regionA, err)
+		}
+		t.Logf("[%s] Added Pod route in %s: %s -> %s via %s", ProviderAWS, regionA, podCIDRB, regionB, peeringConnID)
+	}
+
+	// Add routes in region B to reach region A's VPC and Pods
+	if routeTableB != "" {
+		// Route for VPC CIDR
+		_, err := ec2Clients[regionB].CreateRouteWithContext(ctx, &ec2.CreateRouteInput{
+			RouteTableId:           aws.String(routeTableB),
+			DestinationCidrBlock:   aws.String(vpcCIDRA),
+			VpcPeeringConnectionId: aws.String(peeringConnID),
+		})
+		if err != nil && !strings.Contains(err.Error(), "already exists") {
+			return fmt.Errorf("failed to add VPC route in %s: %w", regionB, err)
+		}
+		t.Logf("[%s] Added VPC route in %s: %s -> %s via %s", ProviderAWS, regionB, vpcCIDRA, regionA, peeringConnID)
+
+		// Route for Pod CIDR (critical for cross-region pod communication)
+		_, err = ec2Clients[regionB].CreateRouteWithContext(ctx, &ec2.CreateRouteInput{
+			RouteTableId:           aws.String(routeTableB),
+			DestinationCidrBlock:   aws.String(podCIDRA),
+			VpcPeeringConnectionId: aws.String(peeringConnID),
+		})
+		if err != nil && !strings.Contains(err.Error(), "already exists") {
+			return fmt.Errorf("failed to add Pod route in %s: %w", regionB, err)
+		}
+		t.Logf("[%s] Added Pod route in %s: %s -> %s via %s", ProviderAWS, regionB, podCIDRA, regionA, peeringConnID)
+	}
+
+	return nil
+}
+
+// getVPCCIDR returns the VPC CIDR block for a given region.
+// Each region has a unique non-overlapping VPC CIDR to enable VPC peering.
+// Returns region-specific CIDR from centralized constants (e.g., 172.28.112.0/24 for us-east-1).
+func (r *AwsRegion) getVPCCIDR(region string) string {
+	switch region {
+	case awsRegionPrimary:
+		return awsVPCCIDRPrimary
+	case awsRegionSecondary:
+		return awsVPCCIDRSecondary
+	case awsRegionTertiary:
+		return awsVPCCIDRTertiary
+	default:
+		return "172.28.0.0/16" // Fallback
+	}
+}
+
+// updateSecurityGroupsForPeering updates security groups to allow traffic from peered VPCs.
+// For each region's security groups, it adds ingress rules to allow all traffic from:
+// 1. Peer VPC CIDR (e.g., 172.28.144.0/24) - for VPC infrastructure traffic
+// 2. Peer Pod CIDR (e.g., 172.28.48.0/20) - for cross-region pod-to-pod communication
+//
+// This is required in addition to VPC peering routes to allow CockroachDB pods
+// in different regions to communicate with each other.
+func (r *AwsRegion) updateSecurityGroupsForPeering(
+	ctx context.Context, t *testing.T, ec2Clients map[string]*ec2.EC2, regionA, regionB string,
+) error {
+	vpcCIDRA := r.getVPCCIDR(regionA)
+	vpcCIDRB := r.getVPCCIDR(regionB)
+
+	// Also allow traffic from peer VPC's pod CIDRs (for CockroachDB pod-to-pod communication)
+	podCIDRA := r.getPodCIDR(regionA)
+	podCIDRB := r.getPodCIDR(regionB)
+
+	// Update security groups in region A to allow traffic from region B
+	for sgName, sgID := range r.securityGroupIDs {
+		if !strings.Contains(sgName, regionA) {
+			continue // Skip security groups from other regions
+		}
+
+		ec2Client := ec2Clients[regionA]
+
+		// Allow VPC CIDR
+		_, err := ec2Client.AuthorizeSecurityGroupIngressWithContext(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
+			GroupId: aws.String(sgID),
+			IpPermissions: []*ec2.IpPermission{
+				{
+					IpProtocol: aws.String("-1"), // All protocols
+					IpRanges:   []*ec2.IpRange{{CidrIp: aws.String(vpcCIDRB)}},
+				},
+			},
+		})
+		if err != nil && !strings.Contains(err.Error(), "already exists") {
+			t.Logf("[%s] Warning: failed to add VPC CIDR ingress rule to SG %s: %v", ProviderAWS, sgID, err)
+		}
+
+		// Allow all traffic from Pod CIDR (needed for pod-to-pod communication across regions)
+		_, err = ec2Client.AuthorizeSecurityGroupIngressWithContext(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
+			GroupId: aws.String(sgID),
+			IpPermissions: []*ec2.IpPermission{
+				{
+					IpProtocol: aws.String("-1"), // All protocols for pod-to-pod communication
+					IpRanges:   []*ec2.IpRange{{CidrIp: aws.String(podCIDRB)}},
+				},
+			},
+		})
+		if err != nil && !strings.Contains(err.Error(), "already exists") {
+			t.Logf("[%s] Warning: failed to add pod CIDR ingress rule to SG %s: %v", ProviderAWS, sgID, err)
+		}
+	}
+
+	// Update security groups in region B to allow traffic from region A
+	for sgName, sgID := range r.securityGroupIDs {
+		if !strings.Contains(sgName, regionB) {
+			continue // Skip security groups from other regions
+		}
+
+		ec2Client := ec2Clients[regionB]
+
+		// Allow VPC CIDR
+		_, err := ec2Client.AuthorizeSecurityGroupIngressWithContext(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
+			GroupId: aws.String(sgID),
+			IpPermissions: []*ec2.IpPermission{
+				{
+					IpProtocol: aws.String("-1"), // All protocols
+					IpRanges:   []*ec2.IpRange{{CidrIp: aws.String(vpcCIDRA)}},
+				},
+			},
+		})
+		if err != nil && !strings.Contains(err.Error(), "already exists") {
+			t.Logf("[%s] Warning: failed to add VPC CIDR ingress rule to SG %s: %v", ProviderAWS, sgID, err)
+		}
+
+		// Allow all traffic from Pod CIDR (needed for pod-to-pod communication across regions)
+		_, err = ec2Client.AuthorizeSecurityGroupIngressWithContext(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
+			GroupId: aws.String(sgID),
+			IpPermissions: []*ec2.IpPermission{
+				{
+					IpProtocol: aws.String("-1"), // All protocols for pod-to-pod communication
+					IpRanges:   []*ec2.IpRange{{CidrIp: aws.String(podCIDRA)}},
+				},
+			},
+		})
+		if err != nil && !strings.Contains(err.Error(), "already exists") {
+			t.Logf("[%s] Warning: failed to add pod CIDR ingress rule to SG %s: %v", ProviderAWS, sgID, err)
+		}
+	}
+
+	t.Logf("[%s] Updated security groups to allow cross-VPC traffic between %s and %s", ProviderAWS, regionA, regionB)
+	return nil
+}
+
+// getPodCIDR returns the Pod CIDR block for EKS pods in a given region.
+// Each region has a unique non-overlapping Pod CIDR to enable cross-region pod communication.
+// Pod CIDRs are larger than VPC CIDRs (e.g., /20 vs /24) to accommodate many pods.
+// Returns region-specific CIDR from centralized constants (e.g., 172.28.0.0/20 for us-east-1).
+func (r *AwsRegion) getPodCIDR(region string) string {
+	switch region {
+	case awsRegionPrimary:
+		return awsPodCIDRPrimary
+	case awsRegionSecondary:
+		return awsPodCIDRSecondary
+	case awsRegionTertiary:
+		return awsPodCIDRTertiary
+	default:
+		return "172.28.0.0/16" // Fallback
+	}
+}
+
+// deleteVPCPeeringConnections deletes all VPC peering connections created by the test.
+// Uses a two-phase cleanup approach:
+// 1. Delete tracked connections from r.vpcPeeringConnections
+// 2. Search for and delete any connections tagged with TestRunID (fallback cleanup)
+// Deletes connections in parallel across all regions for efficiency.
+func (r *AwsRegion) deleteVPCPeeringConnections(
+	ctx context.Context, t *testing.T, ec2Clients map[string]*ec2.EC2,
+) error {
+	// If we have tracked peering connections, delete them
+	if len(r.vpcPeeringConnections) > 0 {
+		t.Logf("[%s] Deleting %d VPC peering connections", ProviderAWS, len(r.vpcPeeringConnections))
+
+		var wg sync.WaitGroup
+		deletedCount := 0
+		var mu sync.Mutex
+
+		for _, peeringConnID := range r.vpcPeeringConnections {
+			wg.Add(1)
+			go func(connID string) {
+				defer wg.Done()
+
+				// Try to delete it from each region until we find the right one
+				for region, ec2Client := range ec2Clients {
+					_, err := ec2Client.DeleteVpcPeeringConnectionWithContext(ctx, &ec2.DeleteVpcPeeringConnectionInput{
+						VpcPeeringConnectionId: aws.String(connID),
+					})
+					if err == nil {
+						mu.Lock()
+						deletedCount++
+						mu.Unlock()
+						t.Logf("[%s] Deleted VPC peering connection %s in region %s", ProviderAWS, connID, region)
+						return
+					}
+					// If the error is "not found", try the next region
+					if !strings.Contains(err.Error(), "InvalidVpcPeeringConnectionID.NotFound") {
+						t.Logf("[%s] Warning: failed to delete VPC peering %s in region %s: %v", ProviderAWS, connID, region, err)
+					}
+				}
+			}(peeringConnID)
+		}
+
+		wg.Wait()
+		t.Logf("[%s] Successfully deleted %d/%d VPC peering connections", ProviderAWS, deletedCount, len(r.vpcPeeringConnections))
+	}
+
+	// Also search for any peering connections by tags (fallback cleanup)
+	t.Logf("[%s] Searching for VPC peering connections by tags for additional cleanup", ProviderAWS)
+	var wg sync.WaitGroup
+	var taggedPeeringCount int
+	var taggedDeletedCount int
+	var mu sync.Mutex
+
+	for region, ec2Client := range ec2Clients {
+		wg.Add(1)
+		go func(reg string, ec2Client *ec2.EC2) {
+			defer wg.Done()
+
+			// List peering connections with our tags
+			result, err := ec2Client.DescribeVpcPeeringConnectionsWithContext(ctx, &ec2.DescribeVpcPeeringConnectionsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("tag:ManagedBy"),
+						Values: []*string{aws.String("helm-charts-e2e")},
+					},
+					{
+						Name:   aws.String("tag:TestRunID"),
+						Values: []*string{aws.String(r.TestRunID)},
+					},
+				},
+			})
+			if err != nil {
+				t.Logf("[%s] Warning: failed to list VPC peering connections in region %s: %v", ProviderAWS, reg, err)
+				return
+			}
+
+			for _, conn := range result.VpcPeeringConnections {
+				mu.Lock()
+				taggedPeeringCount++
+				mu.Unlock()
+
+				// Skip if already deleted or deleting
+				if conn.Status != nil && (aws.StringValue(conn.Status.Code) == "deleted" || aws.StringValue(conn.Status.Code) == "deleting") {
+					t.Logf("[%s] Skipping VPC peering %s (status: %s)", ProviderAWS, aws.StringValue(conn.VpcPeeringConnectionId), aws.StringValue(conn.Status.Code))
+					continue
+				}
+
+				_, err := ec2Client.DeleteVpcPeeringConnectionWithContext(ctx, &ec2.DeleteVpcPeeringConnectionInput{
+					VpcPeeringConnectionId: conn.VpcPeeringConnectionId,
+				})
+				if err != nil {
+					t.Logf("[%s] ERROR: failed to delete VPC peering %s in region %s: %v", ProviderAWS, aws.StringValue(conn.VpcPeeringConnectionId), reg, err)
+				} else {
+					mu.Lock()
+					taggedDeletedCount++
+					mu.Unlock()
+					t.Logf("[%s] Deleted VPC peering connection %s in region %s (tag-based cleanup)", ProviderAWS, aws.StringValue(conn.VpcPeeringConnectionId), reg)
+				}
+			}
+		}(region, ec2Client)
+	}
+
+	wg.Wait()
+
+	if taggedPeeringCount > 0 {
+		t.Logf("[%s] Tag-based cleanup: found %d VPC peering connections, deleted %d/%d", ProviderAWS, taggedPeeringCount, taggedDeletedCount, taggedPeeringCount)
+	} else {
+		t.Logf("[%s] No additional VPC peering connections found by tags", ProviderAWS)
+	}
+
+	t.Logf("[%s] VPC peering connection deletion completed", ProviderAWS)
+	return nil
+}
+
+func (r *AwsRegion) createEKSClusters(
+	ctx context.Context, t *testing.T, eksClients map[string]*eks.EKS,
+) error {
+	// Suppress controller-runtime logging warning by setting a discard logger
+	ctrllog.SetLogger(logr.Discard())
+
+	var clients = make(map[string]client.Client)
+	r.CorednsClusterOptions = make(map[string]coredns.CoreDNSClusterOption)
+
+	type clusterResult struct {
+		index  int
+		client client.Client
+		err    error
+	}
+
+	resultsChan := make(chan clusterResult, len(r.Clusters))
+
+	for i, clusterName := range r.Clusters {
+		go func(idx int, name string) {
+			defer func() {
+				if rec := recover(); rec != nil {
+					resultsChan <- clusterResult{index: idx, err: fmt.Errorf("panic during cluster creation: %v", rec)}
+				}
+			}()
+
+			cfg := r.clusterConfigs[idx]
+			t.Logf("[%s] Starting parallel creation of EKS cluster '%s' in region %s", ProviderAWS, name, cfg.Region)
+
+			eksClient := eksClients[cfg.Region]
+
+			// Create the EKS cluster
+			err := r.createEKSCluster(ctx, t, eksClient, &cfg)
+			if err != nil {
+				resultsChan <- clusterResult{index: idx, err: fmt.Errorf("failed to create cluster: %w", err)}
+				return
+			}
+
+			// Update kubeconfig using AWS CLI
+			err = UpdateKubeconfigAWS(t, cfg.Region, name, name)
+			if err != nil {
+				resultsChan <- clusterResult{index: idx, err: fmt.Errorf("failed to update kubeconfig: %w", err)}
+				return
+			}
+
+			// Disable TLS verification for corporate proxy compatibility (e.g., Netskope)
+			err = disableTLSVerificationInKubeconfig(t, name)
+			if err != nil {
+				t.Logf("[%s] Warning: Failed to disable TLS verification in kubeconfig: %v", ProviderAWS, err)
+				// Don't fail - this is only needed in proxy environments
+			}
+
+			// Set gp2 StorageClass as default (required for PVCs without explicit storageClassName)
+			t.Logf("[%s] Setting gp2 StorageClass as default for cluster %s (region: %s)", ProviderAWS, name, cfg.Region)
+			patchCmd := exec.Command("kubectl",
+				"--context", name,
+				"patch", "storageclass", "gp2",
+				"-p", `{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}`)
+
+			if output, err := patchCmd.CombinedOutput(); err != nil {
+				// Log warning but don't fail - the StorageClass might not exist yet
+				t.Logf("[%s] Warning: Failed to set gp2 as default StorageClass: %v. Output: %s", ProviderAWS, err, string(output))
+				t.Logf("[%s] PVCs may need explicit storageClassName specified", ProviderAWS)
+			} else {
+				t.Logf("[%s] Successfully set gp2 as default StorageClass", ProviderAWS)
+			}
+
+			// Create a client for this context
+			cfgRest, err := config.GetConfigWithContext(name)
+			if err != nil {
+				resultsChan <- clusterResult{index: idx, err: fmt.Errorf("failed to get config: %w", err)}
+				return
+			}
+			k8sClient, err := client.New(cfgRest, client.Options{})
+			if err != nil {
+				resultsChan <- clusterResult{index: idx, err: fmt.Errorf("failed to create client: %w", err)}
+				return
+			}
+
+			t.Logf("[%s] Successfully created EKS cluster '%s' in region %s", ProviderAWS, name, cfg.Region)
+			resultsChan <- clusterResult{index: idx, client: k8sClient, err: nil}
+		}(i, clusterName)
+	}
+
+	// Wait for all cluster creations to complete
+	for range r.Clusters {
+		result := <-resultsChan
+		if result.err != nil {
+			return fmt.Errorf("failed to create cluster at index %d: %w", result.index, result.err)
+		}
+		clients[r.Clusters[result.index]] = result.client
+
+		// Store CoreDNS options with placeholder IPs (will be updated after service creation)
+		r.CorednsClusterOptions[operator.CustomDomains[result.index]] = coredns.CoreDNSClusterOption{
+			IPs:       []string{"127.0.0.1"}, // Placeholder
+			Namespace: r.Namespace[r.Clusters[result.index]],
+			Domain:    operator.CustomDomains[result.index],
+		}
+	}
+
+	r.Clients = clients
+	t.Logf("[%s] All EKS clusters created successfully", ProviderAWS)
+
+	return nil
+}
+
+func (r *AwsRegion) createEKSCluster(
+	ctx context.Context, t *testing.T, eksClient *eks.EKS, setup *AWSClusterSetupConfig,
+) error {
+	// Check if a cluster already exists
+	_, err := eksClient.DescribeClusterWithContext(ctx, &eks.DescribeClusterInput{
+		Name: aws.String(setup.ClusterName),
+	})
+	if err == nil {
+		t.Logf("[%s] EKS cluster '%s' already exists", ProviderAWS, setup.ClusterName)
+		return nil
+	}
+
+	// Use eksctl for cluster creation as it handles all the complexity
+	args := []string{
+		"create", "cluster",
+		"--name", setup.ClusterName,
+		"--region", setup.Region,
+		"--version", awsDefaultK8sVersion,
+		"--nodegroup-name", fmt.Sprintf("%s-nodegroup", setup.ClusterName),
+		"--node-type", awsDefaultInstanceType,
+		"--nodes", fmt.Sprint(len(setup.AvailabilityZones) * awsDefaultNodesPerAZ),
+		"--nodes-min", fmt.Sprint(len(setup.AvailabilityZones) * awsDefaultNodesPerAZ),
+		"--nodes-max", fmt.Sprint(len(setup.AvailabilityZones) * (awsDefaultNodesPerAZ + 1)),
+		"--node-volume-size", fmt.Sprint(awsDefaultDiskSize),
+		"--tags", fmt.Sprintf("ManagedBy=helm-charts-e2e,TestRunID=%s", r.TestRunID),
+		// Enable OIDC provider (required for EBS CSI driver IAM role)
+		"--with-oidc",
+	}
+
+	// Use existing VPC and subnets that we created
+	if len(setup.SubnetIDs) > 0 {
+		args = append(args, "--vpc-public-subnets", strings.Join(setup.SubnetIDs, ","))
+	}
+
+	// Attach our custom internal security group to nodes (allows cross-region traffic)
+	// The internal SG has rules allowing traffic from 172.28.0.0/16 and peer VPC/Pod CIDRs
+	internalSGName := fmt.Sprintf("%s-%s-%s", r.vpcName, awsInternalSGName, setup.Region)
+	if internalSGID, ok := r.securityGroupIDs[internalSGName]; ok {
+		args = append(args, "--node-security-groups", internalSGID)
+		t.Logf("[%s] Attaching internal security group %s to nodes", ProviderAWS, internalSGID)
+	} else {
+		t.Logf("[%s] Warning: Internal security group not found for key %s", ProviderAWS, internalSGName)
+	}
+
+	cmd := exec.Command("eksctl", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	t.Logf("[%s] Running command: eksctl %s", ProviderAWS, strings.Join(args, " "))
+
+	if err := cmd.Run(); err != nil {
+		// Check if the cluster was actually created despite the eksctl error
+		// (This can happen if eksctl fails on post-creation verification)
+		time.Sleep(5 * time.Second)
+		describeResp, describeErr := eksClient.DescribeClusterWithContext(ctx, &eks.DescribeClusterInput{
+			Name: aws.String(setup.ClusterName),
+		})
+		if describeErr == nil && describeResp.Cluster != nil {
+			t.Logf("[%s] Cluster '%s' was created successfully despite eksctl error (status: %s)",
+				ProviderAWS, setup.ClusterName, *describeResp.Cluster.Status)
+			// Wait for the cluster to be active
+			if err := r.waitForClusterActive(ctx, t, eksClient, setup.ClusterName); err != nil {
+				return err
+			}
+			// Disable TLS verification for proxy compatibility (eksctl already updated kubeconfig)
+			if err := disableTLSVerificationInKubeconfig(t, setup.ClusterName); err != nil {
+				t.Logf("[%s] Warning: Failed to disable TLS verification: %v", ProviderAWS, err)
+			}
+			// Enable OIDC and install EBS CSI driver
+			return r.enableOIDCAndInstallCSIDriver(t, setup)
+		}
+		return fmt.Errorf("eksctl create command failed for cluster '%s': %w", setup.ClusterName, err)
+	}
+
+	// eksctl create cluster automatically updates kubeconfig
+	// Optionally disable TLS verification if KUBECTL_INSECURE_SKIP_TLS_VERIFY=true
+	if err := disableTLSVerificationInKubeconfig(t, setup.ClusterName); err != nil {
+		t.Logf("[%s] Warning: Failed to disable TLS verification: %v", ProviderAWS, err)
+		// Don't fail cluster creation - this is only needed in proxy environments
+	}
+
+	// Enable OIDC provider and install EBS CSI driver
+	// (required for K8s 1.23+ to provision EBS volumes)
+	if err := r.enableOIDCAndInstallCSIDriver(t, setup); err != nil {
+		t.Logf("[%s] Warning: Failed to enable OIDC and install EBS CSI driver: %v", ProviderAWS, err)
+		// Don't fail cluster creation if CSI driver installation fails
+		// It can be installed manually if needed
+	}
+
+	return nil
+}
+
+// waitForClusterActive waits for the EKS cluster to reach ACTIVE status
+func (r *AwsRegion) waitForClusterActive(
+	ctx context.Context, t *testing.T, eksClient *eks.EKS, clusterName string,
+) error {
+	t.Logf("[%s] Waiting for cluster '%s' to become ACTIVE", ProviderAWS, clusterName)
+
+	maxRetries := 60 // 10 minutes
+	for i := 0; i < maxRetries; i++ {
+		resp, err := eksClient.DescribeClusterWithContext(ctx, &eks.DescribeClusterInput{
+			Name: aws.String(clusterName),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to describe cluster: %w", err)
+		}
+
+		status := *resp.Cluster.Status
+		t.Logf("[%s] Cluster status: %s", ProviderAWS, status)
+
+		if status == "ACTIVE" {
+			t.Logf("[%s] Cluster '%s' is now ACTIVE", ProviderAWS, clusterName)
+			return nil
+		}
+
+		if status == "FAILED" || status == "DELETING" {
+			return fmt.Errorf("cluster is in %s state", status)
+		}
+
+		time.Sleep(10 * time.Second)
+	}
+
+	return fmt.Errorf("timeout waiting for cluster to become ACTIVE")
+}
+
+// enableOIDCAndInstallCSIDriver enables OIDC provider and installs the AWS EBS CSI driver addon
+func (r *AwsRegion) enableOIDCAndInstallCSIDriver(
+	t *testing.T, setup *AWSClusterSetupConfig,
+) error {
+	// First, explicitly enable OIDC provider (--with-oidc flag doesn't always work)
+	t.Logf("[%s] Enabling OIDC provider for cluster '%s'", ProviderAWS, setup.ClusterName)
+	oidcCmd := exec.Command("eksctl", "utils", "associate-iam-oidc-provider",
+		"--cluster", setup.ClusterName,
+		"--region", setup.Region,
+		"--approve")
+
+	if output, err := oidcCmd.CombinedOutput(); err != nil {
+		t.Logf("[%s] OIDC association output: %s", ProviderAWS, string(output))
+		// Check if OIDC is already associated
+		if !strings.Contains(string(output), "already exists") && !strings.Contains(string(output), "already associated") {
+			return fmt.Errorf("failed to associate OIDC provider: %w", err)
+		}
+		t.Logf("[%s] OIDC provider already associated", ProviderAWS)
+	} else {
+		t.Logf("[%s] Successfully enabled OIDC provider", ProviderAWS)
+	}
+
+	// Now install EBS CSI driver using AWS CLI instead of eksctl to avoid certificate issues
+	t.Logf("[%s] Installing EBS CSI driver addon for cluster '%s'", ProviderAWS, setup.ClusterName)
+
+	// Get AWS account ID
+	accountCmd := exec.Command("aws", "sts", "get-caller-identity", "--query", "Account", "--output", "text")
+	accountOutput, err := accountCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to get AWS account ID: %w", err)
+	}
+	accountID := strings.TrimSpace(string(accountOutput))
+
+	// Create an IAM role for an EBS CSI driver using AWS IAM (bypasses kubectl/eksctl certificate issues)
+	// Use TestRunID instead of cluster name to avoid exceeding AWS's 64-character limit for IAM role names
+	roleName := fmt.Sprintf("ebs-csi-%s-%s", setup.Region, r.TestRunID)
+
+	// Get OIDC provider URL
+	oidcCmd = exec.Command("aws", "eks", "describe-cluster",
+		"--name", setup.ClusterName,
+		"--region", setup.Region,
+		"--query", "cluster.identity.oidc.issuer",
+		"--output", "text")
+
+	oidcOutput, err := oidcCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to get OIDC provider: %w", err)
+	}
+	oidcProvider := strings.TrimSpace(strings.TrimPrefix(string(oidcOutput), "https://"))
+
+	// Create a trust policy document
+	trustPolicy := fmt.Sprintf(`{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::%s:oidc-provider/%s"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "%s:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa",
+          "%s:aud": "sts.amazonaws.com"
+        }
+      }
+    }
+  ]
+}`, accountID, oidcProvider, oidcProvider, oidcProvider)
+
+	// Create the IAM role
+	t.Logf("[%s] Creating IAM role %s for EBS CSI driver", ProviderAWS, roleName)
+	createRoleCmd := exec.Command("aws", "iam", "create-role",
+		"--role-name", roleName,
+		"--assume-role-policy-document", trustPolicy,
+		"--description", "IAM role for EBS CSI driver",
+		"--tags",
+		"Key=ManagedBy,Value=helm-charts-e2e",
+		fmt.Sprintf("Key=TestRunID,Value=%s", r.TestRunID))
+
+	if output, err := createRoleCmd.CombinedOutput(); err != nil {
+		// Check if a role already exists
+		if !strings.Contains(string(output), "EntityAlreadyExists") {
+			t.Logf("[%s] Failed to create IAM role: %s", ProviderAWS, string(output))
+			return fmt.Errorf("failed to create IAM role: %w", err)
+		}
+		t.Logf("[%s] IAM role %s already exists", ProviderAWS, roleName)
+	}
+
+	// Attach the EBS CSI policy to the role
+	attachPolicyCmd := exec.Command("aws", "iam", "attach-role-policy",
+		"--role-name", roleName,
+		"--policy-arn", "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy")
+
+	if output, err := attachPolicyCmd.CombinedOutput(); err != nil {
+		t.Logf("[%s] Warning: Failed to attach policy (may already be attached): %s", ProviderAWS, string(output))
+	}
+
+	// Install the EBS CSI driver addon using AWS CLI (no kubectl/certificate needed)
+	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, roleName)
+
+	t.Logf("[%s] Installing EBS CSI driver addon with role: %s", ProviderAWS, roleArn)
+	addonCmd := exec.Command("aws", "eks", "create-addon",
+		"--cluster-name", setup.ClusterName,
+		"--region", setup.Region,
+		"--addon-name", "aws-ebs-csi-driver",
+		"--service-account-role-arn", roleArn,
+		"--resolve-conflicts", "OVERWRITE")
+
+	if output, err := addonCmd.CombinedOutput(); err != nil {
+		// Check if addon already exists
+		if strings.Contains(string(output), "ResourceInUseException") || strings.Contains(string(output), "already exists") {
+			t.Logf("[%s] EBS CSI driver addon already exists", ProviderAWS)
+		} else {
+			t.Logf("[%s] EBS CSI driver addon installation output: %s", ProviderAWS, string(output))
+			return fmt.Errorf("failed to install EBS CSI driver addon: %w", err)
+		}
+	} else {
+		t.Logf("[%s] Successfully installed EBS CSI driver addon", ProviderAWS)
+	}
+
+	// Wait for the CSI driver addon to become active
+	t.Logf("[%s] Waiting for EBS CSI driver addon to become active...", ProviderAWS)
+	maxAttempts := 20 // 20 attempts * 15 seconds = 5 minutes max
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		checkCmd := exec.Command("aws", "eks", "describe-addon",
+			"--cluster-name", setup.ClusterName,
+			"--region", setup.Region,
+			"--addon-name", "aws-ebs-csi-driver",
+			"--query", "addon.status",
+			"--output", "text")
+
+		output, err := checkCmd.CombinedOutput()
+		if err != nil {
+			t.Logf("[%s] Attempt %d/%d: Failed to check addon status: %v", ProviderAWS, attempt, maxAttempts, err)
+		} else {
+			status := strings.TrimSpace(string(output))
+			t.Logf("[%s] Attempt %d/%d: EBS CSI driver addon status: %s", ProviderAWS, attempt, maxAttempts, status)
+
+			if status == "ACTIVE" {
+				t.Logf("[%s] EBS CSI driver addon is now active", ProviderAWS)
+				// Give it a bit more time for the CSI driver pods to fully start
+				time.Sleep(15 * time.Second)
+				return nil
+			}
+
+			if status == "CREATE_FAILED" || status == "DEGRADED" {
+				return fmt.Errorf("EBS CSI driver addon failed with status: %s", status)
+			}
+		}
+
+		if attempt < maxAttempts {
+			t.Logf("[%s] Waiting 15 seconds before next check...", ProviderAWS)
+			time.Sleep(15 * time.Second)
+		}
+	}
+
+	return fmt.Errorf("timeout waiting for EBS CSI driver addon to become active after %d attempts", maxAttempts)
+}
+
+// deployAndConfigureCoreDNS handles the deployment and configuration of CoreDNS across all clusters
+func (r *AwsRegion) deployAndConfigureCoreDNS(t *testing.T, kubeConfigPath string) error {
+	// Deploy CoreDNS with initial configuration
+	for i, clusterName := range r.Clusters {
+		// Deploy CoreDNS (AWS uses NLB, which assigns hostnames, will be resolved to IPs)
+		err := DeployCoreDNS(t, clusterName, kubeConfigPath, nil, ProviderAWS, operator.CustomDomains[i], r.CorednsClusterOptions)
+		if err != nil {
+			return fmt.Errorf("failed to deploy CoreDNS to cluster %s: %w", clusterName, err)
+		}
+
+		// Wait for the CoreDNS service to get IPs
+		kubectlOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, coreDNSNamespace)
+		actualIPs, err := WaitForCoreDNSServiceIPs(t, kubectlOpts)
+		if err != nil {
+			return fmt.Errorf("failed to get CoreDNS service IPs for cluster %s: %w", clusterName, err)
+		}
+
+		// Update the cluster options with the actual assigned IPs
+		r.CorednsClusterOptions[operator.CustomDomains[i]] = coredns.CoreDNSClusterOption{
+			IPs:       actualIPs,
+			Namespace: r.Namespace[clusterName],
+			Domain:    operator.CustomDomains[i],
+		}
+	}
+
+	// Update CoreDNS configuration in all clusters with complete cross-cluster information
+	UpdateCoreDNSConfiguration(t, r.Region, kubeConfigPath)
+
+	return nil
+}
+
+// UpdateKubeconfigAWS updates kubeconfig for AWS EKS clusters and verifies connectivity
+func UpdateKubeconfigAWS(t *testing.T, region, clusterName, alias string) error {
+	t.Logf("[%s] Updating kubeconfig for cluster %s (region: %s) and verifying connectivity...", ProviderAWS, clusterName, region)
+
+	// Verify cluster connectivity with retries, refreshing kubeconfig on each attempt
+	maxRetries := 36 // 6 minutes total
+	for i := 0; i < maxRetries; i++ {
+		// Update kubeconfig on each retry to get fresh certificates
+		// Use mutex to prevent concurrent kubeconfig file corruption
+		kubeconfigMutex.Lock()
+		updateCmd := exec.Command("aws", "eks", "update-kubeconfig",
+			"--region", region,
+			"--name", clusterName,
+			"--alias", alias)
+		_, err := updateCmd.CombinedOutput()
+		kubeconfigMutex.Unlock()
+
+		if err != nil {
+			t.Logf("[%s] Warning: aws eks update-kubeconfig failed (attempt %d/%d): %v", ProviderAWS, i+1, maxRetries, err)
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		// Use kubectl to verify connectivity (handles EKS certificates better than a Go client)
+		testCmd := exec.Command("kubectl", "--context", alias, "get", "nodes", "--no-headers")
+		testOutput, testErr := testCmd.CombinedOutput()
+
+		if testErr == nil && len(testOutput) > 0 {
+			t.Logf("[%s] Successfully connected to cluster %s in region %s (found nodes)", ProviderAWS, clusterName, region)
+			// Give the cluster a bit more time to ensure all certificates are fully propagated
+			time.Sleep(10 * time.Second)
+			return nil
+		}
+
+		// Check if it's a TLS certificate error
+		if testErr != nil && (strings.Contains(string(testOutput), "x509") ||
+			strings.Contains(string(testOutput), "certificate") ||
+			strings.Contains(testErr.Error(), "x509") ||
+			strings.Contains(testErr.Error(), "certificate")) {
+			t.Logf("[%s] Waiting for cluster certificates to be ready (attempt %d/%d)...", ProviderAWS, i+1, maxRetries)
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		// If no nodes yet but no certificate error, the cluster might still be starting
+		if testErr != nil {
+			t.Logf("[%s] Cluster not ready yet (attempt %d/%d): %v", ProviderAWS, i+1, maxRetries, testErr)
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		// No nodes found but no error - wait a bit more
+		t.Logf("[%s] No nodes found yet (attempt %d/%d), waiting...", ProviderAWS, i+1, maxRetries)
+		time.Sleep(10 * time.Second)
+	}
+
+	return fmt.Errorf("timeout waiting for cluster %s to be accessible", clusterName)
+}
+
+// ─── DELETE RESOURCES ──────────────────────────────────────────────────────────
+
+// deleteEKSClusters deletes all EKS clusters in parallel.
+// For each cluster:
+//  1. Deletes the EBS CSI driver addon first (prevents orphaned addon resources)
+//  2. Initiates cluster deletion via eksctl (async, no wait)
+//  3. eksctl handles node group and CloudFormation stack deletion
+func (r *AwsRegion) deleteEKSClusters(_ context.Context, t *testing.T) error {
+	type deletionResult struct {
+		clusterName string
+		err         error
+	}
+
+	resultsChan := make(chan deletionResult, len(r.Clusters))
+
+	for i, clusterName := range r.Clusters {
+		go func(idx int, name string) {
+			defer func() {
+				if rec := recover(); rec != nil {
+					resultsChan <- deletionResult{
+						clusterName: name,
+						err:         fmt.Errorf("panic during cluster deletion: %v", rec),
+					}
+				}
+			}()
+
+			cfg := r.clusterConfigs[idx]
+			t.Logf("[%s] Deleting EKS cluster '%s' in region %s", ProviderAWS, name, cfg.Region)
+
+			// Delete EBS CSI driver addon first (must be done before cluster deletion)
+			// The addon can orphan resources if the cluster is deleted first
+			t.Logf("[%s] Deleting EBS CSI driver addon for cluster %s", ProviderAWS, name)
+			deleteAddonCmd := exec.Command("aws", "eks", "delete-addon",
+				"--cluster-name", name,
+				"--region", cfg.Region,
+				"--addon-name", "aws-ebs-csi-driver")
+			deleteAddonOutput, addonErr := deleteAddonCmd.CombinedOutput()
+			if addonErr != nil {
+				if strings.Contains(string(deleteAddonOutput), "ResourceNotFoundException") ||
+					strings.Contains(string(deleteAddonOutput), "No addon") {
+					t.Logf("[%s] EBS CSI addon does not exist for cluster %s, skipping", ProviderAWS, name)
+				} else {
+					t.Logf("[%s] Warning: failed to delete EBS CSI addon for %s: %v", ProviderAWS, name, addonErr)
+				}
+			} else {
+				t.Logf("[%s] Successfully deleted EBS CSI addon for cluster %s", ProviderAWS, name)
+			}
+
+			// Use eksctl to delete the cluster with a force option (async, no wait)
+			deleteCmd := exec.Command("eksctl", "delete", "cluster",
+				"--name", name,
+				"--region", cfg.Region,
+				"--force",
+				"--disable-nodegroup-eviction")
+			deleteCmd.Stdout = os.Stdout
+			deleteCmd.Stderr = os.Stderr
+
+			err := deleteCmd.Run()
+			if err != nil {
+				t.Logf("[%s] Warning: cluster deletion command failed for %s: %v", ProviderAWS, name, err)
+				t.Logf("[%s] Cluster may need manual cleanup", ProviderAWS)
+				resultsChan <- deletionResult{clusterName: name, err: fmt.Errorf("deletion command failed: %w", err)}
+				return
+			}
+			t.Logf("[%s] Initiated async deletion of cluster %s in region %s", ProviderAWS, name, cfg.Region)
+
+			resultsChan <- deletionResult{clusterName: name, err: nil}
+		}(i, clusterName)
+	}
+
+	// Create a map of the cluster name to a region for efficient lookup
+	clusterRegions := make(map[string]string)
+	for idx, name := range r.Clusters {
+		clusterRegions[name] = r.clusterConfigs[idx].Region
+	}
+
+	// Wait for all deletions to complete
+	for range r.Clusters {
+		result := <-resultsChan
+		regionStr := clusterRegions[result.clusterName]
+		if result.err != nil {
+			t.Logf("[%s] Warning: failed to delete cluster %s in region %s: %v", ProviderAWS, result.clusterName, regionStr, result.err)
+		} else {
+			t.Logf("[%s] Successfully deleted cluster %s in region %s", ProviderAWS, result.clusterName, regionStr)
+		}
+	}
+
+	return nil
+}
+
+// deleteIAMRoles deletes IAM roles and OIDC providers for EKS clusters.
+//  1. Deletes IAM roles: searches for roles with pattern ebs-csi-{region}-{testRunID}
+//  2. Deletes OIDC providers: finds providers by querying cluster OIDC issuer URLs
+//     OIDC providers persist after cluster deletion and accumulate over time, causing "already exists" errors.
+func (r *AwsRegion) deleteIAMRoles(t *testing.T) error {
+	t.Logf("[%s] Deleting IAM roles for TestRunID: %s", ProviderAWS, r.TestRunID)
+
+	// Get a list of IAM roles matching our pattern
+	for i := range r.Clusters {
+		region := r.clusterConfigs[i].Region
+		roleName := fmt.Sprintf("ebs-csi-%s-%s", region, r.TestRunID)
+
+		t.Logf("[%s] Checking IAM role: %s", ProviderAWS, roleName)
+
+		// Check if a role exists and has correct tags
+		getCmd := exec.Command("aws", "iam", "get-role", "--role-name", roleName)
+		if output, err := getCmd.CombinedOutput(); err != nil {
+			if strings.Contains(string(output), "NoSuchEntity") {
+				t.Logf("[%s] IAM role %s does not exist, skipping", ProviderAWS, roleName)
+				continue
+			}
+			t.Logf("[%s] Warning: failed to get IAM role %s: %v", ProviderAWS, roleName, err)
+			continue
+		}
+
+		// Detach all attached policies
+		t.Logf("[%s] Detaching policies from IAM role: %s", ProviderAWS, roleName)
+		listPoliciesCmd := exec.Command("aws", "iam", "list-attached-role-policies",
+			"--role-name", roleName,
+			"--query", "AttachedPolicies[].PolicyArn",
+			"--output", "text")
+
+		policiesOutput, err := listPoliciesCmd.CombinedOutput()
+		if err != nil {
+			t.Logf("[%s] Warning: failed to list policies for role %s: %v", ProviderAWS, roleName, err)
+		} else {
+			policies := strings.Fields(string(policiesOutput))
+			for _, policyArn := range policies {
+				if policyArn == "" {
+					continue
+				}
+				detachCmd := exec.Command("aws", "iam", "detach-role-policy",
+					"--role-name", roleName,
+					"--policy-arn", policyArn)
+				if output, err := detachCmd.CombinedOutput(); err != nil {
+					t.Logf("[%s] Warning: failed to detach policy %s from role %s: %v", ProviderAWS, policyArn, roleName, err)
+					t.Logf("[%s] Output: %s", ProviderAWS, string(output))
+				} else {
+					t.Logf("[%s] Detached policy %s from role %s", ProviderAWS, policyArn, roleName)
+				}
+			}
+		}
+
+		// Delete the role
+		t.Logf("[%s] Deleting IAM role: %s", ProviderAWS, roleName)
+		deleteCmd := exec.Command("aws", "iam", "delete-role", "--role-name", roleName)
+		if output, err := deleteCmd.CombinedOutput(); err != nil {
+			t.Logf("[%s] Warning: failed to delete IAM role %s: %v", ProviderAWS, roleName, err)
+			t.Logf("[%s] Output: %s", ProviderAWS, string(output))
+		} else {
+			t.Logf("[%s] Successfully deleted IAM role: %s", ProviderAWS, roleName)
+		}
+	}
+
+	// Delete OIDC providers associated with the EKS clusters
+	// OIDC providers are created with --with-oidc flag during cluster creation but persist after deletion.
+	// They don't have tags, so we identify them by extracting the OIDC issuer URL from each cluster
+	// and matching it against the list of all OIDC providers in the account.
+	t.Logf("[%s] Deleting OIDC providers for TestRunID: %s", ProviderAWS, r.TestRunID)
+	for i := range r.Clusters {
+		clusterName := r.Clusters[i]
+		region := r.clusterConfigs[i].Region
+
+		// Get the OIDC provider ARN for the cluster
+		describeCmd := exec.Command("aws", "eks", "describe-cluster",
+			"--name", clusterName,
+			"--region", region,
+			"--query", "cluster.identity.oidc.issuer",
+			"--output", "text")
+		issuerOutput, err := describeCmd.CombinedOutput()
+		if err != nil {
+			if strings.Contains(string(issuerOutput), "ResourceNotFoundException") ||
+				strings.Contains(string(issuerOutput), "No cluster found") {
+				t.Logf("[%s] Cluster %s does not exist, skipping OIDC provider deletion", ProviderAWS, clusterName)
+				continue
+			}
+			t.Logf("[%s] Warning: failed to get OIDC issuer for cluster %s: %v", ProviderAWS, clusterName, err)
+			continue
+		}
+
+		issuerURL := strings.TrimSpace(string(issuerOutput))
+		if issuerURL == "" || issuerURL == "None" {
+			t.Logf("[%s] No OIDC provider found for cluster %s", ProviderAWS, clusterName)
+			continue
+		}
+
+		// Extract the OIDC provider ID from the issuer URL (last part after /)
+		parts := strings.Split(issuerURL, "/")
+		if len(parts) < 2 {
+			t.Logf("[%s] Warning: invalid OIDC issuer URL format: %s", ProviderAWS, issuerURL)
+			continue
+		}
+		oidcProviderID := parts[len(parts)-1]
+
+		// List all OIDC providers and find the one matching our cluster
+		listOIDCCmd := exec.Command("aws", "iam", "list-open-id-connect-providers",
+			"--query", "OpenIDConnectProviderList[].Arn",
+			"--output", "text")
+		listOutput, err := listOIDCCmd.CombinedOutput()
+		if err != nil {
+			t.Logf("[%s] Warning: failed to list OIDC providers: %v", ProviderAWS, err)
+			continue
+		}
+
+		// Find and delete the matching OIDC provider
+		providerARNs := strings.Fields(string(listOutput))
+		for _, providerARN := range providerARNs {
+			if strings.Contains(providerARN, oidcProviderID) {
+				t.Logf("[%s] Deleting OIDC provider: %s", ProviderAWS, providerARN)
+				deleteOIDCCmd := exec.Command("aws", "iam", "delete-open-id-connect-provider",
+					"--open-id-connect-provider-arn", providerARN)
+				if output, err := deleteOIDCCmd.CombinedOutput(); err != nil {
+					t.Logf("[%s] Warning: failed to delete OIDC provider %s: %v", ProviderAWS, providerARN, err)
+					t.Logf("[%s] Output: %s", ProviderAWS, string(output))
+				} else {
+					t.Logf("[%s] Successfully deleted OIDC provider: %s", ProviderAWS, providerARN)
+				}
+				break
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *AwsRegion) deleteSecurityGroups(
+	ctx context.Context, t *testing.T, ec2Clients map[string]*ec2.EC2,
+) error {
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var deletionErrors []error
+
+	for region, ec2Client := range ec2Clients {
+		wg.Add(1)
+		go func(reg string, ec2Client *ec2.EC2) {
+			defer wg.Done()
+
+			// List security groups by ManagedBy tag and TestRunID
+			output, err := ec2Client.DescribeSecurityGroupsWithContext(ctx, &ec2.DescribeSecurityGroupsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("tag:ManagedBy"),
+						Values: []*string{aws.String("helm-charts-e2e")},
+					},
+					{
+						Name:   aws.String("tag:TestRunID"),
+						Values: []*string{aws.String(r.TestRunID)},
+					},
+				},
+			})
+			if err != nil {
+				t.Logf("[%s] Warning: failed to list security groups in region %s: %v", ProviderAWS, reg, err)
+				mu.Lock()
+				deletionErrors = append(deletionErrors, fmt.Errorf("failed to list security groups in %s: %w", reg, err))
+				mu.Unlock()
+				return
+			}
+
+			for _, sg := range output.SecurityGroups {
+				_, err := ec2Client.DeleteSecurityGroupWithContext(ctx, &ec2.DeleteSecurityGroupInput{
+					GroupId: sg.GroupId,
+				})
+				if err != nil {
+					t.Logf("[%s] Warning: failed to delete security group %s: %v", ProviderAWS, *sg.GroupId, err)
+					mu.Lock()
+					deletionErrors = append(deletionErrors, fmt.Errorf("failed to delete SG %s: %w", *sg.GroupId, err))
+					mu.Unlock()
+				} else {
+					t.Logf("[%s] Deleted security group %s", ProviderAWS, *sg.GroupId)
+				}
+			}
+		}(region, ec2Client)
+	}
+
+	wg.Wait()
+
+	if len(deletionErrors) > 0 {
+		return fmt.Errorf("failed to delete %d security group(s)", len(deletionErrors))
+	}
+	return nil
+}
+
+func (r *AwsRegion) deleteSubnetsAndRouteTables(
+	ctx context.Context, t *testing.T, ec2Clients map[string]*ec2.EC2,
+) error {
+	var wg sync.WaitGroup
+
+	for region, ec2Client := range ec2Clients {
+		wg.Add(1)
+		go func(reg string, ec2Client *ec2.EC2) {
+			defer wg.Done()
+
+			// Delete subnets
+			subnets, err := ec2Client.DescribeSubnetsWithContext(ctx, &ec2.DescribeSubnetsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("tag:ManagedBy"),
+						Values: []*string{aws.String("helm-charts-e2e")},
+					},
+					{
+						Name:   aws.String("tag:TestRunID"),
+						Values: []*string{aws.String(r.TestRunID)},
+					},
+				},
+			})
+			if err != nil {
+				t.Logf("[%s] Warning: failed to list subnets in region %s: %v", ProviderAWS, reg, err)
+				return
+			}
+
+			for _, subnet := range subnets.Subnets {
+				_, err := ec2Client.DeleteSubnetWithContext(ctx, &ec2.DeleteSubnetInput{
+					SubnetId: subnet.SubnetId,
+				})
+				if err != nil {
+					t.Logf("[%s] Warning: failed to delete subnet %s: %v", ProviderAWS, *subnet.SubnetId, err)
+				} else {
+					t.Logf("[%s] Deleted subnet %s", ProviderAWS, *subnet.SubnetId)
+				}
+			}
+
+			// Delete route tables
+			routeTables, err := ec2Client.DescribeRouteTablesWithContext(ctx, &ec2.DescribeRouteTablesInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("tag:ManagedBy"),
+						Values: []*string{aws.String("helm-charts-e2e")},
+					},
+					{
+						Name:   aws.String("tag:TestRunID"),
+						Values: []*string{aws.String(r.TestRunID)},
+					},
+				},
+			})
+			if err != nil {
+				t.Logf("[%s] Warning: failed to list route tables in region %s: %v", ProviderAWS, reg, err)
+				return
+			}
+
+			for _, rtb := range routeTables.RouteTables {
+				// Disassociate from subnets first
+				for _, assoc := range rtb.Associations {
+					if assoc.SubnetId != nil {
+						_, err := ec2Client.DisassociateRouteTableWithContext(ctx, &ec2.DisassociateRouteTableInput{
+							AssociationId: assoc.RouteTableAssociationId,
+						})
+						if err != nil {
+							t.Logf("[%s] Warning: failed to disassociate route table %s: %v", ProviderAWS, *rtb.RouteTableId, err)
+						}
+					}
+				}
+
+				_, err := ec2Client.DeleteRouteTableWithContext(ctx, &ec2.DeleteRouteTableInput{
+					RouteTableId: rtb.RouteTableId,
+				})
+				if err != nil {
+					t.Logf("[%s] Warning: failed to delete route table %s: %v", ProviderAWS, *rtb.RouteTableId, err)
+				} else {
+					t.Logf("[%s] Deleted route table %s", ProviderAWS, *rtb.RouteTableId)
+				}
+			}
+		}(region, ec2Client)
+	}
+
+	wg.Wait()
+	return nil
+}
+
+func (r *AwsRegion) deleteInternetGateways(
+	ctx context.Context, t *testing.T, ec2Clients map[string]*ec2.EC2,
+) error {
+	var wg sync.WaitGroup
+
+	for region, ec2Client := range ec2Clients {
+		wg.Add(1)
+		go func(reg string, ec2Client *ec2.EC2) {
+			defer wg.Done()
+
+			igws, err := ec2Client.DescribeInternetGatewaysWithContext(ctx, &ec2.DescribeInternetGatewaysInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("tag:ManagedBy"),
+						Values: []*string{aws.String("helm-charts-e2e")},
+					},
+					{
+						Name:   aws.String("tag:TestRunID"),
+						Values: []*string{aws.String(r.TestRunID)},
+					},
+				},
+			})
+			if err != nil {
+				t.Logf("[%s] Warning: failed to list internet gateways in region %s: %v", ProviderAWS, reg, err)
+				return
+			}
+
+			for _, igw := range igws.InternetGateways {
+				// Detach from VPCs first
+				for _, attachment := range igw.Attachments {
+					_, err := ec2Client.DetachInternetGatewayWithContext(ctx, &ec2.DetachInternetGatewayInput{
+						InternetGatewayId: igw.InternetGatewayId,
+						VpcId:             attachment.VpcId,
+					})
+					if err != nil {
+						t.Logf("[%s] Warning: failed to detach internet gateway %s: %v", ProviderAWS, *igw.InternetGatewayId, err)
+					}
+				}
+
+				_, err := ec2Client.DeleteInternetGatewayWithContext(ctx, &ec2.DeleteInternetGatewayInput{
+					InternetGatewayId: igw.InternetGatewayId,
+				})
+				if err != nil {
+					t.Logf("[%s] Warning: failed to delete internet gateway %s: %v", ProviderAWS, *igw.InternetGatewayId, err)
+				} else {
+					t.Logf("[%s] Deleted internet gateway %s", ProviderAWS, *igw.InternetGatewayId)
+				}
+			}
+		}(region, ec2Client)
+	}
+
+	wg.Wait()
+	return nil
+}
+
+func (r *AwsRegion) deleteVPCs(
+	ctx context.Context, t *testing.T, ec2Clients map[string]*ec2.EC2,
+) error {
+	var wg sync.WaitGroup
+
+	for region, ec2Client := range ec2Clients {
+		wg.Add(1)
+		go func(reg string, ec2Client *ec2.EC2) {
+			defer wg.Done()
+
+			// Small delay to ensure all dependent resources are cleaned up
+			time.Sleep(10 * time.Second)
+
+			vpcs, err := ec2Client.DescribeVpcsWithContext(ctx, &ec2.DescribeVpcsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("tag:ManagedBy"),
+						Values: []*string{aws.String("helm-charts-e2e")},
+					},
+					{
+						Name:   aws.String("tag:TestRunID"),
+						Values: []*string{aws.String(r.TestRunID)},
+					},
+				},
+			})
+			if err != nil {
+				t.Logf("[%s] Warning: failed to list VPCs in region %s: %v", ProviderAWS, reg, err)
+				return
+			}
+
+			for _, vpc := range vpcs.Vpcs {
+				_, err := ec2Client.DeleteVpcWithContext(ctx, &ec2.DeleteVpcInput{
+					VpcId: vpc.VpcId,
+				})
+				if err != nil && !IsResourceNotFound(err) {
+					t.Logf("[%s] Warning: failed to delete VPC %s: %v", ProviderAWS, *vpc.VpcId, err)
+				} else if err == nil {
+					t.Logf("[%s] Deleted VPC %s", ProviderAWS, *vpc.VpcId)
+				}
+			}
+		}(region, ec2Client)
+	}
+
+	wg.Wait()
+	return nil
+}
+
+// ─── ADDITIONAL CLEANUP FUNCTIONS FOR VPC DEPENDENCIES ─────────────────────────
+
+// deleteLoadBalancers deletes all load balancers in VPCs managed by this test
+func (r *AwsRegion) deleteLoadBalancers(
+	ctx context.Context, t *testing.T, ec2Clients map[string]*ec2.EC2,
+) error {
+	// Need to use AWS CLI for ELBv2 operations
+	for region := range ec2Clients {
+		elbCmd := exec.Command("aws", "elbv2", "describe-load-balancers",
+			"--region", region,
+			"--query", "LoadBalancers[*].[LoadBalancerArn,VpcId]",
+			"--output", "text")
+
+		lbOutput, err := elbCmd.CombinedOutput()
+		if err != nil {
+			t.Logf("[%s] Warning: failed to list load balancers in region %s", ProviderAWS, region)
+			continue
+		}
+
+		lines := strings.Split(strings.TrimSpace(string(lbOutput)), "\n")
+		for _, line := range lines {
+			if line == "" {
+				continue
+			}
+
+			fields := strings.Fields(line)
+			if len(fields) < 2 {
+				continue
+			}
+
+			lbArn := fields[0]
+			vpcID := fields[1]
+
+			// Check if this VPC belongs to our test
+			if r.isTestVPC(ctx, ec2Clients[region], vpcID) {
+				t.Logf("[%s] Deleting load balancer in test VPC %s", ProviderAWS, vpcID)
+				delCmd := exec.Command("aws", "elbv2", "delete-load-balancer",
+					"--region", region,
+					"--load-balancer-arn", lbArn)
+
+				if err := delCmd.Run(); err != nil {
+					t.Logf("[%s] Warning: failed to delete load balancer %s: %v", ProviderAWS, lbArn, err)
+				} else {
+					t.Logf("[%s] Deleted load balancer %s", ProviderAWS, lbArn)
+				}
+			}
+		}
+	}
+
+	// Wait for load balancers to be fully deleted
+	t.Logf("[%s] Waiting for load balancers to be deleted...", ProviderAWS)
+	time.Sleep(30 * time.Second)
+
+	return nil
+}
+
+// isTestVPC checks if a VPC has our test tags
+func (r *AwsRegion) isTestVPC(ctx context.Context, ec2Client *ec2.EC2, vpcID string) bool {
+	vpcs, err := ec2Client.DescribeVpcsWithContext(ctx, &ec2.DescribeVpcsInput{
+		VpcIds: []*string{aws.String(vpcID)},
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("tag:ManagedBy"),
+				Values: []*string{aws.String("helm-charts-e2e")},
+			},
+			{
+				Name:   aws.String("tag:TestRunID"),
+				Values: []*string{aws.String(r.TestRunID)},
+			},
+		},
+	})
+	return err == nil && len(vpcs.Vpcs) > 0
+}
+
+// deleteNATGateways deletes NAT gateways in test VPCs
+func (r *AwsRegion) deleteNATGateways(
+	ctx context.Context, t *testing.T, ec2Clients map[string]*ec2.EC2,
+) error {
+	var wg sync.WaitGroup
+
+	for region, ec2Client := range ec2Clients {
+		wg.Add(1)
+		go func(reg string, ec2Client *ec2.EC2) {
+			defer wg.Done()
+
+			// List NAT gateways with our tags
+			natGWs, err := ec2Client.DescribeNatGatewaysWithContext(ctx, &ec2.DescribeNatGatewaysInput{
+				Filter: []*ec2.Filter{
+					{
+						Name:   aws.String("tag:ManagedBy"),
+						Values: []*string{aws.String("helm-charts-e2e")},
+					},
+					{
+						Name:   aws.String("tag:TestRunID"),
+						Values: []*string{aws.String(r.TestRunID)},
+					},
+				},
+			})
+			if err != nil {
+				t.Logf("[%s] Warning: failed to list NAT gateways in region %s: %v", ProviderAWS, reg, err)
+				return
+			}
+
+			for _, natGW := range natGWs.NatGateways {
+				if *natGW.State == "deleted" || *natGW.State == "deleting" {
+					continue
+				}
+
+				_, err := ec2Client.DeleteNatGatewayWithContext(ctx, &ec2.DeleteNatGatewayInput{
+					NatGatewayId: natGW.NatGatewayId,
+				})
+				if err != nil {
+					t.Logf("[%s] Warning: failed to delete NAT gateway %s: %v", ProviderAWS, *natGW.NatGatewayId, err)
+				} else {
+					t.Logf("[%s] Deleted NAT gateway %s", ProviderAWS, *natGW.NatGatewayId)
+				}
+			}
+		}(region, ec2Client)
+	}
+
+	wg.Wait()
+
+	// Wait for NAT gateways to be fully deleted
+	if len(ec2Clients) > 0 {
+		t.Logf("[%s] Waiting for NAT gateways to be deleted...", ProviderAWS)
+		time.Sleep(30 * time.Second)
+	}
+
+	return nil
+}
+
+// deleteNetworkInterfaces deletes network interfaces in test VPCs
+func (r *AwsRegion) deleteNetworkInterfaces(
+	ctx context.Context, t *testing.T, ec2Clients map[string]*ec2.EC2,
+) error {
+	// ENIs created by EKS/load balancers take time to be released - retry a few times
+	maxRetries := 3
+	for retry := 0; retry < maxRetries; retry++ {
+		if retry > 0 {
+			t.Logf("[%s] Retry %d/%d for ENI deletion", ProviderAWS, retry, maxRetries-1)
+			time.Sleep(30 * time.Second)
+		}
+
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		deletedAny := false
+
+		for region, ec2Client := range ec2Clients {
+			wg.Add(1)
+			go func(reg string, ec2Client *ec2.EC2) {
+				defer wg.Done()
+
+				// Get all VPCs for this test
+				vpcs, err := ec2Client.DescribeVpcsWithContext(ctx, &ec2.DescribeVpcsInput{
+					Filters: []*ec2.Filter{
+						{
+							Name:   aws.String("tag:ManagedBy"),
+							Values: []*string{aws.String("helm-charts-e2e")},
+						},
+						{
+							Name:   aws.String("tag:TestRunID"),
+							Values: []*string{aws.String(r.TestRunID)},
+						},
+					},
+				})
+				if err != nil {
+					return
+				}
+
+				for _, vpc := range vpcs.Vpcs {
+					// List network interfaces in this VPC
+					enis, err := ec2Client.DescribeNetworkInterfacesWithContext(ctx, &ec2.DescribeNetworkInterfacesInput{
+						Filters: []*ec2.Filter{
+							{
+								Name:   aws.String("vpc-id"),
+								Values: []*string{vpc.VpcId},
+							},
+							{
+								Name:   aws.String("status"),
+								Values: []*string{aws.String("available")}, // Only try to delete available ENIs
+							},
+						},
+					})
+					if err != nil {
+						continue
+					}
+
+					for _, eni := range enis.NetworkInterfaces {
+						// Try to delete the ENI
+						_, err := ec2Client.DeleteNetworkInterfaceWithContext(ctx, &ec2.DeleteNetworkInterfaceInput{
+							NetworkInterfaceId: eni.NetworkInterfaceId,
+						})
+						if err == nil {
+							mu.Lock()
+							deletedAny = true
+							mu.Unlock()
+							t.Logf("[%s] Deleted ENI %s", ProviderAWS, *eni.NetworkInterfaceId)
+						}
+					}
+				}
+			}(region, ec2Client)
+		}
+
+		wg.Wait()
+
+		// If we didn't delete anything this round, we're done
+		if !deletedAny {
+			break
+		}
+	}
+
+	return nil
+}
+
+// releaseElasticIPs releases Elastic IPs associated with test resources
+func (r *AwsRegion) releaseElasticIPs(
+	ctx context.Context, t *testing.T, ec2Clients map[string]*ec2.EC2,
+) error {
+	var wg sync.WaitGroup
+
+	for region, ec2Client := range ec2Clients {
+		wg.Add(1)
+		go func(reg string, ec2Client *ec2.EC2) {
+			defer wg.Done()
+
+			// List all Elastic IPs with our tags
+			eips, err := ec2Client.DescribeAddressesWithContext(ctx, &ec2.DescribeAddressesInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("tag:ManagedBy"),
+						Values: []*string{aws.String("helm-charts-e2e")},
+					},
+					{
+						Name:   aws.String("tag:TestRunID"),
+						Values: []*string{aws.String(r.TestRunID)},
+					},
+				},
+			})
+			if err != nil {
+				return
+			}
+
+			for _, eip := range eips.Addresses {
+				// Disassociate if associated
+				if eip.AssociationId != nil {
+					_, _ = ec2Client.DisassociateAddressWithContext(ctx, &ec2.DisassociateAddressInput{
+						AssociationId: eip.AssociationId,
+					})
+					time.Sleep(2 * time.Second)
+				}
+
+				// Release the Elastic IP
+				_, err := ec2Client.ReleaseAddressWithContext(ctx, &ec2.ReleaseAddressInput{
+					AllocationId: eip.AllocationId,
+				})
+				if err != nil {
+					t.Logf("[%s] Warning: failed to release EIP %s: %v", ProviderAWS, *eip.AllocationId, err)
+				} else {
+					t.Logf("[%s] Released Elastic IP %s", ProviderAWS, *eip.AllocationId)
+				}
+			}
+		}(region, ec2Client)
+	}
+
+	wg.Wait()
+	return nil
+}
+
+// deleteVPCEndpoints deletes VPC endpoints in test VPCs
+func (r *AwsRegion) deleteVPCEndpoints(
+	ctx context.Context, t *testing.T, ec2Clients map[string]*ec2.EC2,
+) error {
+	var wg sync.WaitGroup
+
+	for region, ec2Client := range ec2Clients {
+		wg.Add(1)
+		go func(reg string, ec2Client *ec2.EC2) {
+			defer wg.Done()
+
+			// Get VPC IDs for this test
+			vpcs, err := ec2Client.DescribeVpcsWithContext(ctx, &ec2.DescribeVpcsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("tag:ManagedBy"),
+						Values: []*string{aws.String("helm-charts-e2e")},
+					},
+					{
+						Name:   aws.String("tag:TestRunID"),
+						Values: []*string{aws.String(r.TestRunID)},
+					},
+				},
+			})
+			if err != nil {
+				return
+			}
+
+			for _, vpc := range vpcs.Vpcs {
+				// List VPC endpoints
+				endpoints, err := ec2Client.DescribeVpcEndpointsWithContext(ctx, &ec2.DescribeVpcEndpointsInput{
+					Filters: []*ec2.Filter{
+						{
+							Name:   aws.String("vpc-id"),
+							Values: []*string{vpc.VpcId},
+						},
+					},
+				})
+				if err != nil {
+					continue
+				}
+
+				var endpointIDs []*string
+				for _, endpoint := range endpoints.VpcEndpoints {
+					endpointIDs = append(endpointIDs, endpoint.VpcEndpointId)
+				}
+
+				if len(endpointIDs) > 0 {
+					_, err := ec2Client.DeleteVpcEndpointsWithContext(ctx, &ec2.DeleteVpcEndpointsInput{
+						VpcEndpointIds: endpointIDs,
+					})
+					if err != nil {
+						t.Logf("[%s] Warning: failed to delete VPC endpoints: %v", ProviderAWS, err)
+					} else {
+						t.Logf("[%s] Deleted %d VPC endpoints in VPC %s", ProviderAWS, len(endpointIDs), *vpc.VpcId)
+					}
+				}
+			}
+		}(region, ec2Client)
+	}
+
+	wg.Wait()
+	return nil
+}
+
+// deleteClusterResources deletes cluster-related resources in parallel
+func (r *AwsRegion) deleteClusterResources(
+	ctx context.Context, t *testing.T, ec2Clients map[string]*ec2.EC2,
+) error {
+	var wg sync.WaitGroup
+	errors := make(chan error, 5)
+
+	// Delete Load Balancers
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := r.deleteLoadBalancers(ctx, t, ec2Clients); err != nil {
+			errors <- fmt.Errorf("load balancer deletion failed: %w", err)
+		}
+	}()
+
+	// Delete NAT Gateways
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := r.deleteNATGateways(ctx, t, ec2Clients); err != nil {
+			errors <- fmt.Errorf("NAT gateway deletion failed: %w", err)
+		}
+	}()
+
+	// Delete Network Interfaces
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := r.deleteNetworkInterfaces(ctx, t, ec2Clients); err != nil {
+			errors <- fmt.Errorf("network interface deletion failed: %w", err)
+		}
+	}()
+
+	// Delete Elastic IPs
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := r.deleteElasticIPs(ctx, t, ec2Clients); err != nil {
+			errors <- fmt.Errorf("elastic IP deletion failed: %w", err)
+		}
+	}()
+
+	// Delete VPC Endpoints
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := r.deleteVPCEndpoints(ctx, t, ec2Clients); err != nil {
+			errors <- fmt.Errorf("VPC endpoint deletion failed: %w", err)
+		}
+	}()
+
+	wg.Wait()
+	close(errors)
+
+	// Collect any errors
+	var errs []error
+	for err := range errors {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("cluster resource deletion had %d errors: %v", len(errs), errs)
+	}
+
+	return nil
+}
+
+// deleteElasticIPs releases and deletes all Elastic IPs created by our test.
+// This includes:
+// 1. EIPs tagged with our TestRunID (if we created them explicitly)
+// 2. EIPs associated with Load Balancers in our VPCs (created by Kubernetes services)
+// 3. EIPs associated with NAT Gateways in our VPCs (if any exist)
+func (r *AwsRegion) deleteElasticIPs(
+	ctx context.Context, t *testing.T, ec2Clients map[string]*ec2.EC2,
+) error {
+	var wg sync.WaitGroup
+
+	for region, ec2Client := range ec2Clients {
+		wg.Add(1)
+		go func(reg string, ec2Client *ec2.EC2) {
+			defer wg.Done()
+
+			// Collect all EIP allocation IDs to delete
+			eipMap := make(map[string]bool) // Use a map to deduplicate
+
+			// 1. Find EIPs with our tags
+			taggedEIPs, err := ec2Client.DescribeAddressesWithContext(ctx, &ec2.DescribeAddressesInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("tag:ManagedBy"),
+						Values: []*string{aws.String("helm-charts-e2e")},
+					},
+					{
+						Name:   aws.String("tag:TestRunID"),
+						Values: []*string{aws.String(r.TestRunID)},
+					},
+				},
+			})
+			if err == nil {
+				for _, eip := range taggedEIPs.Addresses {
+					if eip.AllocationId != nil {
+						eipMap[*eip.AllocationId] = true
+					}
+				}
+			} else if !IsResourceNotFound(err) {
+				t.Logf("[%s] Warning: failed to describe tagged Elastic IPs in region %s: %v", ProviderAWS, reg, err)
+			}
+
+			// 2. Find our VPCs and get all EIPs associated with resources in those VPCs
+			vpcs, err := ec2Client.DescribeVpcsWithContext(ctx, &ec2.DescribeVpcsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("tag:ManagedBy"),
+						Values: []*string{aws.String("helm-charts-e2e")},
+					},
+					{
+						Name:   aws.String("tag:TestRunID"),
+						Values: []*string{aws.String(r.TestRunID)},
+					},
+				},
+			})
+			if err == nil && vpcs.Vpcs != nil {
+				// For each VPC, find all EIPs (these are typically from NLBs created by Kubernetes)
+				for _, vpc := range vpcs.Vpcs {
+					vpcID := aws.StringValue(vpc.VpcId)
+
+					// Find all addresses and check if they're in this VPC via their network interface
+					allEIPs, err := ec2Client.DescribeAddressesWithContext(ctx, &ec2.DescribeAddressesInput{})
+					if err == nil {
+						for _, eip := range allEIPs.Addresses {
+							// Check if EIP is associated with a network interface in our VPC
+							if eip.NetworkInterfaceId != nil {
+								eni, err := ec2Client.DescribeNetworkInterfacesWithContext(ctx, &ec2.DescribeNetworkInterfacesInput{
+									NetworkInterfaceIds: []*string{eip.NetworkInterfaceId},
+								})
+								if err == nil && len(eni.NetworkInterfaces) > 0 {
+									if aws.StringValue(eni.NetworkInterfaces[0].VpcId) == vpcID {
+										if eip.AllocationId != nil {
+											eipMap[*eip.AllocationId] = true
+											t.Logf("[%s] Found Elastic IP %s in VPC %s (likely from NLB)", ProviderAWS, *eip.AllocationId, vpcID)
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+
+			// Now delete all collected EIPs
+			for allocationID := range eipMap {
+				// Get EIP details to check if it's associated
+				eipDetails, err := ec2Client.DescribeAddressesWithContext(ctx, &ec2.DescribeAddressesInput{
+					AllocationIds: []*string{aws.String(allocationID)},
+				})
+				if err != nil {
+					if !IsResourceNotFound(err) {
+						t.Logf("[%s] Warning: failed to describe Elastic IP %s: %v", ProviderAWS, allocationID, err)
+					}
+					continue
+				}
+
+				if len(eipDetails.Addresses) == 0 {
+					continue
+				}
+
+				eip := eipDetails.Addresses[0]
+
+				// Disassociate if associated
+				if eip.AssociationId != nil {
+					_, err := ec2Client.DisassociateAddressWithContext(ctx, &ec2.DisassociateAddressInput{
+						AssociationId: eip.AssociationId,
+					})
+					if err != nil && !IsResourceNotFound(err) {
+						t.Logf("[%s] Warning: failed to disassociate Elastic IP %s: %v", ProviderAWS, allocationID, err)
+					} else {
+						t.Logf("[%s] Disassociated Elastic IP %s", ProviderAWS, allocationID)
+					}
+				}
+
+				// Release the Elastic IP
+				_, err = ec2Client.ReleaseAddressWithContext(ctx, &ec2.ReleaseAddressInput{
+					AllocationId: aws.String(allocationID),
+				})
+				if err != nil {
+					if !IsResourceNotFound(err) {
+						t.Logf("[%s] Warning: failed to release Elastic IP %s: %v", ProviderAWS, allocationID, err)
+					}
+				} else {
+					t.Logf("[%s] Released Elastic IP %s in region %s", ProviderAWS, allocationID, reg)
+				}
+			}
+		}(region, ec2Client)
+	}
+
+	wg.Wait()
+	return nil
+}
+
+// revokeSecurityGroupRules revokes all ingress and egress rules from security groups.
+// This is necessary to break self-referencing and cross-referencing dependencies that prevent SG deletion.
+// Called with retry logic (3 attempts × 30s) to handle AWS eventual consistency issues.
+func (r *AwsRegion) revokeSecurityGroupRules(
+	ctx context.Context, t *testing.T, ec2Clients map[string]*ec2.EC2,
+) error {
+	var wg sync.WaitGroup
+
+	for region, ec2Client := range ec2Clients {
+		wg.Add(1)
+		go func(reg string, ec2Client *ec2.EC2) {
+			defer wg.Done()
+
+			// List security groups with our tags
+			sgs, err := ec2Client.DescribeSecurityGroupsWithContext(ctx, &ec2.DescribeSecurityGroupsInput{
+				Filters: []*ec2.Filter{
+					{
+						Name:   aws.String("tag:ManagedBy"),
+						Values: []*string{aws.String("helm-charts-e2e")},
+					},
+					{
+						Name:   aws.String("tag:TestRunID"),
+						Values: []*string{aws.String(r.TestRunID)},
+					},
+				},
+			})
+			if err != nil {
+				return
+			}
+
+			for _, sg := range sgs.SecurityGroups {
+				// Revoke ingress rules
+				if len(sg.IpPermissions) > 0 {
+					_, err := ec2Client.RevokeSecurityGroupIngressWithContext(ctx, &ec2.RevokeSecurityGroupIngressInput{
+						GroupId:       sg.GroupId,
+						IpPermissions: sg.IpPermissions,
+					})
+					if err != nil {
+						t.Logf("[%s] Warning: failed to revoke ingress rules for SG %s: %v", ProviderAWS, *sg.GroupId, err)
+					} else {
+						t.Logf("[%s] Revoked ingress rules for SG %s", ProviderAWS, *sg.GroupId)
+					}
+				}
+
+				// Revoke egress rules
+				if len(sg.IpPermissionsEgress) > 0 {
+					_, err := ec2Client.RevokeSecurityGroupEgressWithContext(ctx, &ec2.RevokeSecurityGroupEgressInput{
+						GroupId:       sg.GroupId,
+						IpPermissions: sg.IpPermissionsEgress,
+					})
+					if err != nil {
+						t.Logf("[%s] Warning: failed to revoke egress rules for SG %s: %v", ProviderAWS, *sg.GroupId, err)
+					}
+				}
+			}
+		}(region, ec2Client)
+	}
+
+	wg.Wait()
+	return nil
+}
+
+// ─── HELPER FUNCTIONS ────────────────────────────────────────────────────────────
+
+// disableTLSVerificationInKubeconfig modifies the kubeconfig to skip TLS verification for a specific cluster
+// This is needed in corporate proxy environments (e.g., Netskope) that intercept SSL/TLS connections
+func disableTLSVerificationInKubeconfig(t *testing.T, clusterName string) error {
+	// Only disable TLS verification if explicitly enabled via environment variable
+	if os.Getenv(EnvKubectlInsecureSkipTLSVerify) != "true" {
+		return nil // Skip if the environment variable is not set
+	}
+
+	t.Logf("[%s] Disabling TLS verification in kubeconfig (%s=true)", ProviderAWS, EnvKubectlInsecureSkipTLSVerify)
+
+	// Use mutex to prevent concurrent kubeconfig file corruption
+	kubeconfigMutex.Lock()
+	defer kubeconfigMutex.Unlock()
+
+	// Get a kubeconfig path
+	kubeconfigPath := os.Getenv("KUBECONFIG")
+	if kubeconfigPath == "" {
+		kubeconfigPath = os.ExpandEnv("$HOME/.kube/config")
+	}
+
+	// Load the kubeconfig
+	kubeConfig, err := clientcmd.LoadFromFile(kubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to load kubeconfig: %w", err)
+	}
+
+	// Find ALL cluster entries that match (eksctl creates multiple entries)
+	// e.g., both "arn:aws:eks:region:account:cluster/name" and "name.region.eksctl.io"
+	modifiedCount := 0
+	for name, cluster := range kubeConfig.Clusters {
+		if name == clusterName || strings.Contains(name, clusterName) {
+			// Disable TLS verification
+			cluster.InsecureSkipTLSVerify = true
+			// Clear certificate authority data since we're skipping verification
+			cluster.CertificateAuthorityData = nil
+			cluster.CertificateAuthority = ""
+			kubeConfig.Clusters[name] = cluster
+			modifiedCount++
+			t.Logf("[%s] Disabled TLS verification for cluster entry: %s", ProviderAWS, name)
+		}
+	}
+
+	if modifiedCount == 0 {
+		return fmt.Errorf("cluster %s not found in kubeconfig", clusterName)
+	}
+
+	// Write the modified config back
+	err = clientcmd.WriteToFile(*kubeConfig, kubeconfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to write kubeconfig: %w", err)
+	}
+
+	t.Logf("[%s] Successfully disabled TLS verification for %d cluster entries", ProviderAWS, modifiedCount)
+	return nil
+}
+
+// retryWithBackoff executes a function with retry logic for AWS eventual consistency.
+// It retries the function up to maxAttempts times with a delay between attempts.
+// Returns nil if any attempt succeeds, or the last error if all attempts fail.
+func retryWithBackoff(
+	t *testing.T, resourceType string, maxAttempts int, delay time.Duration, fn func() error,
+) error {
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if attempt > 1 {
+			t.Logf("[%s] Retry %d/%d for %s deletion after waiting...", ProviderAWS, attempt, maxAttempts, resourceType)
+			time.Sleep(delay)
+		}
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		if attempt == maxAttempts {
+			return err
+		}
+	}
+	return nil
+}

--- a/tests/e2e/operator/infra/cleanup-aws-resources.sh
+++ b/tests/e2e/operator/infra/cleanup-aws-resources.sh
@@ -1,0 +1,1336 @@
+#!/bin/bash
+# cleanup-aws-resources.sh
+# Cleanup all AWS resources created by e2e tests
+#
+# Resources Cleaned:
+#   - EBS CSI driver addons (deleted before cluster deletion)
+#   - EKS clusters and node groups
+#   - OIDC identity providers (orphaned providers from deleted clusters)
+#   - IAM roles and attached policies
+#   - CloudFormation stacks
+#   - Security groups and their rules
+#   - Subnets, route tables, and routes
+#   - Internet gateways
+#   - Load balancers (NLB/ALB created by Kubernetes services)
+#   - NAT gateways and Elastic IPs
+#   - Network interfaces (ENIs)
+#   - VPC endpoints
+#   - VPC peering connections
+#   - VPCs
+#
+# Multi-Region Support:
+#   By default, cleans up resources in both us-east-1 and us-east-2 (multi-region test regions)
+#   Use AWS_REGION to clean only a single region
+#   Use AWS_REGIONS to specify custom regions (comma-separated)
+#
+# Usage:
+#   ./cleanup-aws-resources.sh [--dry-run] <TEST_RUN_ID>  # Safe - deletes only specific test run
+#   ./cleanup-aws-resources.sh [--dry-run] --all [--noconsent]          # Dangerous - deletes ALL e2e resources
+#   ./cleanup-aws-resources.sh [--dry-run] --before-date <MM/DD/YYYY> --all [--noconsent]  # Delete old zombie resources
+#
+# Examples:
+#   ./cleanup-aws-resources.sh abc123-1710691200                    # Delete in us-east-1 AND us-east-2 (default)
+#   ./cleanup-aws-resources.sh --dry-run abc123-1710691200          # Show what would be deleted (dry run)
+#   AWS_REGION=us-east-1 ./cleanup-aws-resources.sh abc123-1710691200  # Delete only in us-east-1
+#   AWS_REGIONS=us-east-1,us-east-2,eu-west-1 ./cleanup-aws-resources.sh --all  # Delete in 3 regions
+#   ./cleanup-aws-resources.sh --all                                # Delete all in both default regions (asks for confirmation)
+#   ./cleanup-aws-resources.sh --all --noconsent                    # Delete all without confirmation prompt
+#   ./cleanup-aws-resources.sh --dry-run --all                      # Show all resources in both regions
+#   ./cleanup-aws-resources.sh --before-date 03/18/2026 --all       # Delete old resources in both regions
+#   ./cleanup-aws-resources.sh --dry-run --before-date 03/18/2026 --all  # Show old resources
+
+set -e
+
+# Support both single region (AWS_REGION) and multi-region (AWS_REGIONS)
+# Default to both multi-region test regions: us-east-1 and us-east-2
+if [ -n "$AWS_REGIONS" ]; then
+    # Multi-region mode: AWS_REGIONS="us-east-1,us-east-2"
+    IFS=',' read -ra REGIONS <<< "$AWS_REGIONS"
+elif [ -n "$AWS_REGION" ]; then
+    # Single region mode: AWS_REGION="us-east-1"
+    REGIONS=("$AWS_REGION")
+else
+    # Default: both regions used in multi-region tests
+    REGIONS=("us-east-1" "us-east-2")
+fi
+
+TAG_KEY="ManagedBy"
+TAG_VALUE="helm-charts-e2e"
+DRY_RUN=false
+DELETE_ALL=false
+NOCONSENT=false
+TEST_RUN_ID=""
+CLUSTER_NAME=""
+BEFORE_DATE=""
+BEFORE_TIMESTAMP=0
+
+# Parse arguments - allow flags in any order
+if [ $# -eq 0 ]; then
+    echo "Error: Missing required argument"
+    echo ""
+    echo "Usage:"
+    echo "  $0 [--dry-run] <TEST_RUN_ID>                      # Delete resources from specific test run (SAFE)"
+    echo "  $0 [--dry-run] --cluster <CLUSTER_NAME>           # Delete specific cluster only (SAFE)"
+    echo "  $0 [--dry-run] --all [--noconsent]                # Delete ALL e2e resources (DANGEROUS)"
+    echo "  $0 [--dry-run] --before-date <MM/DD/YYYY> --all [--noconsent]   # Delete resources created before date"
+    echo ""
+    echo "Examples:"
+    echo "  $0 abc123-1710691200"
+    echo "  $0 --dry-run abc123-1710691200"
+    echo "  $0 --cluster aws-chart-testing-cluster-0-abc123"
+    echo "  $0 --dry-run --cluster aws-chart-testing-cluster-0-abc123"
+    echo "  $0 --all"
+    echo "  $0 --all --noconsent                              # Skip confirmation prompt"
+    echo "  $0 --dry-run --all"
+    echo "  $0 --before-date 03/18/2026 --all"
+    echo "  $0 --dry-run --before-date 03/18/2026 --all"
+    exit 1
+fi
+
+# Parse all arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --all)
+            DELETE_ALL=true
+            shift
+            ;;
+        --noconsent)
+            NOCONSENT=true
+            shift
+            ;;
+        --cluster)
+            if [ -z "$2" ]; then
+                echo "Error: --cluster requires a cluster name"
+                exit 1
+            fi
+            CLUSTER_NAME="$2"
+            shift 2
+            ;;
+        --before-date)
+            if [ -z "$2" ]; then
+                echo "Error: --before-date requires a date in MM/DD/YYYY format"
+                exit 1
+            fi
+            BEFORE_DATE="$2"
+            # Convert date to Unix timestamp using date command
+            # macOS date command format: date -j -f "%m/%d/%Y" "03/18/2026" "+%s"
+            # Linux date command format: date -d "03/18/2026" "+%s"
+            if date -j -f "%m/%d/%Y" "$BEFORE_DATE" "+%s" >/dev/null 2>&1; then
+                # macOS
+                BEFORE_TIMESTAMP=$(date -j -f "%m/%d/%Y" "$BEFORE_DATE" "+%s")
+            elif date -d "$BEFORE_DATE" "+%s" >/dev/null 2>&1; then
+                # Linux
+                BEFORE_TIMESTAMP=$(date -d "$BEFORE_DATE" "+%s")
+            else
+                echo "Error: Invalid date format '$BEFORE_DATE'. Use MM/DD/YYYY format (e.g., 03/18/2026)"
+                exit 1
+            fi
+            shift 2
+            ;;
+        *)
+            if [ -z "$TEST_RUN_ID" ] && [ -z "$CLUSTER_NAME" ]; then
+                TEST_RUN_ID="$1"
+            else
+                echo "Error: Unexpected argument '$1'"
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Validate arguments
+if [ "$DELETE_ALL" = false ] && [ -z "$TEST_RUN_ID" ] && [ -z "$CLUSTER_NAME" ]; then
+    echo "Error: Must specify either --all, --cluster <name>, or a TEST_RUN_ID"
+    exit 1
+fi
+
+if [ "$DELETE_ALL" = true ] && [ -n "$TEST_RUN_ID" ]; then
+    echo "Error: Cannot specify both --all and a TEST_RUN_ID"
+    exit 1
+fi
+
+if [ "$DELETE_ALL" = true ] && [ -n "$CLUSTER_NAME" ]; then
+    echo "Error: Cannot specify both --all and --cluster"
+    exit 1
+fi
+
+if [ -n "$TEST_RUN_ID" ] && [ -n "$CLUSTER_NAME" ]; then
+    echo "Error: Cannot specify both TEST_RUN_ID and --cluster"
+    exit 1
+fi
+
+if [ -n "$BEFORE_DATE" ] && [ "$DELETE_ALL" = false ]; then
+    echo "Error: --before-date can only be used with --all"
+    exit 1
+fi
+
+if [ "$NOCONSENT" = true ] && [ "$DELETE_ALL" = false ]; then
+    echo "Error: --noconsent can only be used with --all"
+    exit 1
+fi
+
+# Show dry-run banner if enabled
+if [ "$DRY_RUN" = true ]; then
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "🔍 DRY RUN MODE - No resources will be deleted"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+fi
+
+if [ "$DELETE_ALL" = true ]; then
+    if [ "$DRY_RUN" = false ]; then
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        if [ -n "$BEFORE_DATE" ]; then
+            echo "⚠️  WARNING: DELETING OLD HELM-CHARTS-E2E RESOURCES"
+        else
+            echo "⚠️  WARNING: DELETING ALL HELM-CHARTS-E2E RESOURCES"
+        fi
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo ""
+        if [ -n "$BEFORE_DATE" ]; then
+            echo "This will delete resources tagged with ManagedBy=helm-charts-e2e"
+            echo "in regions: ${REGIONS[*]} that were created before $BEFORE_DATE."
+        else
+            echo "This will delete ALL resources tagged with ManagedBy=helm-charts-e2e"
+            echo "in regions: ${REGIONS[*]}, regardless of which test created them."
+        fi
+        echo ""
+        echo "⚠️  This WILL interfere with any concurrent tests!"
+        echo ""
+
+        # Skip confirmation if --noconsent flag is set
+        if [ "$NOCONSENT" = false ]; then
+            echo "Type 'DELETE ALL' (in capitals) to confirm, or Ctrl+C to cancel:"
+            read -r confirmation
+
+            if [ "$confirmation" != "DELETE ALL" ]; then
+                echo "Aborted - confirmation text did not match"
+                exit 1
+            fi
+        else
+            echo "Skipping confirmation (--noconsent flag set)"
+        fi
+
+        if [ -n "$BEFORE_DATE" ]; then
+            echo "Proceeding with deletion of resources created before $BEFORE_DATE..."
+        else
+            echo "Proceeding with deletion of ALL resources..."
+        fi
+    else
+        if [ -n "$BEFORE_DATE" ]; then
+            echo "Showing resources created before $BEFORE_DATE (ManagedBy=helm-charts-e2e) in regions: ${REGIONS[*]}"
+        else
+            echo "Showing ALL resources that would be deleted (ManagedBy=helm-charts-e2e) in regions: ${REGIONS[*]}"
+        fi
+    fi
+elif [ -n "$CLUSTER_NAME" ]; then
+    if [ "$DRY_RUN" = false ]; then
+        echo "Cleaning up cluster: $CLUSTER_NAME in regions: ${REGIONS[*]}"
+    else
+        echo "Showing what would be deleted for cluster: $CLUSTER_NAME in regions: ${REGIONS[*]}"
+    fi
+else
+    if [ "$DRY_RUN" = false ]; then
+        echo "Cleaning up AWS resources for Test Run ID: $TEST_RUN_ID in regions: ${REGIONS[*]}"
+    else
+        echo "Showing resources that would be deleted for Test Run ID: $TEST_RUN_ID in regions: ${REGIONS[*]}"
+    fi
+fi
+
+# Function to get TestRunID from tags
+get_test_run_id() {
+    local tags_json="$1"
+    if [ -z "$tags_json" ] || [ "$tags_json" = "[]" ] || [ "$tags_json" = "{}" ]; then
+        echo ""
+        return
+    fi
+
+    # Handle both array format (EC2 resources) and object format (EKS resources)
+    local test_run_id=""
+    if echo "$tags_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
+        test_run_id=$(echo "$tags_json" | jq -r '.[] | select(.Key=="TestRunID") | .Value' 2>/dev/null || echo "")
+    else
+        test_run_id=$(echo "$tags_json" | jq -r '.TestRunID // ""' 2>/dev/null || echo "")
+    fi
+
+    echo "$test_run_id"
+}
+
+# Function to extract timestamp from TestRunID
+# TestRunID format: "abc123-1710691200" where the number after dash is Unix timestamp
+get_timestamp_from_test_run_id() {
+    local test_run_id="$1"
+    if [ -z "$test_run_id" ]; then
+        echo "0"
+        return
+    fi
+    # Extract timestamp (everything after the last dash)
+    local timestamp=$(echo "$test_run_id" | awk -F'-' '{print $NF}')
+    if [[ "$timestamp" =~ ^[0-9]+$ ]]; then
+        echo "$timestamp"
+    else
+        echo "0"
+    fi
+}
+
+# Function to check if a resource is old enough to delete based on creation timestamp
+# Returns 0 (true) if resource should be deleted, 1 (false) if too new
+is_resource_old_enough() {
+    local resource_timestamp="$1"
+
+    # If no before-date filter specified, delete all resources
+    if [ -z "$BEFORE_DATE" ] || [ "$BEFORE_TIMESTAMP" -eq 0 ]; then
+        return 0
+    fi
+
+    # If resource has no timestamp, be conservative and don't delete
+    if [ -z "$resource_timestamp" ] || [ "$resource_timestamp" -eq 0 ]; then
+        return 1
+    fi
+
+    # Delete if resource timestamp is before the cutoff
+    if [ "$resource_timestamp" -lt "$BEFORE_TIMESTAMP" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Function to convert ISO 8601 datetime to Unix timestamp
+# Input: 2026-03-17T12:34:56.789Z
+# Output: Unix timestamp
+iso8601_to_timestamp() {
+    local iso_date="$1"
+    if [ -z "$iso_date" ]; then
+        echo "0"
+        return
+    fi
+
+    # Remove milliseconds and timezone for easier parsing
+    # 2026-03-17T12:34:56.789Z -> 2026-03-17T12:34:56
+    local clean_date=$(echo "$iso_date" | sed 's/\.[0-9]*Z$//' | sed 's/Z$//' | sed 's/\+.*//')
+
+    # Convert to timestamp
+    if date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_date" "+%s" >/dev/null 2>&1; then
+        # macOS
+        date -j -f "%Y-%m-%dT%H:%M:%S" "$clean_date" "+%s"
+    elif date -d "$clean_date" "+%s" >/dev/null 2>&1; then
+        # Linux
+        date -d "$clean_date" "+%s"
+    else
+        echo "0"
+    fi
+}
+
+# Get AWS account ID for ARN construction (once, outside region loop)
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+# Loop through each region and perform cleanup
+for REGION in "${REGIONS[@]}"; do
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "Processing region: $REGION"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+
+# 1. Delete EKS clusters
+if [ "$DRY_RUN" = false ]; then
+    echo "Step 1: Deleting EKS clusters in region $REGION..."
+else
+    echo "Step 1: Finding EKS clusters in region $REGION..."
+fi
+
+# Track if any clusters were deleted (to decide if we need to wait for resource release)
+CLUSTERS_DELETED=false
+
+# If specific cluster name provided, only process that cluster
+if [ -n "$CLUSTER_NAME" ]; then
+    # Check if cluster exists
+    if aws eks describe-cluster --region "$REGION" --name "$CLUSTER_NAME" &>/dev/null; then
+        cluster_arn="arn:aws:eks:$REGION:$ACCOUNT_ID:cluster/$CLUSTER_NAME"
+        tags=$(aws eks list-tags-for-resource --region "$REGION" --resource-arn "$cluster_arn" --query 'tags' --output json 2>/dev/null || echo "{}")
+        cluster_test_run_id=$(get_test_run_id "$tags")
+
+        # Store TestRunID for later cleanup of associated resources
+        TEST_RUN_ID="$cluster_test_run_id"
+
+        if [ "$DRY_RUN" = false ]; then
+            echo "Deleting EKS cluster: $CLUSTER_NAME"
+            [ -n "$cluster_test_run_id" ] && echo "  TestRunID: $cluster_test_run_id"
+            [ -n "$cluster_test_run_id" ] && echo "  Will also delete all resources with TestRunID: $cluster_test_run_id"
+
+            # Delete EBS CSI driver addon first (must be done before cluster deletion)
+            # The addon can orphan resources if the cluster is deleted first
+            echo "  Deleting EBS CSI driver addon for cluster $CLUSTER_NAME..."
+            aws eks delete-addon \
+                --cluster-name "$CLUSTER_NAME" \
+                --region "$REGION" \
+                --addon-name "aws-ebs-csi-driver" 2>/dev/null || echo "  EBS CSI addon does not exist or already deleted"
+
+            eksctl delete cluster --name "$CLUSTER_NAME" --region "$REGION" --force --disable-nodegroup-eviction --wait || true
+            CLUSTERS_DELETED=true
+        else
+            echo "[DRY RUN] Would delete EKS cluster: $CLUSTER_NAME"
+            [ -n "$cluster_test_run_id" ] && echo "  TestRunID: $cluster_test_run_id"
+            [ -n "$cluster_test_run_id" ] && echo "  Would also delete all resources with TestRunID: $cluster_test_run_id"
+        fi
+    else
+        echo "Cluster $CLUSTER_NAME not found in region $REGION"
+        exit 1
+    fi
+else
+    # Process all clusters matching pattern
+    clusters=$(aws eks list-clusters --region "$REGION" --query 'clusters' --output text)
+    for cluster in $clusters; do
+        if [[ $cluster == aws-chart-testing-* ]]; then
+            # Get cluster details including creation time
+            cluster_arn="arn:aws:eks:$REGION:$ACCOUNT_ID:cluster/$cluster"
+            cluster_info=$(aws eks describe-cluster --region "$REGION" --name "$cluster" --query 'cluster' --output json 2>/dev/null || echo "{}")
+            created_at=$(echo "$cluster_info" | jq -r '.createdAt // ""' 2>/dev/null || echo "")
+
+            tags=$(aws eks list-tags-for-resource --region "$REGION" --resource-arn "$cluster_arn" --query 'tags' --output json 2>/dev/null || echo "{}")
+            cluster_test_run_id=$(get_test_run_id "$tags")
+
+            # Check if this cluster matches our TestRunID filter
+            if [ -n "$TEST_RUN_ID" ] && [ "$cluster_test_run_id" != "$TEST_RUN_ID" ]; then
+                # Skip this cluster - doesn't match our TestRunID
+                continue
+            fi
+
+            # If --all mode and cluster has no TestRunID tag, check if it's a helm-charts-e2e cluster
+            if [ -z "$TEST_RUN_ID" ] && [ -z "$cluster_test_run_id" ]; then
+                # Check if cluster has ManagedBy=helm-charts-e2e tag
+                managed_by=$(echo "$tags" | jq -r '.ManagedBy // ""' 2>/dev/null || echo "")
+                if [ "$managed_by" != "helm-charts-e2e" ]; then
+                    # Skip - not a helm-charts-e2e cluster
+                    continue
+                fi
+            fi
+
+            # Check if cluster is old enough to delete (if --before-date specified)
+            if [ -n "$BEFORE_DATE" ]; then
+                cluster_timestamp=$(iso8601_to_timestamp "$created_at")
+                if ! is_resource_old_enough "$cluster_timestamp"; then
+                    if [ "$DRY_RUN" = false ]; then
+                        echo "Skipping EKS cluster (too new): $cluster (created: $created_at)"
+                    else
+                        echo "[DRY RUN] Would skip EKS cluster (too new): $cluster (created: $created_at)"
+                    fi
+                    continue
+                fi
+            fi
+
+            if [ "$DRY_RUN" = false ]; then
+                echo "Deleting EKS cluster: $cluster"
+                [ -n "$created_at" ] && echo "  Created: $created_at"
+                [ -n "$cluster_test_run_id" ] && echo "  TestRunID: $cluster_test_run_id"
+
+                # Delete EBS CSI driver addon first (must be done before cluster deletion)
+                # The addon can orphan resources if the cluster is deleted first
+                echo "  Deleting EBS CSI driver addon for cluster $cluster..."
+                aws eks delete-addon \
+                    --cluster-name "$cluster" \
+                    --region "$REGION" \
+                    --addon-name "aws-ebs-csi-driver" 2>/dev/null || echo "  EBS CSI addon does not exist or already deleted"
+
+                eksctl delete cluster --name "$cluster" --region "$REGION" --force --disable-nodegroup-eviction --wait || true
+                CLUSTERS_DELETED=true
+            else
+                echo "[DRY RUN] Would delete EKS cluster: $cluster"
+                [ -n "$created_at" ] && echo "  Created: $created_at"
+                [ -n "$cluster_test_run_id" ] && echo "  TestRunID: $cluster_test_run_id"
+            fi
+        fi
+    done
+fi
+
+# 1a. Delete OIDC providers
+# OIDC providers are created by EKS with --with-oidc flag but persist after cluster deletion.
+# They accumulate over time and can cause "already exists" errors.
+# OIDC providers don't have tags, so we identify them by:
+#   - ARN pattern: arn:aws:iam::ACCOUNT:oidc-provider/oidc.eks.REGION.amazonaws.com/id/XXXXXX
+#   - Checking if any existing cluster uses the provider (via OIDC issuer URL)
+#   - In --all mode: delete providers not in use by any cluster (orphaned)
+#   - In targeted mode: delete providers only if they belong to our specific cluster/test run
+if [ "$DRY_RUN" = false ]; then
+    echo "Step 1a: Deleting OIDC providers in region $REGION..."
+else
+    echo "Step 1a: Finding OIDC providers in region $REGION..."
+fi
+
+# Get all OIDC providers (global resource, but we filter by region)
+all_oidc_providers=$(aws iam list-open-id-connect-providers --query 'OpenIDConnectProviderList[].Arn' --output text 2>/dev/null || true)
+
+for provider_arn in $all_oidc_providers; do
+    # Check if this OIDC provider is for an EKS cluster
+    if [[ $provider_arn == *"oidc.eks."*".amazonaws.com"* ]]; then
+        # Extract the OIDC provider ID from the ARN (last part after /)
+        provider_id=$(echo "$provider_arn" | awk -F'/' '{print $NF}')
+
+        # Check if this provider belongs to a cluster in our region
+        # OIDC provider URL format: https://oidc.eks.REGION.amazonaws.com/id/XXXXXX
+        if [[ $provider_arn == *"oidc.eks.$REGION.amazonaws.com"* ]]; then
+            # Try to find if this OIDC provider is associated with our tagged clusters
+            should_delete=false
+
+            if [ -n "$TEST_RUN_ID" ] || [ -n "$CLUSTER_NAME" ]; then
+                # In targeted mode, check if OIDC provider matches our clusters
+                # Note: OIDC providers don't have tags, so we need to check cluster association
+                # This is a best-effort check - if cluster is already deleted, we can't verify
+                should_delete=false  # Conservative - only delete if we can verify
+
+                # Try to find a cluster that uses this OIDC provider
+                clusters=$(aws eks list-clusters --region "$REGION" --query 'clusters' --output text 2>/dev/null || true)
+                for cluster in $clusters; do
+                    cluster_oidc=$(aws eks describe-cluster \
+                        --region "$REGION" \
+                        --name "$cluster" \
+                        --query 'cluster.identity.oidc.issuer' \
+                        --output text 2>/dev/null || echo "")
+
+                    if [[ $cluster_oidc == *"$provider_id"* ]]; then
+                        # This OIDC provider belongs to an existing cluster
+                        # Check if the cluster matches our filter
+                        if [ -n "$CLUSTER_NAME" ] && [ "$cluster" = "$CLUSTER_NAME" ]; then
+                            should_delete=true
+                            break
+                        elif [ -n "$TEST_RUN_ID" ]; then
+                            cluster_arn="arn:aws:eks:$REGION:$ACCOUNT_ID:cluster/$cluster"
+                            tags=$(aws eks list-tags-for-resource --region "$REGION" --resource-arn "$cluster_arn" --query 'tags' --output json 2>/dev/null || echo "{}")
+                            cluster_test_run_id=$(get_test_run_id "$tags")
+                            if [ "$cluster_test_run_id" = "$TEST_RUN_ID" ]; then
+                                should_delete=true
+                                break
+                            fi
+                        fi
+                    fi
+                done
+            elif [ "$DELETE_ALL" = true ]; then
+                # In --all mode, check if any helm-charts-e2e cluster uses this provider
+                # If no cluster uses it, it's likely an orphaned provider from a deleted cluster
+                provider_in_use=false
+                clusters=$(aws eks list-clusters --region "$REGION" --query 'clusters' --output text 2>/dev/null || true)
+                for cluster in $clusters; do
+                    cluster_oidc=$(aws eks describe-cluster \
+                        --region "$REGION" \
+                        --name "$cluster" \
+                        --query 'cluster.identity.oidc.issuer' \
+                        --output text 2>/dev/null || echo "")
+
+                    if [[ $cluster_oidc == *"$provider_id"* ]]; then
+                        provider_in_use=true
+                        break
+                    fi
+                done
+
+                # If provider is not in use by any cluster, it's orphaned - delete it
+                if [ "$provider_in_use" = false ]; then
+                    should_delete=true
+                fi
+            fi
+
+            if [ "$should_delete" = true ]; then
+                if [ "$DRY_RUN" = false ]; then
+                    echo "Deleting OIDC provider: $provider_arn"
+                    aws iam delete-open-id-connect-provider --open-id-connect-provider-arn "$provider_arn" 2>/dev/null || true
+                else
+                    echo "[DRY RUN] Would delete OIDC provider: $provider_arn"
+                fi
+            fi
+        fi
+    fi
+done
+
+# 1b. Delete IAM roles for EBS CSI driver
+if [ "$DRY_RUN" = false ]; then
+    echo "Step 1b: Deleting IAM roles in region $REGION..."
+else
+    echo "Step 1b: Finding IAM roles in region $REGION..."
+fi
+
+if [ -n "$TEST_RUN_ID" ]; then
+    # Find IAM roles matching pattern ebs-csi-{region}-{testRunID}
+    role_name="ebs-csi-$REGION-$TEST_RUN_ID"
+
+    # Check if role exists
+    if aws iam get-role --role-name "$role_name" &>/dev/null; then
+        if [ "$DRY_RUN" = false ]; then
+            echo "Deleting IAM role: $role_name"
+
+            # Detach all attached policies
+            policies=$(aws iam list-attached-role-policies \
+                --role-name "$role_name" \
+                --query 'AttachedPolicies[].PolicyArn' \
+                --output text 2>/dev/null || true)
+
+            for policy_arn in $policies; do
+                [ -n "$policy_arn" ] && aws iam detach-role-policy \
+                    --role-name "$role_name" \
+                    --policy-arn "$policy_arn" 2>/dev/null || true
+            done
+
+            # Delete the role
+            aws iam delete-role --role-name "$role_name" 2>/dev/null || true
+        else
+            echo "[DRY RUN] Would delete IAM role: $role_name"
+        fi
+    else
+        echo "No IAM role found: $role_name"
+    fi
+else
+    # In --all mode, find all IAM roles with our tags
+    echo "Listing all IAM roles to find tagged roles (this may take a moment)..."
+    all_roles=$(aws iam list-roles --query 'Roles[?starts_with(RoleName, `ebs-csi-`)].RoleName' --output text 2>/dev/null || true)
+
+    for role_name in $all_roles; do
+        # Get role tags
+        tags=$(aws iam list-role-tags --role-name "$role_name" --query 'Tags' --output json 2>/dev/null || echo "[]")
+        managed_by=$(echo "$tags" | jq -r '.[] | select(.Key=="ManagedBy") | .Value' 2>/dev/null || echo "")
+
+        # Only delete if it has our ManagedBy tag
+        if [ "$managed_by" = "helm-charts-e2e" ]; then
+            role_test_run_id=$(echo "$tags" | jq -r '.[] | select(.Key=="TestRunID") | .Value' 2>/dev/null || echo "")
+
+            # Check if role is old enough to delete (if --before-date specified)
+            if [ -n "$BEFORE_DATE" ] && [ -n "$role_test_run_id" ]; then
+                resource_timestamp=$(get_timestamp_from_test_run_id "$role_test_run_id")
+                if ! is_resource_old_enough "$resource_timestamp"; then
+                    if [ "$DRY_RUN" = false ]; then
+                        echo "Skipping IAM role (too new): $role_name"
+                    else
+                        echo "[DRY RUN] Would skip IAM role (too new): $role_name"
+                    fi
+                    [ -n "$role_test_run_id" ] && echo "  TestRunID: $role_test_run_id"
+                    continue
+                fi
+            fi
+
+            if [ "$DRY_RUN" = false ]; then
+                echo "Deleting IAM role: $role_name"
+                [ -n "$role_test_run_id" ] && echo "  TestRunID: $role_test_run_id"
+
+                # Detach all attached policies
+                policies=$(aws iam list-attached-role-policies \
+                    --role-name "$role_name" \
+                    --query 'AttachedPolicies[].PolicyArn' \
+                    --output text 2>/dev/null || true)
+
+                for policy_arn in $policies; do
+                    [ -n "$policy_arn" ] && aws iam detach-role-policy \
+                        --role-name "$role_name" \
+                        --policy-arn "$policy_arn" 2>/dev/null || true
+                done
+
+                # Delete the role
+                aws iam delete-role --role-name "$role_name" 2>/dev/null || true
+            else
+                echo "[DRY RUN] Would delete IAM role: $role_name"
+                [ -n "$role_test_run_id" ] && echo "  TestRunID: $role_test_run_id"
+            fi
+        fi
+    done
+fi
+
+# 2. Delete CloudFormation stacks (in case eksctl failed)
+if [ "$DRY_RUN" = false ]; then
+    echo "Step 2: Deleting CloudFormation stacks in region $REGION..."
+else
+    echo "Step 2: Finding CloudFormation stacks in region $REGION..."
+fi
+
+# If specific cluster name was provided, look for stacks for that cluster specifically
+if [ -n "$CLUSTER_NAME" ]; then
+    # Find stacks for the specific cluster
+    stacks=$(aws cloudformation list-stacks \
+        --region "$REGION" \
+        --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE ROLLBACK_COMPLETE \
+        --query "StackSummaries[?starts_with(StackName, \`eksctl-$CLUSTER_NAME\`)].StackName" \
+        --output text)
+else
+    # Find all matching stacks
+    stacks=$(aws cloudformation list-stacks \
+        --region "$REGION" \
+        --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE ROLLBACK_COMPLETE \
+        --query 'StackSummaries[?starts_with(StackName, `eksctl-aws-chart-testing`)].StackName' \
+        --output text)
+fi
+
+for stack in $stacks; do
+    # Get stack details including creation time and tags
+    stack_info=$(aws cloudformation describe-stacks --region "$REGION" --stack-name "$stack" --query 'Stacks[0]' --output json 2>/dev/null || echo "{}")
+    tags=$(echo "$stack_info" | jq -r '.Tags // []' 2>/dev/null || echo "[]")
+    created_time=$(echo "$stack_info" | jq -r '.CreationTime // ""' 2>/dev/null || echo "")
+    stack_test_run_id=$(get_test_run_id "$tags")
+
+    # Check if this stack matches our TestRunID filter
+    if [ -n "$TEST_RUN_ID" ] && [ "$stack_test_run_id" != "$TEST_RUN_ID" ]; then
+        # Skip this stack - doesn't match our TestRunID
+        continue
+    fi
+
+    # If --all mode and stack has no TestRunID tag, check if it's a helm-charts-e2e stack
+    if [ -z "$TEST_RUN_ID" ] && [ -z "$CLUSTER_NAME" ] && [ -z "$stack_test_run_id" ]; then
+        # Check if stack has ManagedBy=helm-charts-e2e tag
+        managed_by=$(echo "$tags" | jq -r '.[] | select(.Key=="ManagedBy") | .Value' 2>/dev/null || echo "")
+        if [ "$managed_by" != "helm-charts-e2e" ]; then
+            # Skip - not a helm-charts-e2e stack
+            continue
+        fi
+    fi
+
+    # Check if stack is old enough to delete (if --before-date specified)
+    if [ -n "$BEFORE_DATE" ]; then
+        stack_timestamp=$(iso8601_to_timestamp "$created_time")
+        if ! is_resource_old_enough "$stack_timestamp"; then
+            if [ "$DRY_RUN" = false ]; then
+                echo "Skipping CloudFormation stack (too new): $stack (created: $created_time)"
+            else
+                echo "[DRY RUN] Would skip CloudFormation stack (too new): $stack (created: $created_time)"
+            fi
+            continue
+        fi
+    fi
+
+    if [ "$DRY_RUN" = false ]; then
+        echo "Processing stack: $stack"
+        [ -n "$created_time" ] && echo "  Created: $created_time"
+        [ -n "$stack_test_run_id" ] && echo "  TestRunID: $stack_test_run_id"
+        # Disable termination protection
+        aws cloudformation update-termination-protection \
+            --region "$REGION" \
+            --stack-name "$stack" \
+            --no-enable-termination-protection 2>/dev/null || true
+        # Delete stack
+        aws cloudformation delete-stack \
+            --region "$REGION" \
+            --stack-name "$stack" 2>/dev/null || true
+    else
+        echo "[DRY RUN] Would delete CloudFormation stack: $stack"
+        [ -n "$created_time" ] && echo "  Created: $created_time"
+        [ -n "$stack_test_run_id" ] && echo "  TestRunID: $stack_test_run_id"
+    fi
+done
+
+# Wait a bit for resources to be released (only if clusters were actually deleted)
+if [ "$DRY_RUN" = false ] && [ "$CLUSTERS_DELETED" = true ]; then
+    echo "Waiting for cluster resources to be released..."
+    sleep 30
+fi
+
+# 3. Delete Security Groups (retry needed due to dependencies)
+if [ "$DRY_RUN" = false ]; then
+    echo "Step 3: Deleting Security Groups in region $REGION..."
+else
+    echo "Step 3: Finding Security Groups in region $REGION..."
+fi
+for i in {1..3}; do
+    if [ -n "$TEST_RUN_ID" ]; then
+        sgs=$(aws ec2 describe-security-groups \
+            --region "$REGION" \
+            --filters "Name=tag:$TAG_KEY,Values=$TAG_VALUE" "Name=tag:TestRunID,Values=$TEST_RUN_ID" \
+            --query 'SecurityGroups[].GroupId' \
+            --output text)
+    else
+        sgs=$(aws ec2 describe-security-groups \
+            --region "$REGION" \
+            --filters "Name=tag:$TAG_KEY,Values=$TAG_VALUE" \
+            --query 'SecurityGroups[].GroupId' \
+            --output text)
+    fi
+
+    if [ -z "$sgs" ]; then
+        echo "No security groups found"
+        break
+    fi
+
+    for sg in $sgs; do
+        # Get security group tags
+        tags=$(aws ec2 describe-security-groups --region "$REGION" --group-ids "$sg" --query 'SecurityGroups[0].Tags' --output json 2>/dev/null || echo "[]")
+        test_run_id=$(get_test_run_id "$tags")
+
+        # Check if resource is old enough to delete (if --before-date specified)
+        if [ -n "$BEFORE_DATE" ]; then
+            resource_timestamp=$(get_timestamp_from_test_run_id "$test_run_id")
+            if ! is_resource_old_enough "$resource_timestamp"; then
+                continue
+            fi
+        fi
+
+        if [ "$DRY_RUN" = false ]; then
+            echo "Attempt $i: Deleting security group $sg"
+            [ -n "$test_run_id" ] && echo "  TestRunID: $test_run_id"
+            aws ec2 delete-security-group --region "$REGION" --group-id "$sg" 2>/dev/null || true
+        else
+            echo "[DRY RUN] Would delete security group: $sg"
+            [ -n "$test_run_id" ] && echo "  TestRunID: $test_run_id"
+        fi
+    done
+
+    if [ "$DRY_RUN" = false ] && [ $i -lt 3 ]; then
+        echo "Waiting 10s before retry..."
+        sleep 10
+    fi
+
+    # Only retry once in dry-run mode
+    if [ "$DRY_RUN" = true ]; then
+        break
+    fi
+done
+
+# 4. Delete Subnets
+if [ "$DRY_RUN" = false ]; then
+    echo "Step 4: Deleting Subnets in region $REGION..."
+else
+    echo "Step 4: Finding Subnets in region $REGION..."
+fi
+if [ -n "$TEST_RUN_ID" ]; then
+    subnets=$(aws ec2 describe-subnets \
+        --region "$REGION" \
+        --filters "Name=tag:$TAG_KEY,Values=$TAG_VALUE" "Name=tag:TestRunID,Values=$TEST_RUN_ID" \
+        --query 'Subnets[].SubnetId' \
+        --output text)
+else
+    subnets=$(aws ec2 describe-subnets \
+        --region "$REGION" \
+        --filters "Name=tag:$TAG_KEY,Values=$TAG_VALUE" \
+        --query 'Subnets[].SubnetId' \
+        --output text)
+fi
+
+for subnet in $subnets; do
+    # Get subnet tags
+    tags=$(aws ec2 describe-subnets --region "$REGION" --subnet-ids "$subnet" --query 'Subnets[0].Tags' --output json 2>/dev/null || echo "[]")
+    test_run_id=$(get_test_run_id "$tags")
+
+    # Check if resource is old enough to delete (if --before-date specified)
+    if [ -n "$BEFORE_DATE" ]; then
+        resource_timestamp=$(get_timestamp_from_test_run_id "$test_run_id")
+        if ! is_resource_old_enough "$resource_timestamp"; then
+            if [ "$DRY_RUN" = false ]; then
+                echo "Skipping subnet (too new): $subnet"
+            else
+                echo "[DRY RUN] Would skip subnet (too new): $subnet"
+            fi
+            [ -n "$test_run_id" ] && echo "  TestRunID: $test_run_id"
+            continue
+        fi
+    fi
+
+    if [ "$DRY_RUN" = false ]; then
+        echo "Deleting subnet: $subnet"
+        [ -n "$test_run_id" ] && echo "  TestRunID: $test_run_id"
+        aws ec2 delete-subnet --region "$REGION" --subnet-id "$subnet" 2>/dev/null || true
+    else
+        echo "[DRY RUN] Would delete subnet: $subnet"
+        [ -n "$test_run_id" ] && echo "  TestRunID: $test_run_id"
+    fi
+done
+
+# 5. Delete Route Tables
+if [ "$DRY_RUN" = false ]; then
+    echo "Step 5: Deleting Route Tables in region $REGION..."
+else
+    echo "Step 5: Finding Route Tables in region $REGION..."
+fi
+if [ -n "$TEST_RUN_ID" ]; then
+    rtbs=$(aws ec2 describe-route-tables \
+        --region "$REGION" \
+        --filters "Name=tag:$TAG_KEY,Values=$TAG_VALUE" "Name=tag:TestRunID,Values=$TEST_RUN_ID" \
+        --query 'RouteTables[].RouteTableId' \
+        --output text)
+else
+    rtbs=$(aws ec2 describe-route-tables \
+        --region "$REGION" \
+        --filters "Name=tag:$TAG_KEY,Values=$TAG_VALUE" \
+        --query 'RouteTables[].RouteTableId' \
+        --output text)
+fi
+
+for rtb in $rtbs; do
+    # Get route table tags
+    tags=$(aws ec2 describe-route-tables --region "$REGION" --route-table-ids "$rtb" --query 'RouteTables[0].Tags' --output json 2>/dev/null || echo "[]")
+    test_run_id=$(get_test_run_id "$tags")
+
+    # Check if resource is old enough to delete (if --before-date specified)
+    if [ -n "$BEFORE_DATE" ]; then
+        resource_timestamp=$(get_timestamp_from_test_run_id "$test_run_id")
+        if ! is_resource_old_enough "$resource_timestamp"; then
+            continue
+        fi
+    fi
+
+    if [ "$DRY_RUN" = false ]; then
+        echo "Deleting route table: $rtb"
+        [ -n "$test_run_id" ] && echo "  TestRunID: $test_run_id"
+        # First disassociate from subnets
+        associations=$(aws ec2 describe-route-tables \
+            --region "$REGION" \
+            --route-table-ids "$rtb" \
+            --query 'RouteTables[].Associations[?SubnetId!=`null`].RouteTableAssociationId' \
+            --output text)
+
+        for assoc in $associations; do
+            aws ec2 disassociate-route-table --region "$REGION" --association-id "$assoc" 2>/dev/null || true
+        done
+
+        aws ec2 delete-route-table --region "$REGION" --route-table-id "$rtb" 2>/dev/null || true
+    else
+        echo "[DRY RUN] Would delete route table: $rtb"
+        [ -n "$test_run_id" ] && echo "  TestRunID: $test_run_id"
+    fi
+done
+
+# 6. Delete Internet Gateways
+if [ "$DRY_RUN" = false ]; then
+    echo "Step 6: Deleting Internet Gateways in region $REGION..."
+else
+    echo "Step 6: Finding Internet Gateways in region $REGION..."
+fi
+if [ -n "$TEST_RUN_ID" ]; then
+    igws=$(aws ec2 describe-internet-gateways \
+        --region "$REGION" \
+        --filters "Name=tag:$TAG_KEY,Values=$TAG_VALUE" "Name=tag:TestRunID,Values=$TEST_RUN_ID" \
+        --query 'InternetGateways[].InternetGatewayId' \
+        --output text)
+else
+    igws=$(aws ec2 describe-internet-gateways \
+        --region "$REGION" \
+        --filters "Name=tag:$TAG_KEY,Values=$TAG_VALUE" \
+        --query 'InternetGateways[].InternetGatewayId' \
+        --output text)
+fi
+
+for igw in $igws; do
+    # Get internet gateway tags
+    tags=$(aws ec2 describe-internet-gateways --region "$REGION" --internet-gateway-ids "$igw" --query 'InternetGateways[0].Tags' --output json 2>/dev/null || echo "[]")
+    test_run_id=$(get_test_run_id "$tags")
+
+    # Check if resource is old enough to delete (if --before-date specified)
+    if [ -n "$BEFORE_DATE" ]; then
+        resource_timestamp=$(get_timestamp_from_test_run_id "$test_run_id")
+        if ! is_resource_old_enough "$resource_timestamp"; then
+            continue
+        fi
+    fi
+
+    if [ "$DRY_RUN" = false ]; then
+        echo "Deleting internet gateway: $igw"
+        [ -n "$test_run_id" ] && echo "  TestRunID: $test_run_id"
+        # First detach from VPCs
+        vpcs=$(aws ec2 describe-internet-gateways \
+            --region "$REGION" \
+            --internet-gateway-ids "$igw" \
+            --query 'InternetGateways[].Attachments[].VpcId' \
+            --output text)
+
+        for vpc in $vpcs; do
+            aws ec2 detach-internet-gateway --region "$REGION" --internet-gateway-id "$igw" --vpc-id "$vpc" 2>/dev/null || true
+        done
+
+        aws ec2 delete-internet-gateway --region "$REGION" --internet-gateway-id "$igw" 2>/dev/null || true
+    else
+        echo "[DRY RUN] Would delete internet gateway: $igw"
+        [ -n "$test_run_id" ] && echo "  TestRunID: $test_run_id"
+    fi
+done
+
+# 6a. Delete Load Balancers (created by Kubernetes services)
+if [ "$DRY_RUN" = false ]; then
+    echo "Step 6a: Deleting Load Balancers in region $REGION..."
+else
+    echo "Step 6a: Finding Load Balancers in region $REGION..."
+fi
+
+# Get VPCs to find their load balancers
+if [ -n "$TEST_RUN_ID" ]; then
+    vpc_ids=$(aws ec2 describe-vpcs \
+        --region "$REGION" \
+        --filters "Name=tag:$TAG_KEY,Values=$TAG_VALUE" "Name=tag:TestRunID,Values=$TEST_RUN_ID" \
+        --query 'Vpcs[].VpcId' \
+        --output text)
+else
+    vpc_ids=$(aws ec2 describe-vpcs \
+        --region "$REGION" \
+        --filters "Name=tag:$TAG_KEY,Values=$TAG_VALUE" \
+        --query 'Vpcs[].VpcId' \
+        --output text)
+fi
+
+for vpc_id in $vpc_ids; do
+    # Find ELBv2 load balancers (ALB/NLB) in this VPC
+    lbs=$(aws elbv2 describe-load-balancers \
+        --region "$REGION" \
+        --query "LoadBalancers[?VpcId=='$vpc_id'].LoadBalancerArn" \
+        --output text 2>/dev/null || true)
+
+    for lb_arn in $lbs; do
+        lb_name=$(echo "$lb_arn" | awk -F'/' '{print $3"/"$4}')
+        if [ "$DRY_RUN" = false ]; then
+            echo "Deleting ELBv2 load balancer: $lb_name (VPC: $vpc_id)"
+            aws elbv2 delete-load-balancer --region "$REGION" --load-balancer-arn "$lb_arn" 2>/dev/null || true
+        else
+            echo "[DRY RUN] Would delete ELBv2 load balancer: $lb_name (VPC: $vpc_id)"
+        fi
+    done
+
+    # Find classic load balancers in this VPC
+    classic_lbs=$(aws elb describe-load-balancers \
+        --region "$REGION" \
+        --query "LoadBalancerDescriptions[?VPCId=='$vpc_id'].LoadBalancerName" \
+        --output text 2>/dev/null || true)
+
+    for lb_name in $classic_lbs; do
+        if [ "$DRY_RUN" = false ]; then
+            echo "Deleting classic load balancer: $lb_name (VPC: $vpc_id)"
+            aws elb delete-load-balancer --region "$REGION" --load-balancer-name "$lb_name" 2>/dev/null || true
+        else
+            echo "[DRY RUN] Would delete classic load balancer: $lb_name (VPC: $vpc_id)"
+        fi
+    done
+done
+
+# Wait for load balancers to be deleted
+if [ "$DRY_RUN" = false ] && [ -n "$vpc_ids" ]; then
+    echo "Waiting for load balancers to be deleted..."
+    sleep 20
+fi
+
+# 6b. Delete NAT Gateways
+if [ "$DRY_RUN" = false ]; then
+    echo "Step 6b: Deleting NAT Gateways in region $REGION..."
+else
+    echo "Step 6b: Finding NAT Gateways in region $REGION..."
+fi
+
+for vpc_id in $vpc_ids; do
+    nat_gws=$(aws ec2 describe-nat-gateways \
+        --region "$REGION" \
+        --filter "Name=vpc-id,Values=$vpc_id" "Name=state,Values=available,pending" \
+        --query 'NatGateways[].NatGatewayId' \
+        --output text 2>/dev/null || true)
+
+    for nat_gw in $nat_gws; do
+        if [ "$DRY_RUN" = false ]; then
+            echo "Deleting NAT Gateway: $nat_gw (VPC: $vpc_id)"
+            aws ec2 delete-nat-gateway --region "$REGION" --nat-gateway-id "$nat_gw" 2>/dev/null || true
+        else
+            echo "[DRY RUN] Would delete NAT Gateway: $nat_gw (VPC: $vpc_id)"
+        fi
+    done
+done
+
+# Wait for NAT gateways to be deleted
+if [ "$DRY_RUN" = false ] && [ -n "$vpc_ids" ]; then
+    echo "Waiting for NAT gateways to be deleted..."
+    sleep 30
+fi
+
+# 6c. Delete Network Interfaces (ENIs)
+if [ "$DRY_RUN" = false ]; then
+    echo "Step 6c: Deleting Network Interfaces in region $REGION..."
+else
+    echo "Step 6c: Finding Network Interfaces in region $REGION..."
+fi
+
+for vpc_id in $vpc_ids; do
+    enis=$(aws ec2 describe-network-interfaces \
+        --region "$REGION" \
+        --filters "Name=vpc-id,Values=$vpc_id" \
+        --query 'NetworkInterfaces[?Status==`available`].NetworkInterfaceId' \
+        --output text 2>/dev/null || true)
+
+    for eni in $enis; do
+        if [ "$DRY_RUN" = false ]; then
+            echo "Deleting network interface: $eni (VPC: $vpc_id)"
+            aws ec2 delete-network-interface --region "$REGION" --network-interface-id "$eni" 2>/dev/null || true
+        else
+            echo "[DRY RUN] Would delete network interface: $eni (VPC: $vpc_id)"
+        fi
+    done
+done
+
+# 6d. Release Elastic IPs
+if [ "$DRY_RUN" = false ]; then
+    echo "Step 6d: Releasing Elastic IPs in region $REGION..."
+else
+    echo "Step 6d: Finding Elastic IPs in region $REGION..."
+fi
+
+if [ -n "$TEST_RUN_ID" ]; then
+    eips=$(aws ec2 describe-addresses \
+        --region "$REGION" \
+        --filters "Name=tag:$TAG_KEY,Values=$TAG_VALUE" "Name=tag:TestRunID,Values=$TEST_RUN_ID" \
+        --query 'Addresses[].AllocationId' \
+        --output text 2>/dev/null || true)
+else
+    # In --all mode, ONLY delete EIPs explicitly tagged as managed by helm-charts-e2e
+    # Never delete untagged EIPs as they may belong to other resources in the account
+    eips=$(aws ec2 describe-addresses \
+        --region "$REGION" \
+        --filters "Name=tag:$TAG_KEY,Values=$TAG_VALUE" \
+        --query 'Addresses[].AllocationId' \
+        --output text 2>/dev/null || true)
+fi
+
+for eip in $eips; do
+    # Get EIP tags if available
+    tags=$(aws ec2 describe-addresses --region "$REGION" --allocation-ids "$eip" --query 'Addresses[0].Tags' --output json 2>/dev/null || echo "[]")
+    test_run_id=$(get_test_run_id "$tags")
+
+    # Check if resource is old enough to delete (if --before-date specified)
+    if [ -n "$BEFORE_DATE" ] && [ -n "$test_run_id" ]; then
+        resource_timestamp=$(get_timestamp_from_test_run_id "$test_run_id")
+        if ! is_resource_old_enough "$resource_timestamp"; then
+            continue
+        fi
+    fi
+
+    if [ "$DRY_RUN" = false ]; then
+        echo "Releasing Elastic IP: $eip"
+        [ -n "$test_run_id" ] && echo "  TestRunID: $test_run_id"
+        aws ec2 release-address --region "$REGION" --allocation-id "$eip" 2>/dev/null || true
+    else
+        echo "[DRY RUN] Would release Elastic IP: $eip"
+        [ -n "$test_run_id" ] && echo "  TestRunID: $test_run_id"
+    fi
+done
+
+# 6e. Delete VPC Endpoints
+if [ "$DRY_RUN" = false ]; then
+    echo "Step 6e: Deleting VPC Endpoints in region $REGION..."
+else
+    echo "Step 6e: Finding VPC Endpoints in region $REGION..."
+fi
+
+for vpc_id in $vpc_ids; do
+    vpc_endpoints=$(aws ec2 describe-vpc-endpoints \
+        --region "$REGION" \
+        --filters "Name=vpc-id,Values=$vpc_id" \
+        --query 'VpcEndpoints[].VpcEndpointId' \
+        --output text 2>/dev/null || true)
+
+    for endpoint in $vpc_endpoints; do
+        if [ "$DRY_RUN" = false ]; then
+            echo "Deleting VPC endpoint: $endpoint (VPC: $vpc_id)"
+            aws ec2 delete-vpc-endpoints --region "$REGION" --vpc-endpoint-ids "$endpoint" 2>&1 | grep -v "does not exist" || true
+        else
+            echo "[DRY RUN] Would delete VPC endpoint: $endpoint (VPC: $vpc_id)"
+        fi
+    done
+done
+
+# 6f. Revoke Security Group Rules (required before VPC deletion)
+if [ "$DRY_RUN" = false ]; then
+    echo "Step 6f: Revoking Security Group Rules in region $REGION..."
+else
+    echo "Step 6f: Finding Security Group Rules in region $REGION..."
+fi
+
+for vpc_id in $vpc_ids; do
+    sgs=$(aws ec2 describe-security-groups \
+        --region "$REGION" \
+        --filters "Name=vpc-id,Values=$vpc_id" \
+        --query 'SecurityGroups[].GroupId' \
+        --output text 2>/dev/null || true)
+
+    for sg in $sgs; do
+        if [ "$DRY_RUN" = false ]; then
+            echo "Revoking rules for security group: $sg (VPC: $vpc_id)"
+
+            # Revoke ingress rules
+            ingress_rules=$(aws ec2 describe-security-groups \
+                --region "$REGION" \
+                --group-ids "$sg" \
+                --query 'SecurityGroups[0].IpPermissions' \
+                --output json 2>/dev/null)
+
+            if [ "$ingress_rules" != "[]" ] && [ "$ingress_rules" != "null" ] && [ -n "$ingress_rules" ]; then
+                echo "  Revoking ingress rules..."
+                aws ec2 revoke-security-group-ingress \
+                    --region "$REGION" \
+                    --group-id "$sg" \
+                    --ip-permissions "$ingress_rules" 2>&1 | grep -v "does not exist" || true
+            fi
+
+            # Revoke egress rules (except for VPC default SG, keep one egress rule)
+            sg_name=$(aws ec2 describe-security-groups \
+                --region "$REGION" \
+                --group-ids "$sg" \
+                --query 'SecurityGroups[0].GroupName' \
+                --output text 2>/dev/null)
+
+            if [ "$sg_name" != "default" ]; then
+                egress_rules=$(aws ec2 describe-security-groups \
+                    --region "$REGION" \
+                    --group-ids "$sg" \
+                    --query 'SecurityGroups[0].IpPermissionsEgress' \
+                    --output json 2>/dev/null)
+
+                if [ "$egress_rules" != "[]" ] && [ "$egress_rules" != "null" ] && [ -n "$egress_rules" ]; then
+                    echo "  Revoking egress rules..."
+                    aws ec2 revoke-security-group-egress \
+                        --region "$REGION" \
+                        --group-id "$sg" \
+                        --ip-permissions "$egress_rules" 2>&1 | grep -v "does not exist" || true
+                fi
+            fi
+        else
+            echo "[DRY RUN] Would revoke rules for security group: $sg (VPC: $vpc_id)"
+        fi
+    done
+done
+
+# Wait a bit more for all dependencies to clear
+if [ "$DRY_RUN" = false ] && [ -n "$vpc_ids" ]; then
+    echo "Waiting for VPC dependencies to be fully cleared..."
+    sleep 15
+fi
+
+# 6g. Delete VPC Peering Connections (must be before VPC deletion)
+if [ "$DRY_RUN" = false ]; then
+    echo "Step 6g: Deleting VPC Peering Connections in region $REGION..."
+else
+    echo "Step 6g: Finding VPC Peering Connections in region $REGION..."
+fi
+
+if [ -n "$TEST_RUN_ID" ]; then
+    peering_conns=$(aws ec2 describe-vpc-peering-connections \
+        --region "$REGION" \
+        --filters "Name=tag:$TAG_KEY,Values=$TAG_VALUE" "Name=tag:TestRunID,Values=$TEST_RUN_ID" \
+        --query 'VpcPeeringConnections[].VpcPeeringConnectionId' \
+        --output text 2>/dev/null || true)
+else
+    peering_conns=$(aws ec2 describe-vpc-peering-connections \
+        --region "$REGION" \
+        --filters "Name=tag:$TAG_KEY,Values=$TAG_VALUE" \
+        --query 'VpcPeeringConnections[].VpcPeeringConnectionId' \
+        --output text 2>/dev/null || true)
+fi
+
+for peering_conn in $peering_conns; do
+    # Get VPC peering connection tags
+    tags=$(aws ec2 describe-vpc-peering-connections --region "$REGION" --vpc-peering-connection-ids "$peering_conn" --query 'VpcPeeringConnections[0].Tags' --output json 2>/dev/null || echo "[]")
+    test_run_id=$(get_test_run_id "$tags")
+
+    # Check if resource is old enough to delete (if --before-date specified)
+    if [ -n "$BEFORE_DATE" ]; then
+        resource_timestamp=$(get_timestamp_from_test_run_id "$test_run_id")
+        if ! is_resource_old_enough "$resource_timestamp"; then
+            if [ "$DRY_RUN" = false ]; then
+                echo "Skipping VPC peering connection (too new): $peering_conn"
+            else
+                echo "[DRY RUN] Would skip VPC peering connection (too new): $peering_conn"
+            fi
+            [ -n "$test_run_id" ] && echo "  TestRunID: $test_run_id"
+            continue
+        fi
+    fi
+
+    if [ "$DRY_RUN" = false ]; then
+        echo "Deleting VPC peering connection: $peering_conn"
+        [ -n "$test_run_id" ] && echo "  TestRunID: $test_run_id"
+        aws ec2 delete-vpc-peering-connection --region "$REGION" --vpc-peering-connection-id "$peering_conn" 2>/dev/null || true
+    else
+        echo "[DRY RUN] Would delete VPC peering connection: $peering_conn"
+        [ -n "$test_run_id" ] && echo "  TestRunID: $test_run_id"
+    fi
+done
+
+# 7. Delete VPCs (retry needed)
+if [ "$DRY_RUN" = false ]; then
+    echo "Step 7: Deleting VPCs in region $REGION..."
+else
+    echo "Step 7: Finding VPCs in region $REGION..."
+fi
+for i in {1..3}; do
+    if [ -n "$TEST_RUN_ID" ]; then
+        vpcs=$(aws ec2 describe-vpcs \
+            --region "$REGION" \
+            --filters "Name=tag:$TAG_KEY,Values=$TAG_VALUE" "Name=tag:TestRunID,Values=$TEST_RUN_ID" \
+            --query 'Vpcs[].VpcId' \
+            --output text)
+    else
+        vpcs=$(aws ec2 describe-vpcs \
+            --region "$REGION" \
+            --filters "Name=tag:$TAG_KEY,Values=$TAG_VALUE" \
+            --query 'Vpcs[].VpcId' \
+            --output text)
+    fi
+
+    if [ -z "$vpcs" ]; then
+        echo "No VPCs found"
+        break
+    fi
+
+    for vpc in $vpcs; do
+        # Get VPC tags
+        tags=$(aws ec2 describe-vpcs --region "$REGION" --vpc-ids "$vpc" --query 'Vpcs[0].Tags' --output json 2>/dev/null || echo "[]")
+        test_run_id=$(get_test_run_id "$tags")
+
+        # Check if resource is old enough to delete (if --before-date specified)
+        if [ -n "$BEFORE_DATE" ]; then
+            resource_timestamp=$(get_timestamp_from_test_run_id "$test_run_id")
+            if ! is_resource_old_enough "$resource_timestamp"; then
+                if [ "$DRY_RUN" = false ]; then
+                    echo "Skipping VPC (too new): $vpc"
+                else
+                    echo "[DRY RUN] Would skip VPC (too new): $vpc"
+                fi
+                [ -n "$test_run_id" ] && echo "  TestRunID: $test_run_id"
+                continue
+            fi
+        fi
+
+        if [ "$DRY_RUN" = false ]; then
+            echo "Attempt $i: Deleting VPC $vpc"
+            [ -n "$test_run_id" ] && echo "  TestRunID: $test_run_id"
+            if ! aws ec2 delete-vpc --region "$REGION" --vpc-id "$vpc" 2>&1; then
+                echo "  Warning: Failed to delete VPC $vpc (may have dependencies still clearing)"
+            fi
+        else
+            echo "[DRY RUN] Would delete VPC: $vpc"
+            [ -n "$test_run_id" ] && echo "  TestRunID: $test_run_id"
+        fi
+    done
+
+    if [ "$DRY_RUN" = false ] && [ $i -lt 3 ]; then
+        echo "Waiting 15s before retry..."
+        sleep 15
+    fi
+
+    # Only retry once in dry-run mode
+    if [ "$DRY_RUN" = true ]; then
+        break
+    fi
+done
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Completed cleanup for region: $REGION"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+done  # End of region loop
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if [ "$DRY_RUN" = false ]; then
+    echo "✅ Cleanup complete for all regions: ${REGIONS[*]}"
+    if [ -n "$BEFORE_DATE" ]; then
+        echo "Deleted resources created before $BEFORE_DATE"
+    fi
+    echo "Note: Some resources may still be deleting in the background"
+    echo "Check CloudFormation console to verify all stacks are deleted"
+else
+    echo "🔍 DRY RUN COMPLETE - No resources were deleted"
+    echo "Processed regions: ${REGIONS[*]}"
+    if [ -n "$BEFORE_DATE" ]; then
+        echo "Resources shown were created before $BEFORE_DATE"
+    fi
+    echo "To actually delete these resources, run the same command without --dry-run"
+fi
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/tests/e2e/operator/infra/common.go
+++ b/tests/e2e/operator/infra/common.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
-	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
 )
 
 // Provider types.
@@ -21,6 +22,7 @@ const (
 	ProviderK3D  = "k3d"
 	ProviderKind = "kind"
 	ProviderGCP  = "gcp"
+	ProviderAWS  = "aws"
 )
 
 // Common constants.
@@ -53,6 +55,7 @@ var RegionCodes = map[string][]string{
 	ProviderK3D:  {"us-east1", "us-east2"},
 	ProviderKind: {"us-east1", "us-east2"},
 	ProviderGCP:  {"us-central1", "us-east1"},
+	ProviderAWS:  {"us-east-1", "us-east-2"},
 }
 
 // LoadBalancerAnnotations contains provider-specific service annotations.
@@ -61,6 +64,10 @@ var LoadBalancerAnnotations = map[string]map[string]string{
 		"networking.gke.io/internal-load-balancer-allow-global-access": "true",
 		"networking.gke.io/load-balancer-type":                         "Internal",
 		"cloud.google.com/load-balancer-type":                          "Internal",
+	},
+	ProviderAWS: {
+		"service.beta.kubernetes.io/aws-load-balancer-type":     "nlb",
+		"service.beta.kubernetes.io/aws-load-balancer-internal": "true",
 	},
 	ProviderK3D:  {},
 	ProviderKind: {},
@@ -86,6 +93,23 @@ var NetworkConfigs = map[string]map[string]interface{}{
 			"ServiceCIDR": "172.28.81.0/24",
 			"SubnetRange": "172.28.80.0/24",
 			"StaticIP":    "172.28.80.11",
+		},
+	},
+	ProviderAWS: {
+		"us-east-1": map[string]interface{}{
+			"ClusterCIDR":  "172.28.96.0/20",
+			"ServiceCIDR":  "172.28.113.0/24",
+			"SubnetRanges": []string{"172.28.112.0/26", "172.28.112.64/26"},
+		},
+		"us-east-2": map[string]interface{}{
+			"ClusterCIDR":  "172.28.128.0/20",
+			"ServiceCIDR":  "172.28.145.0/24",
+			"SubnetRanges": []string{"172.28.144.0/26", "172.28.144.64/26"},
+		},
+		"us-west-2": map[string]interface{}{
+			"ClusterCIDR":  "172.28.160.0/20",
+			"ServiceCIDR":  "172.28.177.0/24",
+			"SubnetRanges": []string{"172.28.176.0/26", "172.28.176.64/26"},
 		},
 	},
 }
@@ -130,7 +154,14 @@ func GetLoadBalancerAnnotations(providerType string) map[string]string {
 }
 
 // DeployCoreDNS deploys CoreDNS to a cluster.
-func DeployCoreDNS(t *testing.T, clusterName, kubeConfigPath string, staticIP *string, provider string, customDomain string, options map[string]coredns.CoreDNSClusterOption) error {
+func DeployCoreDNS(
+	t *testing.T,
+	clusterName, kubeConfigPath string,
+	staticIP *string,
+	provider string,
+	customDomain string,
+	options map[string]coredns.CoreDNSClusterOption,
+) error {
 	kubectlOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, coreDNSNamespace)
 
 	// Deploy CoreDNS resources in order.
@@ -148,7 +179,12 @@ func DeployCoreDNS(t *testing.T, clusterName, kubeConfigPath string, staticIP *s
 }
 
 // deployCoreDNSResources deploys the core CoreDNS resources (ConfigMap, RBAC, Deployment)
-func deployCoreDNSResources(t *testing.T, kubectlOpts *k8s.KubectlOptions, customDomain string, options map[string]coredns.CoreDNSClusterOption) error {
+func deployCoreDNSResources(
+	t *testing.T,
+	kubectlOpts *k8s.KubectlOptions,
+	customDomain string,
+	options map[string]coredns.CoreDNSClusterOption,
+) error {
 	// 1. Deploy ConfigMap
 	cm := coredns.CoreDNSConfigMap(customDomain, options)
 	cmYAML := coredns.ToYAML(t, cm)
@@ -201,7 +237,9 @@ func deployCoreDNSRBAC(t *testing.T, kubectlOpts *k8s.KubectlOptions) error {
 }
 
 // deployCoreDNSService creates and applies the CoreDNS service
-func deployCoreDNSService(t *testing.T, kubectlOpts *k8s.KubectlOptions, staticIP *string, provider string) error {
+func deployCoreDNSService(
+	t *testing.T, kubectlOpts *k8s.KubectlOptions, staticIP *string, provider string,
+) error {
 	// Get provider-specific annotations.
 	annotations := GetLoadBalancerAnnotations(provider)
 

--- a/tests/e2e/operator/infra/gcp.go
+++ b/tests/e2e/operator/infra/gcp.go
@@ -2,6 +2,7 @@ package infra
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -316,6 +317,64 @@ func (r *GcpRegion) ScaleNodePool(t *testing.T, location string, nodeCount, inde
 
 func (r *GcpRegion) CanScale() bool {
 	return false
+}
+
+// ─── Encryption At Rest Methods ─────────────────────────────────────────────────
+
+// SetupEncryptionInfrastructure is simplified for GCP (uses file-based encryption for now)
+// TODO: Implement full GCP Cloud KMS support similar to AWS
+// Returns a no-op cleanup function
+func (r *GcpRegion) SetupEncryptionInfrastructure(t *testing.T) (func(), error) {
+	t.Log("GCP provider: Using file-based encryption (UNKNOWN_KEY_TYPE)")
+	t.Log("TODO: Implement full GCP Cloud KMS support for production use")
+	// Return no-op cleanup function
+	return func() {
+		t.Log("GCP provider: No KMS infrastructure to clean up")
+	}, nil
+}
+
+// GetEncryptionPlatformConfig returns GCP-specific encryption platform configuration
+// Currently uses UNKNOWN_KEY_TYPE (file-based) - can be extended to GCP_CLOUD_KMS
+func (r *GcpRegion) GetEncryptionPlatformConfig() operator.EncryptionPlatformConfig {
+	// TODO: Switch to GCP_CLOUD_KMS and implement full KMS support
+	return operator.EncryptionPlatformConfig{
+		Platform:                     "UNKNOWN_KEY_TYPE",
+		RequiresCredentialsSecret:    false,
+		DefaultCredentialsSecretName: "",
+	}
+}
+
+// EncryptStoreKey is a no-op for GCP providers
+// The test code handles encryption key preparation directly (same as original behavior)
+// TODO: Implement actual GCP Cloud KMS encryption when needed
+func (r *GcpRegion) EncryptStoreKey(_ *testing.T, _ []byte, _ string) (string, error) {
+	// No-op: GCP provider tests handle key encoding directly in test code
+	// TODO: Implement GCP Cloud KMS encryption similar to AWS
+	return "", nil
+}
+
+// CreateEncryptionKeySecret is a no-op for GCP providers
+// The test code creates the encryption secret directly (same as original behavior)
+// TODO: Extend to include GCP Cloud KMS fields when full KMS support is implemented
+func (r *GcpRegion) CreateEncryptionKeySecret(
+	_ *testing.T,
+	_ *k8s.KubectlOptions,
+	_ string,
+	_ string,
+	_ string,
+) {
+	// No-op: GCP provider tests create secrets directly in test code
+	// TODO: Add GCP Cloud KMS fields when full KMS support is implemented
+}
+
+// CreateEncryptionCredentialsSecret is a no-op for GCP providers
+// File-based encryption doesn't require KMS credentials
+// Returns empty string since no secret is created
+// TODO: Implement when full GCP Cloud KMS support is added
+func (r *GcpRegion) CreateEncryptionCredentialsSecret(_ *testing.T, _ *k8s.KubectlOptions) string {
+	// No credentials needed for file-based encryption (UNKNOWN_KEY_TYPE)
+	// TODO: Create GCP service account credentials secret when implementing full GCP Cloud KMS
+	return ""
 }
 
 // createGKEClusters handles the complex logic of creating GKE clusters in parallel.

--- a/tests/e2e/operator/infra/local.go
+++ b/tests/e2e/operator/infra/local.go
@@ -9,10 +9,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/helm-charts/tests/e2e/calico"
-	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
-	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
-	"github.com/cockroachdb/helm-charts/tests/testutil"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/shell"
@@ -23,6 +19,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/calico"
+	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/testutil"
 )
 
 // LocalRegion implements CloudProvider for local Kubernetes providers (K3d and Kind)
@@ -124,9 +125,6 @@ func (r *LocalRegion) SetUpInfra(t *testing.T) {
 			Namespace: r.Namespace[cluster],
 			Domain:    operator.CustomDomains[i],
 		}
-		if !r.IsMultiRegion {
-			break
-		}
 	}
 
 	// Update Coredns config.
@@ -143,11 +141,6 @@ func (r *LocalRegion) SetUpInfra(t *testing.T) {
 		// restart coredns pods.
 		err = k8s.RunKubectlE(t, kubectlOptions, "rollout", "restart", "deployment", coreDNSDeploymentName)
 		require.NoError(t, err)
-		if !r.IsMultiRegion {
-			r.Clients = clients
-			r.ReusingInfra = true
-			return
-		}
 	}
 	r.Clients = clients
 	r.ReusingInfra = true
@@ -221,6 +214,55 @@ func (r *LocalRegion) ScaleNodePool(t *testing.T, location string, nodeCount, in
 
 func (r *LocalRegion) CanScale() bool {
 	return false
+}
+
+// ─── Encryption At Rest Methods ─────────────────────────────────────────────────
+
+// SetupEncryptionInfrastructure is a no-op for local providers (file-based encryption)
+// Returns a no-op cleanup function
+func (r *LocalRegion) SetupEncryptionInfrastructure(t *testing.T) (func(), error) {
+	t.Log("Local provider: No KMS infrastructure needed for file-based encryption (UNKNOWN_KEY_TYPE)")
+	// Return no-op cleanup function
+	return func() {
+		t.Log("Local provider: No KMS infrastructure to clean up")
+	}, nil
+}
+
+// GetEncryptionPlatformConfig returns file-based encryption platform configuration for local providers
+func (r *LocalRegion) GetEncryptionPlatformConfig() operator.EncryptionPlatformConfig {
+	return operator.EncryptionPlatformConfig{
+		Platform:                     "UNKNOWN_KEY_TYPE",
+		RequiresCredentialsSecret:    false,
+		DefaultCredentialsSecretName: "", // Not needed for file-based encryption
+	}
+}
+
+// EncryptStoreKey is a no-op for local providers
+// The test code handles encryption key preparation directly (same as original behavior)
+func (r *LocalRegion) EncryptStoreKey(_ *testing.T, _ []byte, _ string) (string, error) {
+	// No-op: Local provider tests handle key encoding directly in test code
+	return "", nil
+}
+
+// CreateEncryptionKeySecret is a no-op for local providers
+// The test code creates the encryption secret directly (same as original behavior)
+func (r *LocalRegion) CreateEncryptionKeySecret(
+	_ *testing.T,
+	_ *k8s.KubectlOptions,
+	_ string,
+	_ string,
+	_ string,
+) {
+	// No-op: Local provider tests create secrets directly in test code
+	// This maintains compatibility with the original test implementation
+}
+
+// CreateEncryptionCredentialsSecret is a no-op for local providers
+// File-based encryption doesn't require KMS credentials
+// Returns empty string since no secret is created
+func (r *LocalRegion) CreateEncryptionCredentialsSecret(_ *testing.T, _ *k8s.KubectlOptions) string {
+	// No credentials needed for file-based encryption
+	return ""
 }
 
 // setupNetworking ensures there is cross-cluster network connectivity and

--- a/tests/e2e/operator/infra/provider.go
+++ b/tests/e2e/operator/infra/provider.go
@@ -83,6 +83,10 @@ func ProviderFactory(providerType string, region *operator.Region) CloudProvider
 		provider := GcpRegion{Region: region}
 		provider.RegionCodes = GetRegionCodes(providerType)
 		return &provider
+	case ProviderAWS:
+		provider := AwsRegion{Region: region}
+		provider.RegionCodes = GetRegionCodes(providerType)
+		return &provider
 	default:
 		return nil
 	}

--- a/tests/e2e/operator/infra/provider.go
+++ b/tests/e2e/operator/infra/provider.go
@@ -3,6 +3,8 @@ package infra
 import (
 	"testing"
 
+	"github.com/gruntwork-io/terratest/modules/k8s"
+
 	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
 )
 
@@ -22,6 +24,48 @@ type CloudProvider interface {
 
 	// CanScale checks if the provider supports scaling.
 	CanScale() bool
+
+	// ─── Encryption At Rest Methods ─────────────────────────────────────────────
+
+	// SetupEncryptionInfrastructure creates cloud KMS resources (keys, roles, policies)
+	// Returns a cleanup function that should be deferred to ensure proper resource cleanup
+	// Called once during test setup, before any encryption secrets are created
+	// For AWS: Creates KMS keys in each region, IAM roles with decrypt permissions
+	// For GCP: Creates KMS keys, service accounts with permissions
+	// For Local: No-op, returns empty cleanup function
+	SetupEncryptionInfrastructure(t *testing.T) (cleanup func(), err error)
+
+	// GetEncryptionPlatformConfig returns provider-specific encryption platform configuration
+	// Defines platform type (AWS_KMS, GCP_CLOUD_KMS, UNKNOWN_KEY_TYPE), whether credentials are needed, etc.
+	GetEncryptionPlatformConfig() operator.EncryptionPlatformConfig
+
+	// EncryptStoreKey encrypts the plaintext store key using provider's KMS
+	// Called for each cluster/region that needs encryption
+	// For AWS: Encrypts with AWS KMS Encrypt API, returns base64-encoded ciphertext
+	// For GCP: Encrypts with GCP KMS Encrypt API, returns base64-encoded ciphertext
+	// For Local: Returns base64-encoded plaintext (no encryption)
+	// clusterRegion identifies which cluster/region this key is for (maps to KMS key)
+	EncryptStoreKey(t *testing.T, plaintextKey []byte, clusterRegion string) (encryptedKeyBase64 string, err error)
+
+	// CreateEncryptionKeySecret creates Kubernetes secret with provider-specific fields
+	// For AWS: StoreKeyData (encrypted), AuthPrincipal, URI, Region, Type, ExternalID
+	// For GCP: StoreKeyData (encrypted), AuthPrincipal, URI, Region, Type
+	// For Local: StoreKeyData (base64 plaintext)
+	// encryptedKeyData is the base64-encoded result from EncryptStoreKey
+	CreateEncryptionKeySecret(
+		t *testing.T,
+		kubectlOptions *k8s.KubectlOptions,
+		secretName string,
+		encryptedKeyData string,
+		clusterRegion string,
+	)
+
+	// CreateEncryptionCredentialsSecret creates Kubernetes secret with KMS access credentials
+	// For AWS: aws_access_key_id, aws_secret_access_key
+	// For GCP: gcp_service_account_key (JSON)
+	// For Local: No-op (returns "")
+	// Returns secret name if created, empty string otherwise
+	CreateEncryptionCredentialsSecret(t *testing.T, kubectlOptions *k8s.KubectlOptions) string
 }
 
 // ProviderFactory creates a CloudProvider instance for the given provider type.

--- a/tests/e2e/operator/multiRegion/cockroachdb_multi_region_advanced_features_test.go
+++ b/tests/e2e/operator/multiRegion/cockroachdb_multi_region_advanced_features_test.go
@@ -1,0 +1,238 @@
+package multiRegion
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestWALFailoverMultiRegion tests WAL failover with different paths in each region
+// Region 0: WAL failover enabled with custom path
+// Region 1: WAL failover disabled
+func (r *multiRegion) TestWALFailoverMultiRegion(t *testing.T) {
+	// Setup namespaces and CA for each region
+	cleanup := r.SetupMultiClusterWithCA(t)
+	defer cleanup()
+
+	// Region 0: Install with WAL failover enabled
+	cluster0 := r.Clusters[0]
+	walPath0 := "/cockroach/wal-region-0"
+
+	t.Logf("Installing region 0 (%s) with WAL failover enabled at path %s", cluster0, walPath0)
+	config0 := operator.AdvancedInstallConfig{
+		WALFailoverEnabled: true,
+		WALFailoverSize:    "5Gi",
+		CustomValues: map[string]string{
+			"cockroachdb.crdbCluster.walFailoverSpec.path": walPath0,
+		},
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster0, 0, config0)
+
+	// Region 1: Install without WAL failover
+	cluster1 := r.Clusters[1]
+	t.Logf("Installing region 1 (%s) without WAL failover", cluster1)
+	config1 := operator.AdvancedInstallConfig{}
+	r.InstallChartsWithAdvancedConfig(t, cluster1, 1, config1)
+
+	// Validate CockroachDB cluster health in both regions
+	for _, cluster := range r.Clusters {
+		r.ValidateCRDB(t, cluster)
+	}
+
+	// Validate multi-region setup
+	r.ValidateMultiRegionSetup(t)
+
+	// Validate WAL failover in region 0
+	t.Log("Validating WAL failover in region 0...")
+	r.ValidateWALFailover(t, cluster0, &operator.AdvancedValidationConfig{
+		WALFailover: operator.WALFailoverValidation{
+			CustomPath: walPath0,
+		},
+	})
+
+	// Validate NO WAL failover in region 1
+	t.Log("Validating NO WAL failover in region 1...")
+	kubeConfig, _ := r.GetCurrentContext(t)
+	kubectlOptions1 := k8s.NewKubectlOptions(cluster1, kubeConfig, r.Namespace[cluster1])
+
+	pods := k8s.ListPods(t, kubectlOptions1, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found in region 1")
+
+	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions1,
+		"get", "pod", pods[0].Name, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+	require.NoError(t, err)
+	require.NotContains(t, podCommand, "--wal-failover", "Region 1 should not have WAL failover enabled")
+	t.Log("Confirmed region 1 does not have WAL failover")
+
+	t.Logf("WAL failover multi-region test completed successfully")
+}
+
+// TestEncryptionAtRestMultiRegion tests encryption at rest with different secrets per region
+// Region 0: Encryption enabled with secret "cmek-key-secret-region-0"
+// Region 1: Encryption disabled (no encryption)
+func (r *multiRegion) TestEncryptionAtRestMultiRegion(t *testing.T) {
+	// Setup namespaces and CA for each region
+	cleanup := r.SetupMultiClusterWithCA(t)
+	defer cleanup()
+
+	// Generate encryption key for region 0
+	encryptionKeyB64 := r.GenerateEncryptionKey(t)
+	t.Logf("Generated encryption key for region 0 (base64 length: %d)", len(encryptionKeyB64))
+
+	// Region 0: Install with encryption at rest enabled
+	cluster0 := r.Clusters[0]
+	secretName0 := "cmek-key-secret-region-0"
+
+	encryptionRegions0 := []map[string]interface{}{
+		{
+			"code":          r.RegionCodes[0],
+			"cloudProvider": r.Provider,
+			"nodes":         r.NodeCount,
+			"namespace":     r.Namespace[cluster0],
+			"domain":        operator.CustomDomains[0],
+			"encryptionAtRest": map[string]interface{}{
+				"platform":      "UNKNOWN_KEY_TYPE",
+				"keySecretName": secretName0,
+			},
+		},
+	}
+
+	t.Logf("Installing region 0 (%s) with encryption at rest enabled", cluster0)
+	config0 := operator.AdvancedInstallConfig{
+		EncryptionEnabled:       true,
+		EncryptionKeySecret:     encryptionKeyB64,
+		EncryptionKeySecretName: secretName0,
+		CustomRegions:           encryptionRegions0,
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster0, 0, config0)
+
+	// Region 1: Install without encryption
+	cluster1 := r.Clusters[1]
+	t.Logf("Installing region 1 (%s) without encryption at rest", cluster1)
+	config1 := operator.AdvancedInstallConfig{}
+	r.InstallChartsWithAdvancedConfig(t, cluster1, 1, config1)
+
+	// Validate CockroachDB cluster health in both regions
+	for _, cluster := range r.Clusters {
+		r.ValidateCRDB(t, cluster)
+	}
+
+	// Validate multi-region setup
+	r.ValidateMultiRegionSetup(t)
+
+	// Validate encryption in region 0
+	t.Log("Validating encryption at rest in region 0...")
+	r.ValidateEncryptionAtRest(t, cluster0, &operator.AdvancedValidationConfig{
+		EncryptionAtRest: operator.EncryptionAtRestValidation{
+			SecretName: secretName0,
+		},
+	})
+
+	// Validate NO encryption in region 1
+	t.Log("Validating NO encryption at rest in region 1...")
+	kubeConfig, _ := r.GetCurrentContext(t)
+	kubectlOptions1 := k8s.NewKubectlOptions(cluster1, kubeConfig, r.Namespace[cluster1])
+
+	pods := k8s.ListPods(t, kubectlOptions1, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found in region 1")
+
+	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions1,
+		"get", "pod", pods[0].Name, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+	require.NoError(t, err)
+	require.NotContains(t, podCommand, "--enterprise-encryption", "Region 1 should not have encryption enabled")
+	t.Log("Confirmed region 1 does not have encryption at rest")
+
+	t.Logf("Encryption at rest multi-region test completed successfully")
+}
+
+// TestPCRMultiRegion tests Physical Cluster Replication with multi-region setup
+// Creates a multi-region primary cluster, then creates a standby cluster and tests failover/failback
+func (r *multiRegion) TestPCRMultiRegion(t *testing.T) {
+	// Creating random namespace for primary multi-region cluster
+	for _, cluster := range r.Clusters {
+		r.Namespace[cluster] = fmt.Sprintf("%s-primary-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
+	}
+
+	// Create CA certificate once for all clusters
+	cleanupCA := r.RequireCACertificate(t)
+	defer cleanupCA()
+
+	var standbyNamespace string
+
+	// Cleanup both primary and standby clusters
+	defer r.CleanupResources(t)
+	defer func() {
+		if standbyNamespace != "" {
+			kubeConfig, _ := r.GetCurrentContext(t)
+			// Standby is always installed on Clusters[0]; use its context explicitly.
+			kubectlOptions := k8s.NewKubectlOptions(r.Clusters[0], kubeConfig, standbyNamespace)
+			k8s.DeleteNamespace(t, kubectlOptions, standbyNamespace)
+		}
+	}()
+
+	// Step 1: Install primary multi-region cluster
+	t.Log("Installing primary multi-region cluster...")
+	for i, cluster := range r.Clusters {
+		primaryConfig := operator.AdvancedInstallConfig{
+			VirtualClusterMode: "primary",
+		}
+		r.InstallChartsWithAdvancedConfig(t, cluster, i, primaryConfig)
+	}
+
+	// Validate primary cluster health in all regions
+	r.VirtualClusterModePrimary = true
+	for _, cluster := range r.Clusters {
+		r.ValidateCRDB(t, cluster)
+	}
+	r.VirtualClusterModePrimary = false
+
+	// Validate multi-region setup
+	r.ValidateMultiRegionSetup(t)
+	t.Log("Primary multi-region cluster is healthy")
+
+	// Step 2: Install standby cluster (single region for simplicity)
+	t.Log("Installing standby cluster...")
+	standbyCluster := r.Clusters[0] // Use first cluster for standby
+	standbyNamespace = fmt.Sprintf("%s-standby-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
+
+	// Temporarily update namespace for standby installation
+	originalNamespace := r.Namespace[standbyCluster]
+	r.Namespace[standbyCluster] = standbyNamespace
+
+	standbyConfig := operator.AdvancedInstallConfig{
+		VirtualClusterMode:  "standby",
+		SkipOperatorInstall: true, // Operator already installed
+	}
+	r.InstallChartsWithAdvancedConfig(t, standbyCluster, 0, standbyConfig)
+
+	// Validate standby cluster
+	r.VirtualClusterModeStandby = true
+	r.ValidateCRDB(t, standbyCluster)
+	r.VirtualClusterModeStandby = false
+	t.Log("Standby cluster is healthy")
+
+	// Step 3: Set up replication and test failover/failback
+	t.Log("Testing PCR failover and failback...")
+	r.ValidatePCR(t, &operator.AdvancedValidationConfig{
+		PCR: operator.PCRValidation{
+			Cluster:          standbyCluster,
+			PrimaryNamespace: originalNamespace,
+			StandbyNamespace: standbyNamespace,
+		},
+	})
+
+	// Restore original namespace
+	r.Namespace[standbyCluster] = originalNamespace
+
+	t.Logf("PCR multi-region test completed successfully")
+}

--- a/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
+++ b/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
@@ -83,14 +83,21 @@ func TestOperatorInMultiRegion(t *testing.T) {
 		// Set up infrastructure for this provider once.
 		cloudProvider.SetUpInfra(t)
 
-		testCases := map[string]func(*testing.T){
-			"TestHelmInstall":           providerRegion.TestHelmInstall,
-			"TestHelmUpgrade":           providerRegion.TestHelmUpgrade,
-			"TestClusterRollingRestart": providerRegion.TestClusterRollingRestart,
-			"TestKillingCockroachNode":  providerRegion.TestKillingCockroachNode,
-			"TestClusterScaleUp":        func(t *testing.T) { providerRegion.TestClusterScaleUp(t, cloudProvider) },
-		}
+		// Build test cases based on TEST_ADVANCED_FEATURES environment variable
+		testCases := make(map[string]func(*testing.T))
 
+		// Run only advanced test cases when TEST_ADVANCED_FEATURES is enabled
+		if os.Getenv("TEST_ADVANCED_FEATURES") == "true" {
+			testCases["TestWALFailoverMultiRegion"] = providerRegion.TestWALFailoverMultiRegion
+			testCases["TestEncryptionAtRestMultiRegion"] = providerRegion.TestEncryptionAtRestMultiRegion
+			testCases["TestPCRMultiRegion"] = providerRegion.TestPCRMultiRegion
+		} else {
+			testCases["TestHelmInstall"] = providerRegion.TestHelmInstall
+			testCases["TestHelmUpgrade"] = providerRegion.TestHelmUpgrade
+			testCases["TestClusterRollingRestart"] = providerRegion.TestClusterRollingRestart
+			testCases["TestKillingCockroachNode"] = providerRegion.TestKillingCockroachNode
+			testCases["TestClusterScaleUp"] = func(t *testing.T) { providerRegion.TestClusterScaleUp(t, cloudProvider) }
+		}
 		// Run tests sequentially within a provider.
 		var testFailed bool
 		for name, method := range testCases {

--- a/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
+++ b/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
 	"github.com/cockroachdb/helm-charts/tests/e2e/operator/infra"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/utils"
 	"github.com/cockroachdb/helm-charts/tests/testutil"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -20,7 +21,6 @@ import (
 
 // Region codes for each provider are now centralized in infra.RegionCodes
 type multiRegion struct {
-	operator.OperatorUseCases
 	operator.Region
 }
 
@@ -30,19 +30,10 @@ func newMultiRegion() *multiRegion {
 
 // TestOperatorInMultiRegion tests CockroachDB operator functionality across multiple regions
 func TestOperatorInMultiRegion(t *testing.T) {
-	// Fetch provider from env
-	var provider string
-	if p := strings.TrimSpace(strings.ToLower(os.Getenv("PROVIDER"))); p != "" {
-		switch p {
-		case "kind":
-			provider = infra.ProviderKind
-		case "gcp":
-			provider = infra.ProviderGCP
-		default:
-			t.Fatalf("Unsupported provider override: %s", p)
-		}
-	} else {
-		provider = infra.ProviderK3D
+	// Get provider from environment variable
+	provider, err := utils.GetProviderFromEnv()
+	if err != nil {
+		t.Fatalf("Failed to get provider: %v", err)
 	}
 
 	t.Run(provider, func(t *testing.T) {
@@ -51,20 +42,21 @@ func TestOperatorInMultiRegion(t *testing.T) {
 		// Create a provider-specific instance to avoid race conditions.
 		providerRegion := newMultiRegion()
 		providerRegion.Region = operator.Region{
-			IsMultiRegion: true,
-			NodeCount:     3,
-			ReusingInfra:  false,
+			NodeCount:    3,
+			ReusingInfra: false,
+			TestRunID:    utils.GenerateTestRunID(),
 		}
 		providerRegion.Clients = make(map[string]client.Client)
 		providerRegion.Namespace = make(map[string]string)
-
 		providerRegion.Provider = provider
-		for _, cluster := range operator.Clusters {
-			clusterName := fmt.Sprintf("%s-%s", providerRegion.Provider, cluster)
-			if providerRegion.Provider != infra.ProviderK3D && provider != infra.ProviderKind {
-				clusterName = fmt.Sprintf("%s-%s", clusterName, strings.ToLower(random.UniqueId()))
-			}
-			providerRegion.Clusters = append(providerRegion.Clusters, clusterName)
+
+		t.Logf("Test Run ID: %s", providerRegion.TestRunID)
+
+		// Generate cluster names with user/PR context
+		clusterNames := utils.GenerateClusterNames(provider, len(operator.Clusters))
+		providerRegion.Clusters = clusterNames
+		for i, name := range clusterNames {
+			t.Logf("Cluster %d name: %s", i, name)
 		}
 
 		// Create and reuse the same provider instance for both setup and teardown.
@@ -107,19 +99,7 @@ func TestOperatorInMultiRegion(t *testing.T) {
 				continue
 			}
 
-			t.Run(name, func(t *testing.T) {
-				// Add immediate cleanup trigger if this individual test fails
-				defer func() {
-					if t.Failed() {
-						testFailed = true
-						t.Logf("Test %s failed, triggering immediate infrastructure cleanup", name)
-						cloudProvider.TeardownInfra(t)
-						t.Logf("Infrastructure cleanup completed due to test failure")
-					}
-				}()
-
-				method(t)
-			})
+			testFailed = !t.Run(name, method)
 		}
 	})
 }
@@ -337,7 +317,7 @@ func (r *multiRegion) TestClusterRollingRestart(t *testing.T) {
 }
 
 // TestKillingCockroachNode will manually kill one cockroachdb node to verify
-// if the reconciliation is working as expected in multi region and verifies the same.
+// if the reconciliation is working as expected in a multi region and verifies the same.
 func (r *multiRegion) TestKillingCockroachNode(t *testing.T) {
 
 	// Creating random namespace for each region.

--- a/tests/e2e/operator/region.go
+++ b/tests/e2e/operator/region.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"github.com/cockroachdb/helm-charts/tests/testutil"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/stretchr/testify/require"
@@ -124,7 +126,7 @@ func (r *Region) InstallCharts(t *testing.T, cluster string, index int) {
 	// Setup kubectl options for this cluster.
 	kubectlOptions = k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
 	if !r.IsOperatorInstalled {
-		InstallCockroachDBEnterpriseOperator(t, kubectlOptions)
+		InstallCockroachDBEnterpriseOperator(t, kubectlOptions, r.RegionCodes[index])
 	}
 
 	if r.IsCertManager {
@@ -427,9 +429,11 @@ func (r *Region) EnsureKubeConfigPath() (string, error) {
 // Any failure in doing so might cause issues in other tests as some of the
 // cluster resources are tied to the namespace.
 func (r *Region) CleanupResources(t *testing.T) {
+	kubeConfig, _ := r.GetCurrentContext(t)
 	for cluster, namespace := range r.Namespace {
-		kubectlOptions := k8s.NewKubectlOptions(cluster, "", namespace)
-		certManagerK8sOptions := k8s.NewKubectlOptions(cluster, "", testutil.CertManagerNamespace)
+		kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, namespace)
+		certManagerK8sOptions := k8s.NewKubectlOptions(cluster, kubeConfig, testutil.CertManagerNamespace)
+		clusterOptions := k8s.NewKubectlOptions(cluster, kubeConfig, "")
 
 		extraArgs := map[string][]string{
 			"delete": {
@@ -441,10 +445,32 @@ func (r *Region) CleanupResources(t *testing.T) {
 			KubectlOptions: kubectlOptions,
 			ExtraArgs:      extraArgs,
 		}
-		err := helm.DeleteE(t, helmOptions, ReleaseName, true)
-		require.NoError(t, err)
-		err = helm.DeleteE(t, helmOptions, operatorReleaseName, true)
-		require.NoError(t, err)
+		if err := helm.DeleteE(t, helmOptions, ReleaseName, true); err != nil {
+			t.Logf("Warning: helm delete %s failed (may not exist): %v", ReleaseName, err)
+		}
+		if err := helm.DeleteE(t, helmOptions, operatorReleaseName, true); err != nil {
+			t.Logf("Warning: helm delete %s failed (may not exist): %v", operatorReleaseName, err)
+		}
+
+		// Always explicitly delete cluster-scoped resources to prevent annotation
+		// conflicts in subsequent runs, even when helm delete fails or is incomplete.
+		nodeReaderName := fmt.Sprintf("cockroachdb-%s-node-reader", namespace)
+		clusterScopedResources := [][]string{
+			{"priorityclass", "cockroach-operator"},
+			{"priorityclass", "cockroachdb"},
+			{"clusterrole", "cockroach-operator-role"},
+			{"clusterrolebinding", "cockroach-operator-default"},
+			{"clusterrole", nodeReaderName},
+			{"clusterrolebinding", nodeReaderName},
+			{"mutatingwebhookconfiguration", "cockroach-operator-mutating-webhook-configuration"},
+			{"mutatingwebhookconfiguration", "cockroach-mutating-webhook-config"},
+			{"validatingwebhookconfiguration", "cockroach-operator-validating-webhook-configuration"},
+			{"validatingwebhookconfiguration", "cockroach-webhook-config"},
+		}
+		for _, res := range clusterScopedResources {
+			_ = k8s.RunKubectlE(t, clusterOptions, "delete", res[0], res[1], "--ignore-not-found")
+		}
+
 		if r.IsCertManager {
 			testutil.DeleteBundle(t, kubectlOptions)
 			testutil.DeleteCAIssuer(t, kubectlOptions, namespace)
@@ -473,29 +499,33 @@ func HelmChartPaths() (helmChartPath string, operatorChartPath string) {
 
 // createOperatorRegions returns the appropriate regions config
 // required while installing CockroachDb charts.
+// Other clusters' regions are listed first so their join addresses are tried
+// before the current cluster's, allowing it to join the existing cluster immediately.
 func (r *Region) createOperatorRegions(index int, nodes int, customDomains map[int]string) []map[string]interface{} {
-	regions := make([]map[string]interface{}, 0, len(r.Clusters))
-
-	for i := 0; i < len(r.Clusters); i++ {
-		if i > index {
-			break
-		}
-
+	buildRegion := func(i int) map[string]interface{} {
 		region := map[string]interface{}{
 			"code":          r.RegionCodes[i],
 			"cloudProvider": r.Provider,
 			"nodes":         nodes,
 			"namespace":     r.Namespace[r.Clusters[i]],
 		}
-
 		if len(r.Clusters) > i && r.Clusters[i] != "" {
 			if domain, ok := customDomains[i]; ok {
 				region["domain"] = domain
 			}
 		}
-
-		regions = append(regions, region)
+		return region
 	}
+
+	regions := make([]map[string]interface{}, 0, index+1)
+
+	// Add all preceding regions first so their join addresses are tried first.
+	for i := 0; i < index; i++ {
+		regions = append(regions, buildRegion(i))
+	}
+
+	// Add the current cluster's region last.
+	regions = append(regions, buildRegion(index))
 
 	return regions
 }
@@ -517,13 +547,14 @@ func VerifyInitCommandInOperatorLogs(t *testing.T, kubectlOptions *k8s.KubectlOp
 	require.Contains(t, logs, expected, "operator logs did not contain expected init command")
 }
 
-func InstallCockroachDBEnterpriseOperator(t *testing.T, kubectlOptions *k8s.KubectlOptions) {
+func InstallCockroachDBEnterpriseOperator(t *testing.T, kubectlOptions *k8s.KubectlOptions, cloudRegion string) {
 	_, operatorChartPath := HelmChartPaths()
 
 	operatorOpts := &helm.Options{
 		KubectlOptions: kubectlOptions,
 		SetValues: map[string]string{
 			"numReplicas": "1",
+			"cloudRegion": cloudRegion,
 		},
 		ExtraArgs: helmExtraArgs,
 	}
@@ -586,4 +617,815 @@ func PatchHelmValues(inputValues map[string]string) map[string]string {
 	}
 
 	return inputValues
+}
+
+const (
+	defaultWALFailoverPath  = "/cockroach/cockroach-wal-failover"
+	defaultEncryptionSecret = "cmek-key-secret"
+)
+
+// AdvancedValidationConfig aggregates validation knobs for advanced feature assertions.
+type AdvancedValidationConfig struct {
+	WALFailover      WALFailoverValidation
+	EncryptionAtRest EncryptionAtRestValidation
+	PCR              PCRValidation
+}
+
+// WALFailoverValidation captures WAL failover expectations.
+type WALFailoverValidation struct {
+	CustomPath string
+}
+
+// EncryptionAtRestValidation captures encryption validation expectations.
+type EncryptionAtRestValidation struct {
+	SecretName string
+	// OldKeyExpected is the substring expected in the --enterprise-encryption old-key field.
+	// Defaults to "old-key=plain" (initial encryption setup). For key rotation use "old-key=/etc/cockroach-key/".
+	OldKeyExpected string
+}
+
+// PCRValidation captures virtual cluster replication validation inputs.
+type PCRValidation struct {
+	Cluster          string
+	PrimaryNamespace string
+	StandbyNamespace string
+}
+
+// DefaultAdvancedValidationConfig returns default validation values used when a test does not override them.
+func DefaultAdvancedValidationConfig() AdvancedValidationConfig {
+	return AdvancedValidationConfig{
+		WALFailover: WALFailoverValidation{
+			CustomPath: defaultWALFailoverPath,
+		},
+		EncryptionAtRest: EncryptionAtRestValidation{
+			SecretName:     defaultEncryptionSecret,
+			OldKeyExpected: "old-key=plain",
+		},
+	}
+}
+
+func mergeValidationConfig(cfg *AdvancedValidationConfig) AdvancedValidationConfig {
+	merged := DefaultAdvancedValidationConfig()
+	if cfg == nil {
+		return merged
+	}
+
+	if cfg.WALFailover.CustomPath != "" {
+		merged.WALFailover = cfg.WALFailover
+	}
+	if cfg.EncryptionAtRest.SecretName != "" {
+		merged.EncryptionAtRest.SecretName = cfg.EncryptionAtRest.SecretName
+	}
+	if cfg.EncryptionAtRest.OldKeyExpected != "" {
+		merged.EncryptionAtRest.OldKeyExpected = cfg.EncryptionAtRest.OldKeyExpected
+	}
+	if cfg.PCR.Cluster != "" || cfg.PCR.PrimaryNamespace != "" || cfg.PCR.StandbyNamespace != "" {
+		merged.PCR = cfg.PCR
+	}
+
+	return merged
+}
+
+// AssignRandomNamespace assigns a randomized namespace for the given cluster using the default prefix.
+func (r *Region) AssignRandomNamespace(cluster string) string {
+	return r.AssignRandomNamespaceWithPrefix(cluster, Namespace)
+}
+
+// AssignRandomNamespaceWithPrefix assigns a randomized namespace for the given cluster using the provided prefix.
+func (r *Region) AssignRandomNamespaceWithPrefix(cluster string, prefix string) string {
+	if prefix == "" {
+		prefix = Namespace
+	}
+	if r.Namespace == nil {
+		r.Namespace = make(map[string]string)
+	}
+	name := fmt.Sprintf("%s-%s", prefix, strings.ToLower(random.UniqueId()))
+	r.Namespace[cluster] = name
+	return name
+}
+
+// AssignRandomNamespacesWithPrefix assigns randomized namespaces for all tracked clusters.
+func (r *Region) AssignRandomNamespacesWithPrefix(prefix string) {
+	for _, cluster := range r.Clusters {
+		r.AssignRandomNamespaceWithPrefix(cluster, prefix)
+	}
+}
+
+// RequireCACertificate creates a CA certificate for the current test and returns a cleanup closure.
+func (r *Region) RequireCACertificate(t *testing.T) func() {
+	err := r.CreateCACertificate(t)
+	require.NoError(t, err)
+	return func() {
+		r.CleanUpCACertificate(t)
+	}
+}
+
+// SetupSingleClusterWithCA prepares a single cluster for advanced tests and returns a cleanup closure.
+func (r *Region) SetupSingleClusterWithCA(t *testing.T, cluster string) func() {
+	r.AssignRandomNamespace(cluster)
+	cleanupCA := r.RequireCACertificate(t)
+	return func() {
+		r.CleanupResources(t)
+		cleanupCA()
+	}
+}
+
+// SetupMultiClusterWithCA prepares all clusters for advanced tests and returns a cleanup closure.
+func (r *Region) SetupMultiClusterWithCA(t *testing.T) func() {
+	r.AssignRandomNamespacesWithPrefix(Namespace)
+	cleanupCA := r.RequireCACertificate(t)
+	return func() {
+		r.CleanupResources(t)
+		cleanupCA()
+	}
+}
+
+// BaseRegionConfig returns a baseline region configuration map for the provided cluster and index.
+func (r *Region) BaseRegionConfig(cluster string, index int) map[string]interface{} {
+	code := fmt.Sprintf("region-%d", index)
+	if len(r.RegionCodes) > index {
+		code = r.RegionCodes[index]
+	}
+	region := map[string]interface{}{
+		"code":          code,
+		"cloudProvider": r.Provider,
+		"nodes":         r.NodeCount,
+		"namespace":     r.Namespace[cluster],
+	}
+	if domain, ok := CustomDomains[index]; ok {
+		region["domain"] = domain
+	}
+	return region
+}
+
+// EncryptionAtRestConfig returns a reusable encryption configuration map with optional overrides.
+// When an override value is nil or empty string, the key is omitted from the config entirely.
+// This matters because the operator uses *string with omitempty — a nil/absent keySecretName
+// is interpreted as "plain" (unencrypted), while an empty string is not the same as nil.
+func (r *Region) EncryptionAtRestConfig(secretName string, overrides map[string]interface{}) map[string]interface{} {
+	if secretName == "" {
+		secretName = "cmek-key-secret"
+	}
+	config := map[string]interface{}{
+		"platform":      "UNKNOWN_KEY_TYPE",
+		"keySecretName": secretName,
+	}
+	for k, v := range overrides {
+		if v == nil || v == "" {
+			// Delete the key so it is omitted from JSON (nil pointer in operator = "plain").
+			delete(config, k)
+		} else {
+			config[k] = v
+		}
+	}
+	return config
+}
+
+// BuildEncryptionRegions creates a slice containing a single region entry with encryption settings applied.
+func (r *Region) BuildEncryptionRegions(cluster string, index int, encryptionOverrides map[string]interface{}) []map[string]interface{} {
+	region := r.BaseRegionConfig(cluster, index)
+	region["encryptionAtRest"] = r.EncryptionAtRestConfig("", encryptionOverrides)
+	return []map[string]interface{}{region}
+}
+
+// AdvancedInstallConfig holds configuration for advanced feature installations
+type AdvancedInstallConfig struct {
+	// WAL Failover configuration
+	WALFailoverEnabled bool
+	WALFailoverSize    string
+
+	// Encryption at Rest configuration
+	EncryptionEnabled      bool
+	EncryptionKeySecret    string
+	EncryptionKeySecretName string // defaults to "cmek-key-secret" if empty
+
+	// Virtual Cluster configuration (for PCR)
+	VirtualClusterMode string // "primary", "standby", or ""
+
+	// Custom helm values to merge
+	CustomValues map[string]string
+
+	// Custom regions configuration (for encryption)
+	CustomRegions []map[string]interface{}
+
+	// Skip operator installation (for second virtual cluster)
+	SkipOperatorInstall bool
+}
+
+// InstallChartsWithAdvancedConfig installs CockroachDB with advanced features configuration
+func (r *Region) InstallChartsWithAdvancedConfig(t *testing.T, cluster string, index int, config AdvancedInstallConfig) {
+	// Get the current context name.
+	kubeConfig, rawConfig := r.GetCurrentContext(t)
+
+	// Get helm chart paths.
+	helmChartPath, _ := HelmChartPaths()
+
+	// Verify if a cluster exists in the contexts.
+	if _, ok := rawConfig.Contexts[cluster]; !ok {
+		t.Fatal()
+	}
+
+	// Setup kubectl options for this cluster.
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+
+	// Create a namespace.
+	k8s.CreateNamespace(t, kubectlOptions, r.Namespace[cluster])
+
+	// create CA Secret.
+	err := k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", customCASecret, "--from-file=ca.crt",
+		"--from-file=ca.key")
+	require.NoError(t, err)
+
+	// Create encryption key secret if encryption is enabled
+	if config.EncryptionEnabled && config.EncryptionKeySecret != "" {
+		encryptionSecretName := config.EncryptionKeySecretName
+		if encryptionSecretName == "" {
+			encryptionSecretName = "cmek-key-secret"
+		}
+
+		// Use --from-literal with the base64-encoded key string. Kubernetes base64-encodes
+		// secret values for storage, so the pod receives the original base64 string when
+		// the secret is mounted — which the init container then decodes to get the raw key.
+		err = k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", encryptionSecretName,
+			fmt.Sprintf("--from-literal=StoreKeyData=%s", config.EncryptionKeySecret))
+		require.NoError(t, err)
+
+		// Verify secret was created with data
+		secretSize, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+			"get", "secret", encryptionSecretName,
+			"-o", "jsonpath={.data.StoreKeyData}")
+		require.NoError(t, err)
+		require.True(t, len(secretSize) > 0, "Secret StoreKeyData should be >0")
+		t.Logf("Created encryption secret %s with size: %d bytes", encryptionSecretName, len(secretSize))
+	}
+
+	// Install the operator when it is not skipped and not already marked as installed.
+	if !config.SkipOperatorInstall && !r.IsOperatorInstalled {
+		InstallCockroachDBEnterpriseOperator(t, kubectlOptions, r.RegionCodes[index])
+	}
+
+	// Build helm values
+	helmValues := PatchHelmValues(map[string]string{
+		"cockroachdb.clusterDomain":             CustomDomains[index],
+		"cockroachdb.tls.selfSigner.caProvided": "true",
+		"cockroachdb.tls.selfSigner.caSecret":   customCASecret,
+	})
+
+	// Add WAL failover configuration
+	if config.WALFailoverEnabled {
+		helmValues["cockroachdb.crdbCluster.walFailoverSpec.status"] = "enable"
+		helmValues["cockroachdb.crdbCluster.walFailoverSpec.size"] = config.WALFailoverSize
+		helmValues["cockroachdb.crdbCluster.walFailoverSpec.name"] = "datadir-wal-failover"
+		helmValues["cockroachdb.crdbCluster.walFailoverSpec.path"] = "/cockroach/cockroach-wal-failover"
+	}
+
+	// Add virtual cluster configuration
+	if config.VirtualClusterMode != "" {
+		helmValues["cockroachdb.crdbCluster.virtualCluster.mode"] = config.VirtualClusterMode
+	}
+
+	// Merge custom values
+	for k, v := range config.CustomValues {
+		helmValues[k] = v
+	}
+
+	// Determine which regions configuration to use
+	var regionsConfig interface{}
+	if config.CustomRegions != nil {
+		regionsConfig = config.CustomRegions
+	} else {
+		regionsConfig = r.OperatorRegions(index, r.NodeCount)
+	}
+
+	// Helm install cockroach CR with configuration
+	crdbOptions := &helm.Options{
+		KubectlOptions: kubectlOptions,
+		SetValues:      helmValues,
+		SetJsonValues: map[string]string{
+			"cockroachdb.crdbCluster.regions": MustMarshalJSON(regionsConfig),
+		},
+		ExtraArgs: helmExtraArgs,
+	}
+
+	helm.Install(t, crdbOptions, helmChartPath, ReleaseName)
+
+	serviceName := "cockroachdb-public"
+	k8s.WaitUntilServiceAvailable(t, kubectlOptions, serviceName, 30, 5*time.Second)
+}
+
+// ValidateWALFailover verifies that WAL failover is properly configured by checking the --wal-failover flag and PVC.
+// Pass nil config to rely on defaults or provide a pointer with overrides through AdvancedValidationConfig.WALFailover.
+func (r *Region) ValidateWALFailover(t *testing.T, cluster string, cfg *AdvancedValidationConfig) {
+	validationConfig := mergeValidationConfig(cfg)
+	expectedPath := validationConfig.WALFailover.CustomPath
+	if expectedPath == "" {
+		expectedPath = defaultWALFailoverPath
+	}
+
+	kubeConfig, _ := r.GetCurrentContext(t)
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+
+	// Get CockroachDB pods
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+
+	podName := pods[0].Name
+
+	// 1. Verify cockroach start command contains --wal-failover flag with custom path
+	t.Logf("Verifying cockroach start command contains --wal-failover flag with path %s...", expectedPath)
+	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+	require.NoError(t, err)
+	expectedFlag := fmt.Sprintf("--wal-failover=path=%s", expectedPath)
+	require.Contains(t, podCommand, expectedFlag,
+		"Pod command should contain %s", expectedFlag)
+	t.Logf("Cockroach start command contains --wal-failover flag with path %s", expectedPath)
+
+	// 2. Verify COCKROACH_WAL_FAILOVER environment variable is set
+	t.Log("Verifying COCKROACH_WAL_FAILOVER environment variable...")
+	walFailoverEnv, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].env[?(@.name=='COCKROACH_WAL_FAILOVER')].value}")
+	if err == nil && walFailoverEnv != "" {
+		t.Logf("COCKROACH_WAL_FAILOVER environment variable is set to: %s", walFailoverEnv)
+	}
+
+	// 3. Verify WAL failover PVC exists with correct naming convention
+	t.Log("Verifying WAL failover PVC exists...")
+	pvcs, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pvc", "-o", "jsonpath={.items[*].metadata.name}")
+	require.NoError(t, err)
+	t.Logf("Found PVCs: %s", pvcs)
+	// PVC should follow the pattern: datadir-wal-failover-cockroachdb-{index}
+	// The name prefix comes from walFailoverSpec.name which we set to "datadir-wal-failover"
+	require.Contains(t, pvcs, "datadir-wal-failover", "WAL failover PVC should exist with correct naming")
+	t.Log("WAL failover PVC exists with correct naming convention")
+
+	// 4. Verify WAL failover volume is mounted in the pod
+	t.Log("Verifying WAL failover volume is mounted...")
+	volumes, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pod", podName, "-o", "jsonpath={.spec.volumes[*].name}")
+	require.NoError(t, err)
+	// The volume name is always "wal-failover" regardless of the custom path or PVC name
+	require.Contains(t, volumes, "wal-failover", "WAL failover volume should be mounted")
+	t.Log("WAL failover volume is properly mounted")
+
+	// 5. Verify the custom WAL failover path exists in the container
+	t.Logf("Verifying custom WAL failover path %s exists in container...", expectedPath)
+	_, err = k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"exec", podName, "-c", "cockroachdb", "--",
+		"ls", "-la", expectedPath)
+	require.NoError(t, err)
+	t.Logf("Custom WAL failover path %s exists in container", expectedPath)
+
+	t.Log("WAL failover validation completed successfully")
+}
+
+// GenerateEncryptionKey generates a 256-bit AES encryption key and returns base64 encoded value
+func (r *Region) GenerateEncryptionKey(t *testing.T) string {
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "store.key")
+
+	// Generate 256-bit AES key using cockroach gen encryption-key
+	cmd := shell.Command{
+		Command:    "cockroach",
+		Args:       []string{"gen", "encryption-key", "--size", "256", "store.key"},
+		WorkingDir: tempDir,
+	}
+
+	_, err := shell.RunCommandAndGetOutputE(t, cmd)
+	require.NoError(t, err)
+
+	// Read the generated key file
+	keyBytes, err := os.ReadFile(keyPath)
+	require.NoError(t, err)
+
+	// Base64 encode the key (removing any newlines)
+	storeKeyB64 := base64.StdEncoding.EncodeToString(keyBytes)
+	storeKeyB64 = strings.ReplaceAll(storeKeyB64, "\n", "")
+
+	return storeKeyB64
+}
+
+// ValidateEncryptionAtRest verifies that encryption at rest is properly configured by checking flags and encryption status.
+// Pass nil config to rely on defaults or provide overrides via AdvancedValidationConfig.EncryptionAtRest.
+func (r *Region) ValidateEncryptionAtRest(t *testing.T, cluster string, cfg *AdvancedValidationConfig) {
+	kubeConfig, _ := r.GetCurrentContext(t)
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+
+	// Get CockroachDB pods
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+
+	podName := pods[0].Name
+
+	validationConfig := mergeValidationConfig(cfg)
+	secretName := validationConfig.EncryptionAtRest.SecretName
+	if secretName == "" {
+		secretName = defaultEncryptionSecret
+	}
+
+	// 1. Assert CR spec has encryptionAtRest set, which means --enterprise-encryption
+	// must be present in the pod start command.
+	t.Log("Verifying encryptionAtRest is set in the CrdbCluster CR spec...")
+	crEncryption, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "crdbcluster", "cockroachdb",
+		"-o", "jsonpath={.spec.regions[*].encryptionAtRest.keySecretName}")
+	require.NoError(t, err)
+	require.NotEmpty(t, crEncryption, "CrdbCluster CR spec should have encryptionAtRest.keySecretName set")
+	t.Logf("CrdbCluster CR spec has encryptionAtRest set with keySecretName: %s", crEncryption)
+
+	// 2. Verify the encryption key secret exists and has data
+	t.Logf("Verifying encryption key secret %s...", secretName)
+	secretSize, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "secret", secretName,
+		"-o", "jsonpath={.data.StoreKeyData}")
+	require.NoError(t, err)
+	require.True(t, len(secretSize) > 0, "Secret StoreKeyData should not be empty")
+	t.Logf("Encryption key secret %s exists with data", secretName)
+
+	// 3. Verify cockroach start command contains encryption flags
+	t.Log("Verifying cockroach start command contains encryption flags...")
+	podSpec, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+	require.NoError(t, err)
+	require.Contains(t, podSpec, "--enterprise-encryption", "Pod command should contain --enterprise-encryption flag")
+	t.Log("Cockroach start command contains encryption flags")
+
+	// 4. Verify all required fields of the --enterprise-encryption flag are present.
+	// Required fields per CockroachDB docs: path, key, old-key.
+	require.Contains(t, podSpec, "path=cockroach-data", "Encryption flag should contain path=cockroach-data")
+	require.Contains(t, podSpec, "key=/etc/cockroach-key/", "Encryption flag should contain key path")
+	oldKeyExpected := validationConfig.EncryptionAtRest.OldKeyExpected
+	require.Contains(t, podSpec, oldKeyExpected, "Encryption flag should contain %s", oldKeyExpected)
+	t.Log("Encryption flag verified: path, key, and old-key are all present")
+
+	// 5. Verify encryption algorithm via node metrics.
+	// rocksdb.encryption.algorithm: 0=Plaintext, 1=AES-128-CTR, 2=AES-192-CTR, 3=AES-256-CTR
+	t.Log("Verifying encryption algorithm via node metrics...")
+	encAlgorithm, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"exec", podName, "-c", "cockroachdb", "--",
+		"/cockroach/cockroach", "sql",
+		"--certs-dir=/cockroach/cockroach-certs",
+		"--host=localhost:26257",
+		"-e", "SET allow_unsafe_internals = true; SELECT value FROM crdb_internal.node_metrics WHERE name = 'rocksdb.encryption.algorithm';")
+	require.NoError(t, err)
+	require.Contains(t, encAlgorithm, "3", "rocksdb.encryption.algorithm should be 3 (AES-256-CTR)")
+	t.Logf("Encryption algorithm verified: AES-256-CTR (value=3)")
+
+	t.Log("Encryption at rest validation completed successfully")
+}
+
+// generateLocalTenantURI creates local connection URI for connecting to same cluster's tenants
+// Returns: postgresql://root:root@localhost:26257?options=-ccluster%3D<cluster>
+func generateLocalTenantURI(cluster string) string {
+	return fmt.Sprintf("postgresql://root:root@localhost:26257?options=-ccluster%%3D%s", cluster)
+}
+
+// generateExternalConnectionURI creates external connection URI using cockroach encode-uri
+// This is used for cross-cluster connections (e.g., replication from primary to standby)
+// Format: cockroach encode-uri 'postgresql://USERNAME:PASSWORD@HOST' [flags]
+func generateExternalConnectionURI(t *testing.T, kubectlOpts *k8s.KubectlOptions, pod string, connString string) string {
+	output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOpts,
+		"exec", pod, "-c", "cockroachdb", "--",
+		"/cockroach/cockroach", "encode-uri",
+		connString, // Format: postgresql://user:pass@host:port
+		"--ca-cert=/cockroach/cockroach-certs/ca.crt",
+		"--inline")
+	require.NoError(t, err)
+	return strings.TrimSpace(output)
+}
+
+// Helper function to execute SQL on a specific virtual cluster
+func execSQLOnVC(t *testing.T, kubectlOpts *k8s.KubectlOptions, pod string, vcURI string, database string, sql string) (string, error) {
+	args := []string{
+		"exec", pod, "-c", "cockroachdb", "--",
+		"/cockroach/cockroach", "sql",
+		"--certs-dir=/cockroach/cockroach-certs",
+		"--url", vcURI,
+	}
+	if database != "" {
+		args = append(args, "--database="+database)
+	}
+	args = append(args, "-e", sql)
+
+	return k8s.RunKubectlAndGetOutputE(t, kubectlOpts, args...)
+}
+
+// ValidatePCR validates PCR by verifying virtual cluster configuration and testing failover/failback connections.
+// Provide the cluster and namespaces through AdvancedValidationConfig.PCR.
+func (r *Region) ValidatePCR(t *testing.T, cfg *AdvancedValidationConfig) {
+	validationConfig := mergeValidationConfig(cfg)
+	cluster := validationConfig.PCR.Cluster
+	primaryNamespace := validationConfig.PCR.PrimaryNamespace
+	standbyNamespace := validationConfig.PCR.StandbyNamespace
+
+	require.NotEmpty(t, cluster, "PCR validation requires a cluster context")
+	require.NotEmpty(t, primaryNamespace, "PCR validation requires a primary namespace")
+	require.NotEmpty(t, standbyNamespace, "PCR validation requires a standby namespace")
+
+	kubeConfig, _ := r.GetCurrentContext(t)
+
+	// Get primary and standby pods
+	primaryKubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, primaryNamespace)
+	standbyKubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, standbyNamespace)
+
+	primaryPods := k8s.ListPods(t, primaryKubectlOptions, metav1.ListOptions{
+		LabelSelector: LabelSelector,
+	})
+	require.True(t, len(primaryPods) > 0, "No primary pods found")
+
+	standbyPods := k8s.ListPods(t, standbyKubectlOptions, metav1.ListOptions{
+		LabelSelector: LabelSelector,
+	})
+	require.True(t, len(standbyPods) > 0, "No standby pods found")
+
+	primaryPod := primaryPods[0].Name
+	standbyPod := standbyPods[0].Name
+
+	// Step 1: Setup primary cluster for PCR
+	t.Log("==================================================")
+	t.Log("Step 1: Setting up primary cluster for Physical Cluster Replication")
+	t.Log("==================================================")
+
+	// Generate local connection URIs for primary
+	primarySystemURI := generateLocalTenantURI("system")
+	t.Logf("Connecting to primary system tenant at: %s", primarySystemURI)
+
+	// Enable rangefeed for PCR (required for replication)
+	t.Log("Enabling rangefeed on primary cluster (required for PCR)...")
+	_, err := execSQLOnVC(t, primaryKubectlOptions, primaryPod, primarySystemURI, "", "SET CLUSTER SETTING kv.rangefeed.enabled = true")
+	require.NoError(t, err)
+	t.Log("✓ Rangefeed enabled on primary cluster")
+
+	// With --virtualized flag, the 'main' virtual cluster is created automatically
+	// We just need to verify it exists and ensure it's in SHARED mode
+	t.Log("Verifying main virtual cluster exists on primary (automatically created with --virtualized flag)...")
+	primaryVCs, err := execSQLOnVC(t, primaryKubectlOptions, primaryPod, primarySystemURI, "", "SHOW VIRTUAL CLUSTERS")
+	require.NoError(t, err)
+	require.Contains(t, primaryVCs, "main", "Primary should have main virtual cluster")
+	t.Logf("✓ Main virtual cluster exists on primary\n%s", primaryVCs)
+
+	// Ensure the service is started in SHARED mode
+	t.Log("Ensuring main virtual cluster service is in SHARED mode...")
+	_, err = execSQLOnVC(t, primaryKubectlOptions, primaryPod, primarySystemURI, "", "ALTER VIRTUAL CLUSTER main START SERVICE SHARED")
+	if err != nil && !strings.Contains(err.Error(), "already") {
+		t.Logf("Note: Service start returned: %v", err)
+	}
+	t.Log("✓ Main virtual cluster service is running in SHARED mode")
+
+	// Wait for main virtual cluster service to be ready in SHARED mode
+	t.Log("Waiting for main virtual cluster service readiness on primary...")
+	_, err = retry.DoWithRetryE(t, "wait for main virtual cluster service to be ready in SHARED mode",
+		24, 5*time.Second,
+		func() (string, error) {
+			out, execErr := execSQLOnVC(t, primaryKubectlOptions, primaryPod, primarySystemURI, "", "SHOW VIRTUAL CLUSTERS")
+			if execErr != nil {
+				return "", execErr
+			}
+			if !strings.Contains(out, "shared") {
+				return "", fmt.Errorf("main virtual cluster service not yet in SHARED mode: %s", out)
+			}
+			return out, nil
+		})
+	require.NoError(t, err, "main virtual cluster service did not reach SHARED mode")
+	t.Log("✓ Main virtual cluster service is ready in SHARED mode")
+
+	// Create replication user on primary with required permissions
+	t.Log("Creating replication user on primary cluster...")
+	createUserSQL := fmt.Sprintf("CREATE USER IF NOT EXISTS %s WITH PASSWORD '%s'", "pcr_source", "repl_password_123")
+	_, err = execSQLOnVC(t, primaryKubectlOptions, primaryPod, primarySystemURI, "", createUserSQL)
+	require.NoError(t, err)
+	t.Log("✓ Created user: pcr_source")
+
+	t.Log("Granting admin privileges to pcr_source...")
+	_, err = execSQLOnVC(t, primaryKubectlOptions, primaryPod, primarySystemURI, "", "GRANT admin TO pcr_source")
+	require.NoError(t, err)
+	t.Log("✓ Granted admin privileges to pcr_source")
+
+	t.Log("Primary cluster setup complete!")
+
+	// Step 2: Setup standby cluster
+	t.Log("")
+	t.Log("==================================================")
+	t.Log("Step 2: Setting up standby cluster")
+	t.Log("==================================================")
+
+	// Generate local connection URI for standby
+	standbySystemURI := generateLocalTenantURI("system")
+	t.Logf("Connecting to standby system tenant at: %s", standbySystemURI)
+
+	// Enable rangefeed on standby cluster
+	t.Log("Enabling rangefeed on standby cluster...")
+	_, err = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "SET CLUSTER SETTING kv.rangefeed.enabled = true")
+	require.NoError(t, err)
+	t.Log("✓ Rangefeed enabled on standby cluster")
+
+	// Verify standby was initialized with --virtualized-empty (no main VC yet)
+	t.Log("Verifying standby cluster state (should have no main virtual cluster yet)...")
+	standbyVCsInitial, err := execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "SHOW VIRTUAL CLUSTERS")
+	require.NoError(t, err)
+	t.Logf("Standby virtual clusters before replication:\n%s", standbyVCsInitial)
+	t.Log("✓ Standby initialized with --virtualized-empty (no main tenant yet)")
+
+	// Create admin user on standby
+	t.Log("Creating admin user on standby cluster...")
+	createAdminSQL := fmt.Sprintf("CREATE USER IF NOT EXISTS %s WITH PASSWORD '%s'", "pcr_admin", "admin_password_123")
+	_, err = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", createAdminSQL)
+	require.NoError(t, err)
+	_, err = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "GRANT admin TO pcr_admin")
+	require.NoError(t, err)
+	t.Log("✓ Created user pcr_admin with admin privileges")
+	t.Log("Standby cluster setup complete!")
+
+	// Step 4: Set up replication stream from standby to primary
+	t.Log("")
+	t.Log("==================================================")
+	t.Log("Step 4: Creating replication stream from primary to standby")
+	t.Log("==================================================")
+
+	// Step 4a: Generate external connection URI for replication
+	// Following: https://www.cockroachlabs.com/docs/stable/set-up-physical-cluster-replication#step-4-start-replication
+	t.Log("Generating connection URI for primary cluster using cockroach encode-uri...")
+	primaryHost := fmt.Sprintf("cockroachdb-public.%s.svc.%s:26257", primaryNamespace, CustomDomains[0])
+	primaryConnString := fmt.Sprintf("postgresql://%s:%s@%s", "pcr_source", "repl_password_123", primaryHost)
+	t.Logf("Primary connection string format: postgresql://pcr_source:***@%s", primaryHost)
+
+	// Use encode-uri to generate the proper connection string with certificates
+	encodedPrimaryURI := generateExternalConnectionURI(t, standbyKubectlOptions, standbyPod, primaryConnString)
+	t.Logf("✓ Generated encoded connection URI for replication")
+
+	// Step 4b: Create external connection on standby (as per documentation)
+	t.Log("Creating external connection on standby cluster...")
+	createExternalConnSQL := fmt.Sprintf("CREATE EXTERNAL CONNECTION IF NOT EXISTS primary_replication AS '%s'", encodedPrimaryURI)
+	_, err = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", createExternalConnSQL)
+	require.NoError(t, err)
+	t.Log("✓ External connection 'primary_replication' created on standby")
+
+	// Step 4c: Create the replication stream using the external connection name
+	t.Log("Creating replication stream on standby cluster using external connection...")
+	t.Log("This will create the main virtual cluster on standby and start replicating data from primary")
+	createReplicationCmd := "CREATE VIRTUAL CLUSTER main FROM REPLICATION OF main ON 'external://primary_replication'"
+	t.Logf("Executing: %s", createReplicationCmd)
+
+	output, err := execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", createReplicationCmd)
+	if err != nil && !strings.Contains(err.Error(), "already exists") && !strings.Contains(output, "already exists") {
+		t.Logf("ERROR: Replication stream creation failed: %v", err)
+		t.Logf("Output: %s", output)
+		// Debug: Check what tenants exist on primary
+		t.Log("Debugging: Checking virtual clusters on primary...")
+		tenantsOutput, _ := execSQLOnVC(t, primaryKubectlOptions, primaryPod, primarySystemURI, "", "SHOW VIRTUAL CLUSTERS")
+		t.Logf("Virtual clusters on primary:\n%s", tenantsOutput)
+		require.NoError(t, err, "Failed to create replication stream")
+	} else {
+		t.Log("✓ Replication stream created successfully!")
+		t.Log("✓ Main virtual cluster now exists on standby and is replicating from primary")
+	}
+
+	// Wait for replication stream to be active on standby
+	t.Log("Waiting for initial replication stream to become active on standby...")
+	_, err = retry.DoWithRetryE(t, "wait for replication stream to become active on standby",
+		36, 10*time.Second,
+		func() (string, error) {
+			out, execErr := execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "SHOW VIRTUAL CLUSTERS")
+			if execErr != nil {
+				return "", execErr
+			}
+			if !strings.Contains(out, "replicat") {
+				return "", fmt.Errorf("replication stream not yet active: %s", out)
+			}
+			return out, nil
+		})
+	require.NoError(t, err, "replication stream did not become active on standby")
+	t.Log("✓ Initial replication sync complete")
+
+	// Step 5: Verify replication status
+	t.Log("")
+	t.Log("==================================================")
+	t.Log("Step 5: Verifying replication status")
+	t.Log("==================================================")
+
+	t.Log("Checking virtual clusters on standby (should now include main)...")
+	standbyVCsStatus, err := execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "SHOW VIRTUAL CLUSTERS")
+	require.NoError(t, err)
+	require.Contains(t, standbyVCsStatus, "main", "Standby should now have main virtual cluster after replication setup")
+	t.Logf("Virtual clusters on standby:\n%s", standbyVCsStatus)
+	t.Log("✓ Main virtual cluster exists on standby with replication status")
+
+	t.Log("Replication verification complete!")
+
+	// Step 6: Test read-only access on standby using a separate reader virtual cluster
+	// Following: https://www.cockroachlabs.com/docs/stable/read-from-standby
+	t.Log("")
+	t.Log("==================================================")
+	t.Log("Step 6: Testing read-only access on standby cluster")
+	t.Log("==================================================")
+
+	// Step 6a: Create a reader virtual cluster for read-only access
+	// This is the recommended approach per documentation
+	t.Log("Creating a reader virtual cluster on standby for read-only access...")
+	t.Log("This allows read queries without affecting the replication stream")
+	createReaderSQL := `CREATE VIRTUAL CLUSTER "main-reader" FROM REPLICATION OF main ON 'external://primary_replication' WITH READ VIRTUAL CLUSTER`
+	_, err = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", createReaderSQL)
+	if err != nil && !strings.Contains(err.Error(), "already exists") {
+		t.Logf("Note: Reader VC creation returned: %v", err)
+	}
+	t.Log("✓ Reader virtual cluster 'main-reader' created")
+
+	// Step 6b: Start the reader service in SHARED mode
+	t.Log("Starting reader virtual cluster service in SHARED mode...")
+	_, err = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", `ALTER VIRTUAL CLUSTER "main-reader" START SERVICE SHARED`)
+	if err != nil && !strings.Contains(err.Error(), "already") {
+		t.Logf("Note: Service start returned: %v (may already be started)", err)
+	}
+	t.Log("✓ Reader service started in SHARED mode")
+
+	// Wait for reader virtual cluster service to be ready in SHARED mode
+	t.Log("Waiting for reader virtual cluster service to be ready in SHARED mode...")
+	_, err = retry.DoWithRetryE(t, "wait for main-reader virtual cluster service to be ready in SHARED mode",
+		36, 10*time.Second,
+		func() (string, error) {
+			out, execErr := execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "SHOW VIRTUAL CLUSTERS")
+			if execErr != nil {
+				return "", execErr
+			}
+			if !strings.Contains(out, "main-reader") || !strings.Contains(out, "shared") {
+				return "", fmt.Errorf("main-reader service not yet in SHARED mode: %s", out)
+			}
+			return out, nil
+		})
+	require.NoError(t, err, "main-reader virtual cluster service did not reach SHARED mode")
+
+	// Step 6c: Verify reader virtual cluster exists
+	t.Log("Verifying reader virtual cluster status...")
+	readerVCsStatus, err := execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "SHOW VIRTUAL CLUSTERS")
+	require.NoError(t, err)
+	require.Contains(t, readerVCsStatus, "main-reader", "Standby should have main-reader virtual cluster")
+	t.Logf("Virtual clusters on standby:\n%s", readerVCsStatus)
+	t.Log("✓ Reader virtual cluster is ready")
+
+	// Step 6d: Read from the reader virtual cluster
+	t.Log("Attempting to read replicated data from reader virtual cluster...")
+	readerURI := generateLocalTenantURI("main-reader")
+	readFromStandby, err := execSQLOnVC(t, standbyKubectlOptions, standbyPod, readerURI, "bank", "SELECT id, balance FROM accounts ORDER BY id")
+	if err != nil {
+		t.Logf("Warning: Read from standby reader failed (may need more time): %v", err)
+		// Try reading directly from main VC as fallback
+		t.Log("Trying to read from main virtual cluster instead...")
+		standbyMainURI := generateLocalTenantURI("main")
+		readFromStandby, err = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbyMainURI, "bank", "SELECT id, balance FROM accounts ORDER BY id")
+		if err != nil {
+			t.Logf("Warning: Read from main VC also failed: %v", err)
+		}
+	}
+
+	if err == nil {
+		require.Contains(t, readFromStandby, "1000", "Should be able to read replicated data from standby")
+		require.Contains(t, readFromStandby, "250", "Should be able to read replicated data from standby")
+		t.Log("✓ Successfully read replicated data from standby reader!")
+		t.Logf("Data from standby reader:\n%s", readFromStandby)
+	}
+
+	t.Log("Read-only access test complete!")
+
+	// Step 7: Test failover (cutover)
+	t.Log("")
+	t.Log("==================================================")
+	t.Log("Step 7: Testing failover (promoting standby to primary)")
+	t.Log("==================================================")
+
+	// Stop the service first (if running in SHARED mode)
+	t.Log("Stopping main virtual cluster service on standby before cutover...")
+	_, _ = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "ALTER VIRTUAL CLUSTER main STOP SERVICE")
+	t.Log("✓ Service stopped")
+
+	time.Sleep(5 * time.Second)
+
+	// Complete replication to latest - this makes the standby writable
+	t.Log("Completing replication to latest (this promotes standby to be writable)...")
+	_, err = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "ALTER VIRTUAL CLUSTER main COMPLETE REPLICATION TO LATEST")
+	if err != nil {
+		t.Logf("Note: Cutover command returned: %v", err)
+	}
+	t.Log("✓ Replication completed to latest")
+
+	// Wait for cutover to complete
+	t.Log("Waiting for cutover to complete (15 seconds)...")
+	time.Sleep(15 * time.Second)
+
+	// Step 8: Start the service after cutover
+	t.Log("")
+	t.Log("==================================================")
+	t.Log("Step 8: Starting service on promoted standby")
+	t.Log("==================================================")
+
+	t.Log("Starting main virtual cluster service after cutover...")
+	_, err = execSQLOnVC(t, standbyKubectlOptions, standbyPod, standbySystemURI, "", "ALTER VIRTUAL CLUSTER main START SERVICE SHARED")
+	if err != nil {
+		t.Logf("Note: Service start returned: %v (may already be started)", err)
+	}
+	t.Log("✓ Service started, standby is now the primary and can accept writes")
 }

--- a/tests/e2e/operator/region.go
+++ b/tests/e2e/operator/region.go
@@ -32,6 +32,20 @@ const (
 	OperatorLabelSelector = "app=cockroach-operator"
 )
 
+// EncryptionPlatformConfig holds provider-specific encryption configuration defaults
+type EncryptionPlatformConfig struct {
+	// Platform is the KMS platform type: "AWS_KMS", "GCP_CLOUD_KMS", or "UNKNOWN_KEY_TYPE"
+	Platform string
+
+	// RequiresCredentialsSecret indicates if cmekCredentialsSecretName is required
+	// True for AWS_KMS and GCP_KMS, false for UNKNOWN_KEY_TYPE (file-based)
+	RequiresCredentialsSecret bool
+
+	// DefaultCredentialsSecretName is the default name for the credentials secret
+	// Used when RequiresCredentialsSecret is true
+	DefaultCredentialsSecretName string
+}
+
 var (
 	Clusters      = []string{"chart-testing-cluster-0", "chart-testing-cluster-1"}
 	CustomDomains = map[int]string{

--- a/tests/e2e/operator/region.go
+++ b/tests/e2e/operator/region.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
-	"github.com/cockroachdb/helm-charts/tests/testutil"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
@@ -23,13 +21,16 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
+	"github.com/cockroachdb/helm-charts/tests/testutil"
 )
 
 const (
 	TestDBName            = "testdb"
 	Namespace             = "cockroach-ns"
 	LabelSelector         = "app=cockroachdb"
-	OperatorLabelSelector = "app=cockroach-operator"
+	LabelSelectorOperator = "app=cockroach-operator"
 )
 
 // EncryptionPlatformConfig holds provider-specific encryption configuration defaults
@@ -66,21 +67,9 @@ var (
 	}
 )
 
-// OperatorUseCases defines use cases for the CockroachDB cluster.
-type OperatorUseCases interface {
-	TestHelmInstall(t *testing.T)
-	TestHelmUpgrade(t *testing.T)
-	TestClusterScaleUp(t *testing.T)
-	TestClusterRollingRestart(t *testing.T)
-	TestKillingCockroachNode(t *testing.T)
-	TestInstallWithCertManager(t *testing.T)
-}
-
 type Region struct {
 	// IsCertManager is true if the cockroachdb cluster is using cert-manager.
 	IsCertManager bool
-	// IsMultiRegion is true if the region is multi-region.
-	IsMultiRegion bool
 	// NodeCount is the desired CockroachDB nodes in the region.
 	NodeCount int
 	// Namespace stores mapping between cluster name and namespace.
@@ -93,6 +82,8 @@ type Region struct {
 	CorednsClusterOptions map[string]coredns.CoreDNSClusterOption
 	Provider              string
 	RegionCodes           []string
+	// TestRunID is a unique identifier for this test run (for concurrent test isolation)
+	TestRunID string
 
 	VirtualClusterModePrimary bool
 	VirtualClusterModeStandby bool
@@ -120,8 +111,28 @@ func (r *Region) InstallCharts(t *testing.T, cluster string, index int) {
 	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
 	certManagerK8sOptions := k8s.NewKubectlOptions(cluster, kubeConfig, testutil.CertManagerNamespace)
 
-	// Create a namespace.
-	k8s.CreateNamespace(t, kubectlOptions, r.Namespace[cluster])
+	// Create a namespace with retry logic to handle transient proxy errors (e.g., Netskope)
+	var err error
+	const maxRetries = 5
+	const sleepBetweenRetries = 5 * time.Second
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		err = k8s.CreateNamespaceE(t, kubectlOptions, r.Namespace[cluster])
+		if err == nil {
+			break
+		}
+		// Only retry on transient proxy/certificate errors using centralized helper
+		if testutil.IsTransientNetworkError(err) {
+			t.Logf("Transient proxy error creating namespace (will retry, attempt %d/%d): %v", attempt, maxRetries, err)
+			if attempt < maxRetries {
+				time.Sleep(sleepBetweenRetries)
+				continue
+			}
+		} else {
+			// Non-transient error: fail immediately without retrying
+			require.NoError(t, err, "Failed to create namespace (non-transient error)")
+		}
+	}
+	require.NoError(t, err, "Failed to create namespace after retries")
 
 	if r.IsCertManager {
 		testutil.InstallCertManager(t, certManagerK8sOptions)
@@ -131,10 +142,28 @@ func (r *Region) InstallCharts(t *testing.T, cluster string, index int) {
 		testutil.CreateCAIssuer(t, kubectlOptions, r.Namespace[cluster])
 		testutil.CreateBundle(t, kubectlOptions, testutil.CASecretName, testutil.CAConfigMapName)
 	} else {
-		// create CA Secret.
-		err := k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", customCASecret, "--from-file=ca.crt",
-			"--from-file=ca.key")
-		require.NoError(t, err)
+		// create CA Secret with retry logic for transient proxy errors using centralized helper
+		const maxCASecRetries = 5
+		const sleepBetweenCASecRetries = 5 * time.Second
+		for attempt := 1; attempt <= maxCASecRetries; attempt++ {
+			err = k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", customCASecret, "--from-file=ca.crt",
+				"--from-file=ca.key")
+			if err == nil {
+				break
+			}
+			// Only retry on transient proxy / certificate issues using centralized helper
+			if testutil.IsTransientNetworkError(err) {
+				t.Logf("Transient proxy error creating secret (will retry, attempt %d/%d): %v", attempt, maxCASecRetries, err)
+				if attempt < maxCASecRetries {
+					time.Sleep(sleepBetweenCASecRetries)
+					continue
+				}
+			} else {
+				// Non-transient error: fail immediately without further retries
+				require.NoError(t, err, "failed to create CA secret (non-transient error)")
+			}
+		}
+		require.NoError(t, err, "failed to create CA secret after transient retries")
 	}
 
 	// Setup kubectl options for this cluster.
@@ -234,7 +263,9 @@ func (r *Region) ValidateCRDB(t *testing.T, cluster string) {
 // VerifyHelmUpgrade waits till all the pods are restarted after the
 // helm upgrade is completed, it verifies with initialTimestamp which is the timestamp
 // of the pods before recreation and returns the pod name.
-func (r *Region) VerifyHelmUpgrade(t *testing.T, initialTimestamp time.Time, kubectlOptions *k8s.KubectlOptions) error {
+func (r *Region) VerifyHelmUpgrade(
+	t *testing.T, initialTimestamp time.Time, kubectlOptions *k8s.KubectlOptions,
+) error {
 	// Wait for the pods to be recreated with a new timestamp after the upgrade.
 	_, err := retry.DoWithRetryE(t, "waiting for pods to be recreated with new timestamp",
 		60, 10*time.Second,
@@ -375,6 +406,10 @@ func (r *Region) ValidateCRDBContainerResources(t *testing.T, kubectlOptions *k8
 
 // CreateCACertificate creates CA cert and key at the same path.
 func (r *Region) CreateCACertificate(t *testing.T) error {
+	// Clean up any existing certificate files from previous runs
+	// (prevents "CA key ca.key exists, but key reuse is disabled" error)
+	r.CleanUpCACertificate(t)
+
 	// Create CA secret in all regions.
 	cmd := shell.Command{
 		Command:    "cockroach",
@@ -401,13 +436,13 @@ func (r *Region) CleanUpCACertificate(t *testing.T) {
 
 // GetCurrentContext gets the current cluster context from KubeConfig.
 func (r *Region) GetCurrentContext(t *testing.T) (string, api.Config) {
-	// Try to get kubeconfig path using the standard method
+	// Try to get a kubeconfig path using the standard method
 	kubeConfig, err := k8s.GetKubeConfigPathE(t)
 	require.NoError(t, err)
 	_, err = r.EnsureKubeConfigPath()
 	require.NoError(t, err)
-	config := k8s.LoadConfigFromPath(kubeConfig)
-	rawConfig, err := config.RawConfig()
+	configFromPath := k8s.LoadConfigFromPath(kubeConfig)
+	rawConfig, err := configFromPath.RawConfig()
 	require.NoError(t, err)
 	return kubeConfig, rawConfig
 }
@@ -545,10 +580,12 @@ func (r *Region) createOperatorRegions(index int, nodes int, customDomains map[i
 }
 
 // VerifyInitCommandInOperatorLogs verifies that the operator logs contain the expected init command.
-func VerifyInitCommandInOperatorLogs(t *testing.T, kubectlOptions *k8s.KubectlOptions, expected string) {
+func VerifyInitCommandInOperatorLogs(
+	t *testing.T, kubectlOptions *k8s.KubectlOptions, expected string,
+) {
 	// Get operator pods
 	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
-		LabelSelector: OperatorLabelSelector,
+		LabelSelector: LabelSelectorOperator,
 	})
 	require.NotEmpty(t, pods, "no operator pods found")
 
@@ -587,7 +624,7 @@ func InstallCockroachDBEnterpriseOperator(t *testing.T, kubectlOptions *k8s.Kube
 
 	// wait for the operator pod to be running
 	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
-		LabelSelector: OperatorLabelSelector,
+		LabelSelector: LabelSelectorOperator,
 	})
 
 	for i := range pods {

--- a/tests/e2e/operator/singleRegion/cockroachdb_single_region_advanced_features_test.go
+++ b/tests/e2e/operator/singleRegion/cockroachdb_single_region_advanced_features_test.go
@@ -1,0 +1,590 @@
+package singleRegion
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestWALFailover tests the WAL failover functionality by:
+// 1. Installing CockroachDB with WAL failover enabled with custom path
+// 2. Verifying the cluster is healthy
+// 3. Verifying --wal-failover flag with custom path and PVC mounting
+func (r *singleRegion) TestWALFailover(t *testing.T) {
+	cluster := r.Clusters[0]
+	cleanup := r.SetupSingleClusterWithCA(t, cluster)
+	defer cleanup()
+
+	// Install CockroachDB with WAL failover enabled using common method
+	config := operator.AdvancedInstallConfig{
+		WALFailoverEnabled: true,
+		WALFailoverSize:    "5Gi",
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
+
+	// Validate CockroachDB cluster is healthy
+	r.ValidateCRDB(t, cluster)
+
+	// Validate WAL failover with workload and metrics monitoring
+	r.ValidateWALFailover(t, cluster, nil)
+
+	t.Logf("WAL failover test completed successfully")
+}
+
+// TestWALFailoverDisable tests disabling WAL failover via helm upgrade by:
+// 1. Installing CockroachDB with WAL failover enabled with custom path
+// 2. Verifying WAL failover is configured with custom path
+// 3. Upgrading to disable WAL failover
+// 4. Verifying --wal-failover flag contains disable and prev_path
+func (r *singleRegion) TestWALFailoverDisable(t *testing.T) {
+	cluster := r.Clusters[0]
+	cleanup := r.SetupSingleClusterWithCA(t, cluster)
+	defer cleanup()
+
+	// Step 1: Install CockroachDB with WAL failover enabled
+	t.Log("Installing CockroachDB with WAL failover enabled...")
+	config := operator.AdvancedInstallConfig{
+		WALFailoverEnabled: true,
+		WALFailoverSize:    "5Gi",
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
+
+	// Validate CockroachDB cluster is healthy
+	r.ValidateCRDB(t, cluster)
+
+	// Validate WAL failover is enabled
+	r.ValidateWALFailover(t, cluster, nil)
+
+	// Step 2: Upgrade to disable WAL failover
+	t.Log("Upgrading to disable WAL failover...")
+	kubeConfig, _ := r.GetCurrentContext(t)
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+
+	// Get initial pod timestamps before upgrade
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+	initialTimestamp := pods[0].CreationTimestamp.Time
+
+	// Get helm chart paths
+	helmChartPath, _ := operator.HelmChartPaths()
+
+	// Upgrade with WAL failover disabled
+	disableConfig := operator.PatchHelmValues(map[string]string{
+		"cockroachdb.clusterDomain":                      operator.CustomDomains[0],
+		"cockroachdb.tls.selfSigner.caProvided":          "true",
+		"cockroachdb.tls.selfSigner.caSecret":            "cockroachdb-ca-secret",
+		"cockroachdb.crdbCluster.walFailoverSpec.status": "disable",
+		"cockroachdb.crdbCluster.walFailoverSpec.name":   "datadir-wal-failover",
+		"cockroachdb.crdbCluster.walFailoverSpec.path":   "/cockroach/cockroach-wal-failover",
+	})
+
+	upgradeOptions := &helm.Options{
+		KubectlOptions: kubectlOptions,
+		SetValues:      disableConfig,
+		SetJsonValues: map[string]string{
+			"cockroachdb.crdbCluster.regions": operator.MustMarshalJSON(r.OperatorRegions(0, r.NodeCount)),
+		},
+		ExtraArgs: map[string][]string{
+			"upgrade": {"--reuse-values", "--wait"},
+		},
+	}
+
+	helm.Upgrade(t, upgradeOptions, helmChartPath, operator.ReleaseName)
+
+	// Wait for upgrade to complete using VerifyHelmUpgrade helper
+	err := r.VerifyHelmUpgrade(t, initialTimestamp, kubectlOptions)
+	require.NoError(t, err)
+
+	// Step 3: Verify WAL failover is disabled
+	t.Log("Verifying WAL failover is disabled after upgrade...")
+	pods = k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+
+	podName := pods[0].Name
+
+	// Verify --wal-failover flag now contains "disable" and "prev_path"
+	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+	require.NoError(t, err)
+	require.Contains(t, podCommand, "--wal-failover=disable", "Pod command should contain --wal-failover=disable after disabling")
+	require.Contains(t, podCommand, "prev_path=/cockroach/cockroach-wal-failover", "Pod command should contain prev_path with custom path after disabling")
+
+	// Verify WAL failover PVC still exists (not deleted on disable)
+	pvcs, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pvc", "-o", "jsonpath={.items[*].metadata.name}")
+	require.NoError(t, err)
+	require.Contains(t, pvcs, "datadir-wal-failover", "WAL failover PVC should still exist after disable")
+	t.Logf("PVCs after disable: %s", pvcs)
+
+	t.Log("WAL failover successfully disabled")
+	t.Logf("WAL failover disable test completed successfully")
+}
+
+// TestEncryptionAtRestEnable tests encryption at rest functionality by:
+// 1. Generating a proper 256-bit AES encryption key
+// 2. Creating encryption key secret
+// 3. Installing CockroachDB with encryption at rest enabled
+// 4. Verifying the cluster is healthy and encryption is active
+func (r *singleRegion) TestEncryptionAtRestEnable(t *testing.T) {
+	cluster := r.Clusters[0]
+	cleanup := r.SetupSingleClusterWithCA(t, cluster)
+	defer cleanup()
+
+	// Generate proper 256-bit AES encryption key
+	t.Log("Generating 256-bit AES encryption key...")
+	encryptionKeyB64 := r.GenerateEncryptionKey(t)
+	t.Logf("Generated encryption key (base64 length: %d)", len(encryptionKeyB64))
+
+	// Configure encryption at rest regions
+	encryptionRegions := r.BuildEncryptionRegions(cluster, 0, nil)
+
+	// Install CockroachDB with encryption at rest enabled using common method
+	config := operator.AdvancedInstallConfig{
+		EncryptionEnabled:   true,
+		EncryptionKeySecret: encryptionKeyB64,
+		CustomRegions:       encryptionRegions,
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
+
+	// Validate CockroachDB cluster is healthy
+	r.ValidateCRDB(t, cluster)
+
+	// Validate encryption at rest is active
+	r.ValidateEncryptionAtRest(t, cluster, nil)
+
+	// Additional validation: Verify key and old-key in the encryption flag
+	kubeConfig, _ := r.GetCurrentContext(t)
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+	podName := pods[0].Name
+
+	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+	require.NoError(t, err)
+
+	// Verify encryption flag format: key should point to the secret, old-key should be "plain" for initial setup
+	require.Contains(t, podCommand, "key=/etc/cockroach-key/", "Encryption flag should contain key path")
+	require.Contains(t, podCommand, "old-key=plain", "Encryption flag should have old-key=plain for initial setup")
+	t.Logf("Verified encryption flag format with key and old-key=plain")
+
+	t.Logf("Encryption at rest enable test completed successfully")
+}
+
+// TestEncryptionAtRestDisable tests transitioning from encrypted to plaintext by:
+// 1. Installing CockroachDB with encryption at rest enabled
+// 2. Verifying encryption is active
+// 3. Upgrading to use plaintext (setting keySecretName to nil and oldKeySecretName to existing secret)
+// 4. Verifying --enterprise-encryption flag still exists but now points to "plain" (plaintext)
+// Note: Once encryption is enabled, you must always include the --enterprise-encryption flag.
+// To disable encryption, keep encryptionAtRest enabled but
+// set keySecretName to nil/empty and oldKeySecretName to the existing secret.
+func (r *singleRegion) TestEncryptionAtRestDisable(t *testing.T) {
+	cluster := r.Clusters[0]
+	cleanup := r.SetupSingleClusterWithCA(t, cluster)
+	defer cleanup()
+
+	// Step 1: Install CockroachDB with encryption at rest enabled
+	t.Log("Installing CockroachDB with encryption at rest enabled...")
+	encryptionKeyB64 := r.GenerateEncryptionKey(t)
+	t.Logf("Generated encryption key (base64 length: %d)", len(encryptionKeyB64))
+
+	// Configure encryption at rest regions
+	encryptionRegions := r.BuildEncryptionRegions(cluster, 0, nil)
+
+	config := operator.AdvancedInstallConfig{
+		EncryptionEnabled:   true,
+		EncryptionKeySecret: encryptionKeyB64,
+		CustomRegions:       encryptionRegions,
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
+
+	// Validate CockroachDB cluster is healthy
+	r.ValidateCRDB(t, cluster)
+
+	// Validate encryption at rest is active
+	r.ValidateEncryptionAtRest(t, cluster, nil)
+
+	// Step 2: Trigger plaintext transition via helm upgrade.
+	// Setting keySecretName absent (nil in operator = "plain") and oldKeySecretName to the
+	// current key secret tells the operator to transition to plaintext mode.
+	t.Log("Upgrading CrdbCluster to configure plaintext transition...")
+	kubeConfig, _ := r.GetCurrentContext(t)
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+	helmChartPath, _ := operator.HelmChartPaths()
+
+	// Get initial pod timestamps before upgrade
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+	initialTimestamp := pods[0].CreationTimestamp.Time
+
+	// keySecretName="" is deleted from the map by EncryptionAtRestConfig (nil/empty → omit from JSON).
+	// An absent keySecretName is interpreted by the operator as "plain" (no new key).
+	// oldKeySecretName tells the operator to reference the previous key during the transition.
+	regions := r.BuildEncryptionRegions(cluster, 0, map[string]interface{}{
+		"keySecretName":    "",
+		"oldKeySecretName": "cmek-key-secret",
+	})
+
+	upgradeOptions := &helm.Options{
+		KubectlOptions: kubectlOptions,
+		SetJsonValues: map[string]string{
+			"cockroachdb.crdbCluster.regions": operator.MustMarshalJSON(regions),
+		},
+		ExtraArgs: map[string][]string{
+			"upgrade": {"--reuse-values", "--wait"},
+		},
+	}
+
+	helm.Upgrade(t, upgradeOptions, helmChartPath, operator.ReleaseName)
+
+	err := r.VerifyHelmUpgrade(t, initialTimestamp, kubectlOptions)
+	require.NoError(t, err)
+
+	// Step 3: Verify the CrdbCluster CR spec was correctly updated.
+	// The authoritative signal for "disable EAR" is the CR spec:
+	//   - keySecretName must be absent (operator interprets nil as "plain")
+	//   - oldKeySecretName must reference the previous key secret
+	// This validation works regardless of the pod-level rolling restart state.
+	t.Log("Verifying CrdbCluster CR spec reflects plaintext transition...")
+	crEncryption, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "crdbcluster", "cockroachdb",
+		"-o", "jsonpath={.spec.regions[*].encryptionAtRest}")
+	require.NoError(t, err)
+	require.Contains(t, crEncryption, "cmek-key-secret",
+		"CrdbCluster CR should reference the old key secret for the plaintext transition")
+	require.NotContains(t, crEncryption, `"keySecretName"`,
+		"CrdbCluster CR should not have keySecretName set (absent = operator uses plain)")
+	t.Logf("CrdbCluster CR spec correctly updated for plaintext transition: %s", crEncryption)
+
+	// Step 4: Verify pod command reflects plaintext transition.
+	t.Log("Verifying transition to plaintext after upgrade...")
+	pods = k8s.ListPods(t, kubectlOptions, metav1.ListOptions{LabelSelector: operator.LabelSelector})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+	podName := pods[0].Name
+
+	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+	require.NoError(t, err)
+	require.Contains(t, podCommand, "--enterprise-encryption",
+		"Pod command should still contain --enterprise-encryption flag (required once encryption is enabled)")
+	require.Contains(t, podCommand, "key=plain",
+		"Encryption flag should have key=plain for plaintext mode")
+	require.Contains(t, podCommand, "old-key=/etc/cockroach-key/",
+		"Encryption flag should have old-key pointing to the previous encrypted key")
+	t.Logf("Verified encryption flag format with key=plain and old-key pointing to encrypted key")
+
+	t.Log("Encryption at rest disable test completed successfully")
+}
+
+// TestEncryptionAtRestModifySecret tests rotating the encryption key by:
+// 1. Installing CockroachDB with encryption at rest enabled
+// 2. Verifying encryption is active
+// 3. Generating a new encryption key and creating a new secret
+// 4. Upgrading with keySecretName pointing to new secret and oldKeySecretName to existing secret
+// 5. Verifying encryption still works with rotated key
+// Note: Key rotation requires setting keySecretName to the new key and oldKeySecretName to the old key.
+func (r *singleRegion) TestEncryptionAtRestModifySecret(t *testing.T) {
+	cluster := r.Clusters[0]
+	cleanup := r.SetupSingleClusterWithCA(t, cluster)
+	defer cleanup()
+
+	// Step 1: Install CockroachDB with encryption at rest enabled
+	t.Log("Installing CockroachDB with encryption at rest enabled...")
+	encryptionKeyB64 := r.GenerateEncryptionKey(t)
+	t.Logf("Generated initial encryption key (base64 length: %d)", len(encryptionKeyB64))
+
+	// Configure encryption at rest regions
+	encryptionRegions := r.BuildEncryptionRegions(cluster, 0, nil)
+
+	config := operator.AdvancedInstallConfig{
+		EncryptionEnabled:   true,
+		EncryptionKeySecret: encryptionKeyB64,
+		CustomRegions:       encryptionRegions,
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
+
+	// Validate CockroachDB cluster is healthy
+	r.ValidateCRDB(t, cluster)
+
+	// Validate encryption at rest is active
+	r.ValidateEncryptionAtRest(t, cluster, nil)
+
+	// Step 2: Generate new encryption key and create new secret
+	t.Log("Generating new encryption key and creating new secret...")
+	kubeConfig, _ := r.GetCurrentContext(t)
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+
+	newEncryptionKeyB64 := r.GenerateEncryptionKey(t)
+	t.Logf("Generated new encryption key (base64 length: %d)", len(newEncryptionKeyB64))
+
+	// Create new secret using --from-literal with the base64-encoded key string.
+	// Kubernetes base64-encodes secret values for storage, so the pod receives the
+	// original base64 string when mounted — which the init container then decodes.
+	err := k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", "cmek-key-secret-new",
+		fmt.Sprintf("--from-literal=StoreKeyData=%s", newEncryptionKeyB64))
+	require.NoError(t, err)
+
+	t.Log("Created new encryption key secret: cmek-key-secret-new")
+
+	// Get initial pod timestamps before upgrade
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+	initialTimestamp := pods[0].CreationTimestamp.Time
+
+	// Step 3: Configure regions with key rotation - new key in keySecretName, old key in oldKeySecretName
+	t.Log("Upgrading with key rotation configuration...")
+	helmChartPath, _ := operator.HelmChartPaths()
+
+	// Configure regions with both new and old keys for rotation
+	rotationRegions := r.BuildEncryptionRegions(cluster, 0, map[string]interface{}{
+		"keySecretName":    "cmek-key-secret-new",
+		"oldKeySecretName": "cmek-key-secret",
+	})
+
+	upgradeOptions := &helm.Options{
+		KubectlOptions: kubectlOptions,
+		SetJsonValues: map[string]string{
+			"cockroachdb.crdbCluster.regions": operator.MustMarshalJSON(rotationRegions),
+		},
+		ExtraArgs: map[string][]string{
+			"upgrade": {"--reuse-values", "--wait"},
+		},
+	}
+
+	helm.Upgrade(t, upgradeOptions, helmChartPath, operator.ReleaseName)
+
+	// Wait for pods to restart and key rotation to complete using VerifyHelmUpgrade helper
+	err = r.VerifyHelmUpgrade(t, initialTimestamp, kubectlOptions)
+	require.NoError(t, err)
+
+	// Step 4: Verify encryption is still active with new key
+	t.Log("Verifying encryption at rest is still active with new key...")
+
+	// Validate CockroachDB cluster is healthy
+	r.ValidateCRDB(t, cluster)
+
+	// Validate encryption at rest is still active. After key rotation old-key points to
+	// the previous key path rather than "plain".
+	r.ValidateEncryptionAtRest(t, cluster, &operator.AdvancedValidationConfig{
+		EncryptionAtRest: operator.EncryptionAtRestValidation{
+			SecretName:     "cmek-key-secret-new",
+			OldKeyExpected: "old-key=/etc/cockroach-key/",
+		},
+	})
+
+	// Verify new secret exists and is being used
+	newSecretData, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "secret", "cmek-key-secret-new", "-o", "jsonpath={.data.StoreKeyData}")
+	require.NoError(t, err)
+	t.Logf("New secret key length: %d", len(newSecretData))
+
+	// Verify old secret still exists (referenced in oldKeySecretName)
+	oldSecretData, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "secret", "cmek-key-secret", "-o", "jsonpath={.data.StoreKeyData}")
+	require.NoError(t, err)
+	t.Logf("Old secret key length: %d", len(oldSecretData))
+
+	// Verify pod command contains encryption flag with both key references
+	pods = k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+	podName := pods[0].Name
+
+	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+	require.NoError(t, err)
+	require.Contains(t, podCommand, "--enterprise-encryption", "Pod command should contain --enterprise-encryption flag")
+
+	// Verify encryption flag format: key should point to new secret, old-key should point to old secret
+	require.Contains(t, podCommand, "key=/etc/cockroach-key/", "Encryption flag should contain new key path")
+	require.Contains(t, podCommand, "old-key=/etc/cockroach-key/", "Encryption flag should contain old key path for rotation")
+	t.Logf("Verified encryption flag format with both new key and old-key during rotation")
+	t.Logf("Encryption flag after key rotation: %s", podCommand)
+
+	t.Log("Encryption at rest successfully working with rotated key")
+	t.Logf("Encryption at rest modify secret test completed successfully")
+}
+
+// TestWALFailoverWithEncryption tests WAL failover with encryption at rest by:
+// 1. Installing CockroachDB with both WAL failover and encryption at rest enabled
+// 2. Verifying the cluster is healthy
+// 3. Verifying --wal-failover flag with custom path
+// 4. Verifying --enterprise-encryption flag includes WAL path encryption
+// Note: When WAL failover is enabled with encryption at rest, the WAL path must also be encrypted.
+func (r *singleRegion) TestWALFailoverWithEncryption(t *testing.T) {
+	cluster := r.Clusters[0]
+	cleanup := r.SetupSingleClusterWithCA(t, cluster)
+	defer cleanup()
+
+	// Step 1: Generate encryption key
+	t.Log("Generating 256-bit AES encryption key...")
+	encryptionKeyB64 := r.GenerateEncryptionKey(t)
+	t.Logf("Generated encryption key (base64 length: %d)", len(encryptionKeyB64))
+
+	// Configure encryption at rest regions
+	encryptionRegions := r.BuildEncryptionRegions(cluster, 0, nil)
+
+	// Install CockroachDB with both WAL failover and encryption enabled
+	config := operator.AdvancedInstallConfig{
+		WALFailoverEnabled:  true,
+		WALFailoverSize:     "5Gi",
+		EncryptionEnabled:   true,
+		EncryptionKeySecret: encryptionKeyB64,
+		CustomRegions:       encryptionRegions,
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
+
+	// Validate CockroachDB cluster is healthy
+	r.ValidateCRDB(t, cluster)
+
+	// Step 2: Verify WAL failover is configured
+	t.Log("Verifying WAL failover configuration...")
+	kubeConfig, _ := r.GetCurrentContext(t)
+	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
+
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: operator.LabelSelector,
+	})
+	require.True(t, len(pods) > 0, "No CockroachDB pods found")
+	podName := pods[0].Name
+
+	// Verify --wal-failover flag exists
+	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+	require.NoError(t, err)
+	require.Contains(t, podCommand, "--wal-failover=path=/cockroach/cockroach-wal-failover",
+		"Pod command should contain --wal-failover flag with custom path")
+
+	// Step 3: Verify encryption is configured for both data store and WAL path
+	t.Log("Verifying encryption is configured for data store and WAL path...")
+	// Encryption flag is part of the command
+	require.Contains(t, podCommand, "--enterprise-encryption",
+		"Pod command should contain --enterprise-encryption flag")
+
+	// The encryption flag should reference the WAL failover path
+	// Format: --enterprise-encryption=path=cockroach-data,key=...,old-key=plain;path=/cockroach/cockroach-wal-failover,key=...,old-key=plain
+	require.Contains(t, podCommand, "cockroach-data",
+		"Encryption flag should include data store path")
+	require.Contains(t, podCommand, "/cockroach/cockroach-wal-failover",
+		"Encryption flag should include WAL failover path for encryption")
+
+	// Verify encryption flag format: both data and WAL paths should have key=/etc/cockroach-key/ and old-key=plain
+	require.Contains(t, podCommand, "key=/etc/cockroach-key/", "Encryption flag should contain key path for both data and WAL")
+	require.Contains(t, podCommand, "old-key=plain", "Encryption flag should have old-key=plain for initial setup")
+	t.Logf("Verified encryption flag format with key and old-key=plain for both data store and WAL path")
+
+	// Step 4: Verify encryption algorithm via node metrics.
+	// rocksdb.encryption.algorithm: 0=Plaintext, 1=AES-128-CTR, 2=AES-192-CTR, 3=AES-256-CTR
+	t.Log("Verifying encryption algorithm via node metrics...")
+	encAlgorithm, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"exec", podName, "-c", "cockroachdb", "--",
+		"/cockroach/cockroach", "sql",
+		"--certs-dir=/cockroach/cockroach-certs",
+		"--host=localhost:26257",
+		"-e", "SET allow_unsafe_internals = true; SELECT value FROM crdb_internal.node_metrics WHERE name = 'rocksdb.encryption.algorithm';")
+	require.NoError(t, err)
+	require.Contains(t, encAlgorithm, "3", "rocksdb.encryption.algorithm should be 3 (AES-256-CTR)")
+	t.Logf("Encryption algorithm verified: AES-256-CTR (value=3)")
+
+	// Verify both PVCs exist
+	pvcs, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "pvc", "-o", "jsonpath={.items[*].metadata.name}")
+	require.NoError(t, err)
+	require.Contains(t, pvcs, "datadir", "Data PVC should exist")
+	require.Contains(t, pvcs, "datadir-wal-failover", "WAL failover PVC should exist")
+
+	t.Log("WAL failover with encryption at rest test completed successfully")
+	t.Logf("Verified both data store and WAL path are encrypted")
+}
+
+// TestPCR tests Physical Cluster Replication by:
+// 1. Installing a primary virtual cluster
+// 2. Installing a standby virtual cluster in separate namespace
+// 3. Creating replication stream between primary and standby
+// 4. Running workload on primary
+// 5. Verifying cutover to standby
+func (r *singleRegion) TestPCR(t *testing.T) {
+	cluster := r.Clusters[0]
+
+	// Create CA certificate once for both clusters
+	cleanupCA := r.RequireCACertificate(t)
+	defer cleanupCA()
+
+	var (
+		primaryNamespace string
+		standbyNamespace string
+	)
+
+	// Step 1: Install primary virtual cluster
+	t.Log("Installing primary virtual cluster...")
+	primaryNamespace = fmt.Sprintf("%s-primary-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
+	r.Namespace[cluster] = primaryNamespace
+
+	primaryConfig := operator.AdvancedInstallConfig{
+		VirtualClusterMode: "primary",
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, primaryConfig)
+
+	r.VirtualClusterModePrimary = true
+	r.ValidateCRDB(t, cluster)
+	r.VirtualClusterModePrimary = false
+
+	// Step 2: Install standby virtual cluster in separate namespace
+	t.Log("Installing standby virtual cluster...")
+	standbyNamespace = fmt.Sprintf("%s-standby-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
+	r.Namespace[cluster] = standbyNamespace
+
+	standbyConfig := operator.AdvancedInstallConfig{
+		VirtualClusterMode:  "standby",
+		SkipOperatorInstall: true,
+	}
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, standbyConfig)
+
+	r.VirtualClusterModeStandby = true
+	r.ValidateCRDB(t, cluster)
+	r.VirtualClusterModeStandby = false
+
+	// Register cleanup for both namespaces before ValidatePCR so namespaces are
+	// always removed even if ValidatePCR fails early via require.* / t.FailNow.
+	kubeConfig, _ := r.GetCurrentContext(t)
+	defer func() {
+		r.Namespace[cluster] = primaryNamespace
+		r.CleanupResources(t)
+	}()
+	defer func() {
+		kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, standbyNamespace)
+		k8s.DeleteNamespace(t, kubectlOptions, standbyNamespace)
+	}()
+
+	// Step 3: Set up replication and test failover/failback
+	r.ValidatePCR(t, &operator.AdvancedValidationConfig{
+		PCR: operator.PCRValidation{
+			Cluster:          cluster,
+			PrimaryNamespace: primaryNamespace,
+			StandbyNamespace: standbyNamespace,
+		},
+	})
+
+	t.Logf("PCR (Physical Cluster Replication) test completed successfully")
+}
+

--- a/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
+++ b/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
@@ -82,14 +82,25 @@ func TestOperatorInSingleRegion(t *testing.T) {
 		// Set up infrastructure for this provider once.
 		cloudProvider.SetUpInfra(t)
 
-		testCases := map[string]func(*testing.T){
-			"TestHelmInstall":               providerRegion.TestHelmInstall,
-			"TestHelmInstallVirtualCluster": providerRegion.TestHelmInstallVirtualCluster,
-			"TestHelmUpgrade":               providerRegion.TestHelmUpgrade,
-			"TestClusterRollingRestart":     providerRegion.TestClusterRollingRestart,
-			"TestKillingCockroachNode":      providerRegion.TestKillingCockroachNode,
-			"TestClusterScaleUp":            func(t *testing.T) { providerRegion.TestClusterScaleUp(t, cloudProvider) },
-			"TestInstallWithCertManager":    providerRegion.TestInstallWithCertManager,
+		testCases := make(map[string]func(*testing.T))
+
+		// Run only advanced test cases when TEST_ADVANCED_FEATURES is enabled
+		if os.Getenv("TEST_ADVANCED_FEATURES") == "true" {
+			testCases["TestWALFailover"] = providerRegion.TestWALFailover
+			testCases["TestWALFailoverDisable"] = providerRegion.TestWALFailoverDisable
+			testCases["TestEncryptionAtRestEnable"] = providerRegion.TestEncryptionAtRestEnable
+			testCases["TestEncryptionAtRestDisable"] = providerRegion.TestEncryptionAtRestDisable
+			testCases["TestEncryptionAtRestModifySecret"] = providerRegion.TestEncryptionAtRestModifySecret
+			testCases["TestWALFailoverWithEncryption"] = providerRegion.TestWALFailoverWithEncryption
+			testCases["TestPCR"] = providerRegion.TestPCR
+		} else {
+			testCases["TestHelmInstall"] = providerRegion.TestHelmInstall
+			testCases["TestHelmInstallVirtualCluster"] = providerRegion.TestHelmInstallVirtualCluster
+			testCases["TestHelmUpgrade"] = providerRegion.TestHelmUpgrade
+			testCases["TestClusterRollingRestart"] = providerRegion.TestClusterRollingRestart
+			testCases["TestKillingCockroachNode"] = providerRegion.TestKillingCockroachNode
+			testCases["TestClusterScaleUp"] = func(t *testing.T) { providerRegion.TestClusterScaleUp(t, cloudProvider) }
+			testCases["TestInstallWithCertManager"] = providerRegion.TestInstallWithCertManager
 		}
 
 		// Run tests sequentially within a provider.

--- a/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
+++ b/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
 	"github.com/cockroachdb/helm-charts/tests/e2e/operator/infra"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/utils"
 	"github.com/cockroachdb/helm-charts/tests/testutil"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -18,11 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Environment variable name to check if running in nightly mode
-const isNightlyEnvVar = "isNightly"
-
 type singleRegion struct {
-	operator.OperatorUseCases
 	operator.Region
 }
 
@@ -30,19 +27,10 @@ func newSingleRegion() *singleRegion {
 	return &singleRegion{}
 }
 func TestOperatorInSingleRegion(t *testing.T) {
-	// Fetch provider from env
-	var provider string
-	if p := strings.TrimSpace(strings.ToLower(os.Getenv("PROVIDER"))); p != "" {
-		switch p {
-		case "kind":
-			provider = infra.ProviderKind
-		case "gcp":
-			provider = infra.ProviderGCP
-		default:
-			t.Fatalf("Unsupported provider override: %s", p)
-		}
-	} else {
-		provider = infra.ProviderK3D
+	// Get provider from environment variable
+	provider, err := utils.GetProviderFromEnv()
+	if err != nil {
+		t.Fatalf("Failed to get provider: %v", err)
 	}
 
 	t.Run(provider, func(t *testing.T) {
@@ -52,19 +40,20 @@ func TestOperatorInSingleRegion(t *testing.T) {
 		// Create a provider-specific instance to avoid race conditions.
 		providerRegion := newSingleRegion()
 		providerRegion.Region = operator.Region{
-			IsMultiRegion: false,
-			NodeCount:     3,
-			ReusingInfra:  false,
+			NodeCount:    3,
+			ReusingInfra: false,
+			TestRunID:    utils.GenerateTestRunID(),
 		}
 		providerRegion.Clients = make(map[string]client.Client)
 		providerRegion.Namespace = make(map[string]string)
-
 		providerRegion.Provider = provider
-		clusterName := fmt.Sprintf("%s-%s", providerRegion.Provider, operator.Clusters[0])
-		if provider != infra.ProviderK3D && provider != infra.ProviderKind {
-			clusterName = fmt.Sprintf("%s-%s", clusterName, strings.ToLower(random.UniqueId()))
-		}
-		providerRegion.Clusters = append(providerRegion.Clusters, clusterName)
+
+		t.Logf("Test Run ID: %s", providerRegion.TestRunID)
+
+		// Generate a cluster name with user/PR context (single cluster for single-region test)
+		clusterNames := utils.GenerateClusterNames(provider, 1)
+		providerRegion.Clusters = clusterNames
+		t.Logf("Cluster name: %s", clusterNames[0])
 
 		// Create and reuse the same provider instance for both setup and teardown.
 		cloudProvider := infra.ProviderFactory(providerRegion.Provider, &providerRegion.Region)
@@ -111,20 +100,7 @@ func TestOperatorInSingleRegion(t *testing.T) {
 				t.Logf("Skipping test %s due to previous test failure", name)
 				continue
 			}
-
-			t.Run(name, func(t *testing.T) {
-				// Add immediate cleanup trigger if this individual test fails
-				defer func() {
-					if t.Failed() {
-						testFailed = true
-						t.Logf("Test %s failed, triggering immediate infrastructure cleanup", name)
-						cloudProvider.TeardownInfra(t)
-						t.Logf("Infrastructure cleanup completed due to test failure")
-					}
-				}()
-
-				method(t)
-			})
+			testFailed = !t.Run(name, method)
 		}
 	})
 }
@@ -158,8 +134,7 @@ func (r *singleRegion) TestHelmInstall(t *testing.T) {
 }
 
 // TestHelmInstallVirtualCluster installs Operator and CockroachDB charts
-// for both primary and standby virtual clusters and verifies if
-// CockroachDB service is up and running.
+// for both primary and standby virtual clusters and verifies if the CockroachDB service is up and running.
 func (r *singleRegion) TestHelmInstallVirtualCluster(t *testing.T) {
 	// Create CA certificate.
 	err := r.CreateCACertificate(t)
@@ -230,8 +205,11 @@ func (r *singleRegion) TestHelmInstallVirtualCluster(t *testing.T) {
 	}
 	defer r.CleanupResources(t)
 	defer func() {
-		kubectlOptions := k8s.NewKubectlOptions("", "", standByNamespace)
-		k8s.DeleteNamespace(t, kubectlOptions, standByNamespace)
+		if standByNamespace != "" {
+			kubectlOptions := k8s.NewKubectlOptions("", "", standByNamespace)
+			// Ignore error if namespace doesn't exist (may have been deleted already)
+			_ = k8s.DeleteNamespaceE(t, kubectlOptions, standByNamespace)
+		}
 	}()
 	defer r.CleanUpCACertificate(t)
 
@@ -498,7 +476,7 @@ func (r *singleRegion) TestClusterScaleUp(t *testing.T, cloudProvider infra.Clou
 }
 
 // TestInstallWithCertManager will install the Operator and CockroachDB charts
-// with cert-manager and trust-manager and verifies cockroachdb cluster is up and running.
+// with cert-manager and trust-manager and verifies the cockroachdb cluster is up and running.
 func (r *singleRegion) TestInstallWithCertManager(t *testing.T) {
 	cluster := r.Clusters[0]
 	r.Namespace[cluster] = fmt.Sprintf("%s-%s", operator.Namespace, strings.ToLower(random.UniqueId()))

--- a/tests/e2e/operator/utils/cluster_naming.go
+++ b/tests/e2e/operator/utils/cluster_naming.go
@@ -1,0 +1,112 @@
+// Package utils provides common utilities for E2E tests to avoid duplication
+// between single-region and multi-region test suites.
+package utils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+const (
+	// Provider constants (duplicated from infra package to avoid import cycles)
+
+	ProviderK3D  = "k3d"
+	ProviderKind = "kind"
+	ProviderGCP  = "gcp"
+	ProviderAWS  = "aws"
+)
+
+// GetProviderFromEnv reads the PROVIDER environment variable and returns the provider string.
+// Returns ProviderK3D as default if no provider is specified.
+func GetProviderFromEnv() (string, error) {
+	p := strings.TrimSpace(strings.ToLower(os.Getenv("PROVIDER")))
+	if p == "" {
+		return ProviderK3D, nil
+	}
+
+	switch p {
+	case "k3d":
+		return ProviderK3D, nil
+	case "kind":
+		return ProviderKind, nil
+	case "gcp":
+		return ProviderGCP, nil
+	case "aws":
+		return ProviderAWS, nil
+	default:
+		return "", fmt.Errorf("unsupported provider: %s", p)
+	}
+}
+
+// GenerateTestRunID creates a unique test run ID for resource isolation.
+// Format: <random-id>-<unix-timestamp>
+func GenerateTestRunID() string {
+	return fmt.Sprintf("%s-%d", strings.ToLower(random.UniqueId()), time.Now().Unix())
+}
+
+// GenerateClusterNames creates cluster names with context about who is running the test.
+// For GitHub CI: includes PR number (e.g., aws-chart-testing-pr602-cluster-0-abc123)
+// For local runs: includes username (e.g., aws-chart-testing-bhaskar-cluster-0-abc123)
+// For K3D/Kind: includes provider prefix to match kubeconfig context names
+//
+//	(e.g., k3d-chart-testing-cluster-0 matches the context created by k3d)
+//
+// Parameters:
+//   - provider: The cloud provider (aws, gcp, k3d, kind)
+//   - clusterCount: Number of clusters to create names for
+//
+// Returns: Array of cluster names
+func GenerateClusterNames(provider string, clusterCount int) []string {
+	// Start with provider prefix for all providers
+	// For k3d/kind, this matches the kubeconfig context name (k3d adds "k3d-" prefix to contexts)
+	var clusterPrefix string
+	clusterPrefix = fmt.Sprintf("%s-%s", provider, "chart-testing")
+
+	// For cloud providers (AWS, GCP), add GitHub PR number or username for isolation
+	// For local providers (k3d, kind), keep simple names without PR/username
+	if provider != ProviderK3D && provider != ProviderKind {
+		// Add GitHub PR number if running in CI
+		if prNumber := os.Getenv("GITHUB_PR_NUMBER"); prNumber != "" {
+			clusterPrefix = fmt.Sprintf("%s-pr%s", clusterPrefix, prNumber)
+		} else if ghRef := os.Getenv("GITHUB_REF"); strings.Contains(ghRef, "/pull/") {
+			// Extract PR number from GITHUB_REF (e.g., refs/pull/123/merge)
+			parts := strings.Split(ghRef, "/")
+			if len(parts) >= 3 {
+				clusterPrefix = fmt.Sprintf("%s-pr%s", clusterPrefix, parts[2])
+			}
+		} else {
+			// For local runs, add username
+			if username := os.Getenv("USER"); username != "" {
+				// Sanitize username for Kubernetes naming (lowercase, alphanumeric and dash only)
+				username = strings.ToLower(username)
+				username = strings.Map(func(r rune) rune {
+					if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+						return r
+					}
+					return '-'
+				}, username)
+				// Truncate username to max 10 characters to avoid exceeding 63-char label limit
+				if len(username) > 10 {
+					username = username[:10]
+				}
+				clusterPrefix = fmt.Sprintf("%s-%s", clusterPrefix, username)
+			}
+		}
+	}
+
+	clusterNames := make([]string, 0, clusterCount)
+	for i := 0; i < clusterCount; i++ {
+		clusterName := fmt.Sprintf("%s-cluster-%d", clusterPrefix, i)
+		// Add random suffix for cloud providers (not for local K3D/Kind)
+		if provider != ProviderK3D && provider != ProviderKind {
+			clusterName = fmt.Sprintf("%s-%s", clusterName, strings.ToLower(random.UniqueId()))
+		}
+		clusterNames = append(clusterNames, clusterName)
+	}
+
+	return clusterNames
+}

--- a/tests/testutil/require.go
+++ b/tests/testutil/require.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/helm-charts/pkg/database"
-	"github.com/cockroachdb/helm-charts/pkg/kube"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/stretchr/testify/require"
@@ -28,10 +26,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
 
-const (
-	TestDBName = "test_db"
+	"github.com/cockroachdb/helm-charts/pkg/database"
+	"github.com/cockroachdb/helm-charts/pkg/kube"
 )
 
 type CockroachCluster struct {
@@ -45,8 +42,35 @@ type CockroachCluster struct {
 	Context                    string
 }
 
+// IsTransientNetworkError checks if an error is a transient network error that should be retried.
+// This includes common network timeouts, connection failures, TLS handshake errors,
+// and corporate proxy/certificate interception issues.
+// Real application errors (validation, logic failures, etc.) return false.
+func IsTransientNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errMsg := strings.ToLower(err.Error())
+	return strings.Contains(errMsg, "eof") ||
+		strings.Contains(errMsg, "i/o timeout") ||
+		strings.Contains(errMsg, "connection refused") ||
+		strings.Contains(errMsg, "connection reset") ||
+		strings.Contains(errMsg, "tls handshake timeout") ||
+		strings.Contains(errMsg, "context deadline exceeded") ||
+		strings.Contains(errMsg, "net/http: tls handshake timeout") ||
+		strings.Contains(errMsg, "client.timeout exceeded") ||
+		// Additional transient proxy / certificate related errors
+		strings.Contains(errMsg, "bad gateway") ||
+		strings.Contains(errMsg, "unable to get local issuer certificate") ||
+		strings.Contains(errMsg, "x509") ||
+		strings.Contains(errMsg, "certificate signed by unknown authority") ||
+		strings.Contains(errMsg, "netskope")
+}
+
 // RequireClusterToBeReadyEventuallyTimeout waits for all the CRDB pods to come into running state.
-func RequireClusterToBeReadyEventuallyTimeout(t *testing.T, crdbCluster CockroachCluster, timeout time.Duration) {
+func RequireClusterToBeReadyEventuallyTimeout(
+	t *testing.T, crdbCluster CockroachCluster, timeout time.Duration,
+) {
 	ctx := context.Background()
 	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true,
 		func(ctx context.Context) (bool, error) {
@@ -74,7 +98,9 @@ func RequireClusterToBeReadyEventuallyTimeout(t *testing.T, crdbCluster Cockroac
 }
 
 // RequireCRDBClusterToBeReadyEventuallyTimeout waits for all the CockroachDB pods to come into running state.
-func RequireCRDBClusterToBeReadyEventuallyTimeout(t *testing.T, opts *k8s.KubectlOptions, crdbCluster CockroachCluster, timeout time.Duration) {
+func RequireCRDBClusterToBeReadyEventuallyTimeout(
+	t *testing.T, opts *k8s.KubectlOptions, crdbCluster CockroachCluster, timeout time.Duration,
+) {
 	ctx := context.Background()
 	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true,
 		func(ctx context.Context) (bool, error) {
@@ -104,7 +130,9 @@ func RequireCRDBClusterToBeReadyEventuallyTimeout(t *testing.T, opts *k8s.Kubect
 	require.NoError(t, err)
 }
 
-func RequirePodToBeCreatedAndReady(t *testing.T, opts *k8s.KubectlOptions, podName string, timeout time.Duration) {
+func RequirePodToBeCreatedAndReady(
+	t *testing.T, opts *k8s.KubectlOptions, podName string, timeout time.Duration,
+) {
 	ctx := context.Background()
 	require.NoError(t, wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true,
 		func(ctx context.Context) (done bool, err error) {
@@ -149,7 +177,9 @@ func logPods(ctx context.Context, sts *appsv1.StatefulSet, cfg *rest.Config, t *
 	}
 }
 
-func fetchStatefulSet(k8sClient client.Client, name, namespace string) (*appsv1.StatefulSet, error) {
+func fetchStatefulSet(
+	k8sClient client.Client, name, namespace string,
+) (*appsv1.StatefulSet, error) {
 	ss := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -195,17 +225,38 @@ func getDBConn(t *testing.T, crdbCluster CockroachCluster, dbName string, podNam
 		RootCertificateSecretName:   crdbCluster.NodeSecret,
 	}
 
-	// Create a new database connection for the update.
-	db, err := database.NewDbConnection(conn)
+	// Create a new database connection with retry logic to handle transient network issues
+	// (e.g., corporate proxy timeouts, connection drops during rolling restarts)
+	var db *sql.DB
+	_, err := retry.DoWithRetryE(t, "Creating database connection",
+		5,              // maxRetries: try up to 5 times
+		10*time.Second, // timeBetweenRetries: wait 10 seconds between attempts
+		func() (string, error) {
+			var connErr error
+			db, connErr = database.NewDbConnection(conn)
+			if connErr != nil {
+				if IsTransientNetworkError(connErr) {
+					t.Logf("Transient DB connection error (will retry): %v", connErr)
+					return "", connErr
+				}
+				// For non-transient errors, return error immediately to stop retrying
+				return "", fmt.Errorf("non-transient DB connection error: %w", connErr)
+			}
+			return "", nil
+		})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		db.Close()
+		if db != nil {
+			db.Close()
+		}
 	})
 	return db
 }
 
 // RequireCRDBDatabaseToFunction creates a database, a table and insert two rows.
-func RequireCRDBDatabaseToFunction(t *testing.T, crdbCluster CockroachCluster, dbName string, podName string) {
+func RequireCRDBDatabaseToFunction(
+	t *testing.T, crdbCluster CockroachCluster, dbName string, podName string,
+) {
 	systemDB := getDBConn(t, crdbCluster, "system", podName)
 	if _, err := systemDB.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", dbName)); err != nil {
 		t.Fatal(err)
@@ -292,7 +343,9 @@ func RequireCRDBToFunction(t *testing.T, crdbCluster CockroachCluster, validateE
 	t.Log("finished testing database")
 }
 
-func RequireCRDBClusterToFunction(t *testing.T, crdbCluster CockroachCluster, rotate bool, podName string) {
+func RequireCRDBClusterToFunction(
+	t *testing.T, crdbCluster CockroachCluster, rotate bool, podName string,
+) {
 	db := getDBConn(t, crdbCluster, "system", podName)
 
 	if rotate {
@@ -453,8 +506,12 @@ func PrintDebugLogs(t *testing.T, options *k8s.KubectlOptions) {
 }
 
 // RequireToRunRotateJob triggers the client/node or CA certificate rotation job based on next cron schedule.
-func RequireToRunRotateJob(t *testing.T, crdbCluster CockroachCluster, values map[string]string,
-	scheduleToTriggerRotation string, caRotate bool,
+func RequireToRunRotateJob(
+	t *testing.T,
+	crdbCluster CockroachCluster,
+	values map[string]string,
+	scheduleToTriggerRotation string,
+	caRotate bool,
 ) {
 	var args []string
 	var jobName string
@@ -533,7 +590,9 @@ func RequireToRunRotateJob(t *testing.T, crdbCluster CockroachCluster, values ma
 }
 
 // RequireCertRotateJobToBeCompleted waits for the certificate rotation job to complete.
-func RequireCertRotateJobToBeCompleted(t *testing.T, jobName string, crdbCluster CockroachCluster, timeout time.Duration) {
+func RequireCertRotateJobToBeCompleted(
+	t *testing.T, jobName string, crdbCluster CockroachCluster, timeout time.Duration,
+) {
 	ctx := context.Background()
 	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true,
 		func(ctx context.Context) (bool, error) {


### PR DESCRIPTION
## Summary

Resolves: https://cockroachlabs.atlassian.net/browse/CRDB-53967

This PR adds comprehensive AWS/EKS infrastructure support for multi-region e2e testing of the CockroachDB operator with thread-safety improvements and security hardening.

## AWS Infrastructure Support

- **EKS Cluster Provisioning**: Full support for creating EKS clusters with eksctl, including automatic EBS CSI driver installation for EKS 1.23+
- **Multi-Region Support**: VPC peering for cross-region connectivity with proper security group configuration and CIDR routing
- **Network Configuration**: Support for 3 regions (us-east-1, us-east-2, us-west-2) with non-overlapping CIDR blocks for VPCs and Pod networks
- **Corporate Proxy & TLS**: Handle corporate TLS inspection proxies with optional TLS verification bypass via KUBECTL_INSECURE_SKIP_TLS_VERIFY
- **Resource Cleanup**: Comprehensive cleanup script with TestRunID-based tagging for concurrent test isolation and orphaned resource detection

## Test Infrastructure Improvements

- **Provider Abstraction**: CloudProvider interface with AWS, GCP, K3D, and Kind implementations for consistent multi-cloud testing
- **Cluster Naming**: Centralized cluster and test-run naming utilities with GitHub PR context integration for better resource tracking
- **Retry Logic**: Improved transient network error detection and retry handling for flaky test resilience

## Code Quality Improvements

- **Removed IsMultiRegion flag**: Replaced redundant boolean with cluster count checks (`len(r.Clusters) > 1`) for cleaner architecture
- **Safer conditional logic**: Changed early returns to conditional blocks for more maintainable code execution paths

## Files Changed

### Core Infrastructure
- `tests/e2e/operator/infra/aws.go` (new, ~2,900 lines) - AWS/EKS provisioning & teardown with thread-safety
- `tests/e2e/operator/infra/cleanup-aws-resources.sh` (new, ~1,300 lines) - Standalone cleanup utility
- `tests/e2e/operator/infra/common.go` - Added AWS constants & internal LB annotations
- `tests/e2e/operator/infra/provider.go` - Wired AWS into provider factory

### Test Improvements
- `tests/e2e/operator/utils/cluster_naming.go` (new) - Naming utilities with PR context
- `tests/testutil/require.go` - Transient error detection & retry logic
- `tests/e2e/operator/region.go` - Removed IsMultiRegion, added retry logic
- `tests/e2e/operator/{singleRegion,multiRegion}/*_test.go` - Provider selection utilities

### Build & Dependencies
- `Makefile` - Increased timeouts for cloud provisioning
- `go.mod`, `go.sum` - Added AWS SDK dependencies

## Testing

- ✅ Single-region AWS tests validated with EKS provisioning
- ✅ Multi-region AWS tests validated with VPC peering
- ✅ Kubeconfig concurrency fix prevents file corruption
- ✅ Instance-level configs prevent test contamination
- ✅ Internal load balancers prevent public exposure
- ✅ Cleanup script successfully removes all AWS resources

## Usage

```bash
# Run single-region tests on AWS
PROVIDER=aws make test/e2e/single-region

# Run multi-region tests on AWS  
PROVIDER=aws make test/e2e/multi-region

# Cleanup AWS resources by TestRunID
./tests/e2e/operator/infra/cleanup-aws-resources.sh --test-run-id <id>

# Cleanup all AWS resources
./tests/e2e/operator/infra/cleanup-aws-resources.sh --all
```

## Notes

- The `KUBECTL_INSECURE_SKIP_TLS_VERIFY` environment variable is only needed in corporate environments with TLS inspection proxies
- VPC peering is used instead of transit gateways for simplicity and cost
- All resources are tagged with `ManagedBy=helm-charts-e2e` and `TestRunID=<unique-id>` for concurrent test isolation
- Thread-safety fixes ensure reliable parallel cluster creation without kubeconfig corruption
- Security hardening prevents accidental public exposure of test infrastructure