### PR TITLE
[CRDB-62682] helm: make hook images configurable for air-gapped support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,6 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: needs-build
     if: (needs.needs-build.outputs.tagChange == 'true')
+    env:
+      HAS_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -56,5 +58,19 @@ jobs:
           username: _json_key
           password: ${{ secrets.GCR_HELM_CHART_SA_JSON }}
 
-      - name: Push Self-signer
+      - name: Push Self-signer to GCR
         run: make build-and-push/self-signer
+
+      - name: Login to DockerHub
+        if: env.HAS_DOCKERHUB == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push Self-signer to DockerHub
+        if: env.HAS_DOCKERHUB == 'true'
+        run: make build-and-push/self-signer
+        env:
+          REGISTRY: docker.io
+          REPOSITORY: cockroachdb/cockroach-self-signer-cert

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [cockroachdb-parent-26.1.3-preview+1] 2026-04-24
+### Added
+- Hook images (`bitnami/kubectl`, `dtzar/helm-kubectl`) are now configurable via
+  `hooks.kubectlImage.{registry,repository,tag,pullPolicy}` in both charts. This
+  unblocks air-gapped deployments where pulling from public registries is not possible.
+- Added `cockroachdb-parent/images.txt` manifest listing all container images
+  required by both charts, including operator-managed runtime images.
+- Added `scripts/mirror-images.sh` to mirror images from the manifest into an
+  internal registry using `crane` or `skopeo`.
+
+### Changed
+- Operator image now uses semantic version tags from DockerHub
+  instead of SHA digests from Google Artifact Registry.
+- Operator now cleans up cluster-scoped webhook configurations and the webhook Service
+  when the operator is removed. In namespace-scoped mode, each operator instance only
+  cleans up its own resources.
+- Operator now sets CrdbNode ownerReferences on all PVCs (data, logs, WAL) for improved
+  resource hierarchy visibility.
+
 ## [cockroachdb-parent-26.1.1-preview+2] 2026-03-26
 ### Changed
 - **API Version Migration**: The operator now uses an image that removes `v1alpha1` entirely and keeps only `v1beta1`.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ UNAME_S := $(shell uname -s)
 NC := $(shell tput sgr0) # No Color
 ifeq ($(UNAME_S),Linux)
   COCKROACH_BIN ?= https://binaries.cockroachdb.com/cockroach-v23.2.0.linux-amd64.tgz
-  HELM_BIN ?= https://get.helm.sh/helm-v3.14.0-linux-amd64.tar.gz
+  HELM_BIN ?= https://get.helm.sh/helm-v3.17.0-linux-amd64.tar.gz
   K3D_BIN ?=  https://github.com/k3d-io/k3d/releases/download/v5.8.3/k3d-linux-amd64
   KIND_BIN ?= https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64
   KUBECTL_BIN ?= https://dl.k8s.io/release/v1.29.1/bin/linux/amd64/kubectl
@@ -13,7 +13,7 @@ ifeq ($(UNAME_S),Linux)
 endif
 ifeq ($(UNAME_S),Darwin)
   COCKROACH_BIN ?= https://binaries.cockroachdb.com/cockroach-v23.2.0.darwin-10.9-amd64.tgz
-  HELM_BIN ?= https://get.helm.sh/helm-v3.14.0-darwin-amd64.tar.gz
+  HELM_BIN ?= https://get.helm.sh/helm-v3.17.0-darwin-amd64.tar.gz
   K3D_BIN ?=  https://github.com/k3d-io/k3d/releases/download/v5.8.3/k3d-darwin-arm64
   KIND_BIN ?= https://kind.sigs.k8s.io/dl/v0.29.0/kind-darwin-arm64
   KUBECTL_BIN ?= https://dl.k8s.io/release/v1.29.1/bin/darwin/amd64/kubectl
@@ -130,7 +130,7 @@ test/e2e/single-region: bin/cockroach bin/kubectl bin/helm build/self-signer bin
 	@PATH="$(PWD)/bin:${PATH}" go test -timeout 60m -v -test.run TestOperatorInSingleRegion ./tests/e2e/operator/singleRegion/... || (echo "Single region tests failed with exit code $$?" && exit 1)
 
 test/e2e/migrate: bin/cockroach bin/kubectl bin/helm bin/migration-helper build/self-signer test/cluster/up/3
-	@PATH="$(PWD)/bin:${PATH}" go test -timeout 30m -v ./tests/e2e/migrate/... || EXIT_CODE=$$?; \
+	@PATH="$(PWD)/bin:${PATH}" go test -timeout 60m -v ./tests/e2e/migrate/... || EXIT_CODE=$$?; \
 	$(MAKE) test/cluster/down; \
 	exit $${EXIT_CODE:-0}
 

--- a/build/templates/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/build/templates/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -468,7 +468,7 @@ cockroachdb:
         # # initContainers captures the list of init containers for CockroachDB pods.
         # initContainers:
         #   - name : cockroachdb-init
-        #     image: us-docker.pkg.dev/releases-prod/self-hosted/init-container@sha256:bcfc9312af84c7966f017c2325981b30314c0c293491f942e54da1667bedaf69
+        #     image: docker.io/cockroachdb/cockroachdb-init-container:1.0.0-rc.1
         # containers captures the list of containers for CockroachDB pods.
         containers:
           - name: cockroachdb
@@ -481,9 +481,9 @@ cockroachdb:
             #     fieldRef:
             #       fieldPath: metadata.name
             resources: {}
-            # image: cockroachdb/cockroach:v26.1.0
+            # image: cockroachdb/cockroach:v{{ .AppVersion }}
             # - name: cert-reloader
-            #   image: us-docker.pkg.dev/releases-prod/self-hosted/inotifywait@sha256:94db3d416e3df8d1ee2605f05b0526b3bd7217ae69b4eeb147929fe0b77aeafc
+            #   image: docker.io/cockroachdb/cockroachdb-cert-reloader:1.0.0-rc.1
         
         # topologySpreadConstraints captures pod topology spread constraints.
         # It is recommended to spread CockroachDB pods across zones to ensure high availability.
@@ -543,6 +543,24 @@ cockroachdb:
     #   # depending on which cluster you want to initialise.
     #   # Possible Values: disabled, primary, standby
     #   mode: "disabled"
+
+# hooks captures the configuration for Helm hook jobs (pre-upgrade validation, etc.).
+# All hook jobs use the image defined here by default. Override these
+# values to use images from an internal registry in air-gapped environments.
+hooks:
+  # kubectlImage is the container image used by hook jobs that run kubectl commands.
+  # If a future hook requires a different image (e.g., cockroach sql), add a new
+  # sibling key (e.g., hooks.cockroachImage) rather than overloading this one.
+  kubectlImage:
+    # registry defines the container registry for the hook image.
+    registry: docker.io
+    # repository defines the image repository for the hook container.
+    repository: dtzar/helm-kubectl
+    # tag defines the image tag for the hook container. Pinned for reproducibility
+    # in air-gapped environments.
+    tag: "3.19"
+    # pullPolicy defines the image pull policy for the hook container.
+    pullPolicy: IfNotPresent
 
 k8s:
   # nameOverride overrides the name of the chart. If not set, the chart name will be used.

--- a/build/templates/cockroachdb-parent/charts/operator/values.yaml
+++ b/build/templates/cockroachdb-parent/charts/operator/values.yaml
@@ -3,13 +3,13 @@
 # image captures the container image settings for Operator pods.
 image:
   # registry is the container registry where the image is stored.
-  registry: "us-docker.pkg.dev/releases-prod/self-hosted"
+  registry: "docker.io/cockroachdb"
   # repository defines the image repository.
-  repository: "cockroachdb-operator@sha256"
+  repository: "cockroachdb-operator-v2"
   # pullPolicy specifies the image pull policy.
   pullPolicy: IfNotPresent
   # tag is the image tag.
-  tag: "62796d0ad9c87cb0f1f85ebcbc905235ca6c1fc3549bf2a62f5c534af0497332"
+  tag: "1.0.0-rc.1"
 # certificate defines the certificate settings for the Operator.
 certificate:
   # validForDays specifies the number of days the certificate is valid for.
@@ -38,3 +38,20 @@ appLabel: "cockroach-operator"
 # startup; certs rotate on every pod restart. When false (default), Helm provisions a stable
 # cockroach-operator-certs Secret. Switching requires deleting that Secret first.
 selfSignedOperatorCerts: false
+# hooks captures the configuration for Helm hook jobs (pre-upgrade validation, etc.).
+# All hook jobs use the image defined here by default. Override these
+# values to use images from an internal registry in air-gapped environments.
+hooks:
+  # kubectlImage is the container image used by hook jobs that run kubectl commands.
+  # If a future hook requires a different image (e.g., cockroach sql), add a new
+  # sibling key (e.g., hooks.cockroachImage) rather than overloading this one.
+  kubectlImage:
+    # registry defines the container registry for the hook image.
+    registry: docker.io
+    # repository defines the image repository for the hook container.
+    repository: dtzar/helm-kubectl
+    # tag defines the image tag for the hook container. Pinned for reproducibility
+    # in air-gapped environments.
+    tag: "3.19"
+    # pullPolicy defines the image pull policy for the hook container.
+    pullPolicy: IfNotPresent

--- a/cockroachdb-parent/Chart.lock
+++ b/cockroachdb-parent/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: operator
   repository: file://charts/operator
-  version: 26.1.3-preview
+  version: 26.1.3-preview+1
 - name: cockroachdb
   repository: file://charts/cockroachdb
-  version: 26.1.3-preview
-digest: sha256:987f35a0995bf2f93e51d4a3490ef3210cbbef1d67acee4c5c2f8d632473b067
-generated: "2026-04-20T14:56:48.003766053Z"
+  version: 26.1.3-preview+1
+digest: sha256:ffa153440956e2bcfee5b900e64a73aa227ad4e28f8f282dc0d65b052bad03ae
+generated: "2026-04-23T22:25:58.065803+05:30"

--- a/cockroachdb-parent/Chart.yaml
+++ b/cockroachdb-parent/Chart.yaml
@@ -3,14 +3,14 @@ apiVersion: v2
 name: cockroachdb-parent
 description: A parent Helm chart for CockroachDB and its operator using helm-spray
 type: application
-version: 26.1.3-preview
+version: 26.1.3-preview+1
 appVersion: 26.1.3
 dependencies:
   - name: operator
-    version: 26.1.3-preview
+    version: 26.1.3-preview+1
     condition: operator.enabled
     repository: "file://charts/operator"
   - name: cockroachdb
-    version: 26.1.3-preview
+    version: 26.1.3-preview+1
     condition: cockroachdb.enabled
     repository: "file://charts/cockroachdb"

--- a/cockroachdb-parent/charts/cockroachdb/Chart.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 26.1.3-preview
+version: 26.1.3-preview+1
 appVersion: 26.1.3
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb-parent/charts/cockroachdb/templates/pre-upgrade-validation.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/templates/pre-upgrade-validation.yaml
@@ -21,7 +21,10 @@ spec:
       restartPolicy: Never
       containers:
         - name: validation
-          image: bitnami/kubectl:latest
+          {{- $hooks := .Values.hooks | default dict }}
+          {{- $kubectlImage := $hooks.kubectlImage | default dict }}
+          image: "{{ $kubectlImage.registry | default "docker.io" }}/{{ $kubectlImage.repository | default "dtzar/helm-kubectl" }}:{{ $kubectlImage.tag | default "3.19" }}"
+          imagePullPolicy: {{ $kubectlImage.pullPolicy | default "IfNotPresent" }}
           command:
             - /bin/bash
             - -c

--- a/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -469,7 +469,7 @@ cockroachdb:
         # # initContainers captures the list of init containers for CockroachDB pods.
         # initContainers:
         #   - name : cockroachdb-init
-        #     image: us-docker.pkg.dev/releases-prod/self-hosted/init-container@sha256:bcfc9312af84c7966f017c2325981b30314c0c293491f942e54da1667bedaf69
+        #     image: docker.io/cockroachdb/cockroachdb-init-container:1.0.0-rc.1
         # containers captures the list of containers for CockroachDB pods.
         containers:
           - name: cockroachdb
@@ -482,9 +482,9 @@ cockroachdb:
             #     fieldRef:
             #       fieldPath: metadata.name
             resources: {}
-            # image: cockroachdb/cockroach:v26.1.0
+            # image: cockroachdb/cockroach:v26.1.3
             # - name: cert-reloader
-            #   image: us-docker.pkg.dev/releases-prod/self-hosted/inotifywait@sha256:94db3d416e3df8d1ee2605f05b0526b3bd7217ae69b4eeb147929fe0b77aeafc
+            #   image: docker.io/cockroachdb/cockroachdb-cert-reloader:1.0.0-rc.1
         
         # topologySpreadConstraints captures pod topology spread constraints.
         # It is recommended to spread CockroachDB pods across zones to ensure high availability.
@@ -544,6 +544,24 @@ cockroachdb:
     #   # depending on which cluster you want to initialise.
     #   # Possible Values: disabled, primary, standby
     #   mode: "disabled"
+
+# hooks captures the configuration for Helm hook jobs (pre-upgrade validation, etc.).
+# All hook jobs use the image defined here by default. Override these
+# values to use images from an internal registry in air-gapped environments.
+hooks:
+  # kubectlImage is the container image used by hook jobs that run kubectl commands.
+  # If a future hook requires a different image (e.g., cockroach sql), add a new
+  # sibling key (e.g., hooks.cockroachImage) rather than overloading this one.
+  kubectlImage:
+    # registry defines the container registry for the hook image.
+    registry: docker.io
+    # repository defines the image repository for the hook container.
+    repository: dtzar/helm-kubectl
+    # tag defines the image tag for the hook container. Pinned for reproducibility
+    # in air-gapped environments.
+    tag: "3.19"
+    # pullPolicy defines the image pull policy for the hook container.
+    pullPolicy: IfNotPresent
 
 k8s:
   # nameOverride overrides the name of the chart. If not set, the chart name will be used.

--- a/cockroachdb-parent/charts/operator/Chart.yaml
+++ b/cockroachdb-parent/charts/operator/Chart.yaml
@@ -4,4 +4,4 @@ name: operator
 description: A Helm chart for managing the CockroachDB operator.
 type: application
 appVersion: 26.1.3
-version: 26.1.3-preview
+version: 26.1.3-preview+1

--- a/cockroachdb-parent/charts/operator/templates/operator.yaml
+++ b/cockroachdb-parent/charts/operator/templates/operator.yaml
@@ -525,6 +525,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: RELATED_IMAGE_INIT_CONTAINER
+              value: "{{ .Values.image.registry }}/cockroachdb-init-container:{{ .Values.image.tag }}"
+            - name: RELATED_IMAGE_INOTIFYWAIT
+              value: "{{ .Values.image.registry }}/cockroachdb-cert-reloader:{{ .Values.image.tag }}"
             - name: CLOUD_REGION
               value: {{ .Values.cloudRegion }}
             # When watchNamespaces is set, restrict the operator to those namespaces only.

--- a/cockroachdb-parent/charts/operator/templates/pre-upgrade-validation.yaml
+++ b/cockroachdb-parent/charts/operator/templates/pre-upgrade-validation.yaml
@@ -22,7 +22,10 @@ spec:
       restartPolicy: Never
       containers:
         - name: pre-upgrade-check
-          image: dtzar/helm-kubectl:latest
+          {{- $hooks := .Values.hooks | default dict }}
+          {{- $kubectlImage := $hooks.kubectlImage | default dict }}
+          image: "{{ $kubectlImage.registry | default "docker.io" }}/{{ $kubectlImage.repository | default "dtzar/helm-kubectl" }}:{{ $kubectlImage.tag | default "3.19" }}"
+          imagePullPolicy: {{ $kubectlImage.pullPolicy | default "IfNotPresent" }}
           command: ["/bin/bash", "-c"]
           args:
             - |

--- a/cockroachdb-parent/charts/operator/values.yaml
+++ b/cockroachdb-parent/charts/operator/values.yaml
@@ -4,13 +4,13 @@
 # image captures the container image settings for Operator pods.
 image:
   # registry is the container registry where the image is stored.
-  registry: "us-docker.pkg.dev/releases-prod/self-hosted"
+  registry: "docker.io/cockroachdb"
   # repository defines the image repository.
-  repository: "cockroachdb-operator@sha256"
+  repository: "cockroachdb-operator-v2"
   # pullPolicy specifies the image pull policy.
   pullPolicy: IfNotPresent
   # tag is the image tag.
-  tag: "62796d0ad9c87cb0f1f85ebcbc905235ca6c1fc3549bf2a62f5c534af0497332"
+  tag: "1.0.0-rc.1"
 # certificate defines the certificate settings for the Operator.
 certificate:
   # validForDays specifies the number of days the certificate is valid for.
@@ -39,3 +39,20 @@ appLabel: "cockroach-operator"
 # startup; certs rotate on every pod restart. When false (default), Helm provisions a stable
 # cockroach-operator-certs Secret. Switching requires deleting that Secret first.
 selfSignedOperatorCerts: false
+# hooks captures the configuration for Helm hook jobs (pre-upgrade validation, etc.).
+# All hook jobs use the image defined here by default. Override these
+# values to use images from an internal registry in air-gapped environments.
+hooks:
+  # kubectlImage is the container image used by hook jobs that run kubectl commands.
+  # If a future hook requires a different image (e.g., cockroach sql), add a new
+  # sibling key (e.g., hooks.cockroachImage) rather than overloading this one.
+  kubectlImage:
+    # registry defines the container registry for the hook image.
+    registry: docker.io
+    # repository defines the image repository for the hook container.
+    repository: dtzar/helm-kubectl
+    # tag defines the image tag for the hook container. Pinned for reproducibility
+    # in air-gapped environments.
+    tag: "3.19"
+    # pullPolicy defines the image pull policy for the hook container.
+    pullPolicy: IfNotPresent

--- a/cockroachdb-parent/images.txt
+++ b/cockroachdb-parent/images.txt
@@ -1,0 +1,38 @@
+# CockroachDB Helm Charts - Container Image Manifest
+#
+# This file lists all container images required by the CockroachDB Helm charts.
+# Use it to mirror images into an internal registry for air-gapped environments.
+#
+# Format: <registry>/<repository>:<tag> or <registry>/<repository>@<digest>
+#
+# To mirror all images, run:
+#   scripts/mirror-images.sh --source-file cockroachdb-parent/images.txt --target-registry <your-registry>
+
+# === Operator chart images ===
+
+# CockroachDB Operator
+docker.io/cockroachdb/cockroachdb-operator-v2:1.0.0-rc.1
+
+# Operator pre-upgrade validation hook
+docker.io/dtzar/helm-kubectl:3.19
+
+# === CockroachDB chart images ===
+
+# CockroachDB database
+docker.io/cockroachdb/cockroach:v26.1.3
+
+# Certificate self-signer
+gcr.io/cockroachlabs-helm-charts/cockroach-self-signer-cert:1.9
+
+# CockroachDB pre-upgrade validation hook
+docker.io/dtzar/helm-kubectl:3.19
+
+# === Operator-managed images (embedded in operator binary) ===
+# These images are pulled by the operator at runtime, not referenced in Helm values.
+# They must also be mirrored for air-gapped environments.
+
+# Init container
+docker.io/cockroachdb/cockroachdb-init-container:1.0.0-rc.1
+
+# Cert reloader (inotifywait)
+docker.io/cockroachdb/cockroachdb-cert-reloader:1.0.0-rc.1

--- a/scripts/mirror-images.sh
+++ b/scripts/mirror-images.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# Mirror all container images required by CockroachDB Helm charts to an
+# internal registry. Designed for air-gapped and restricted environments.
+#
+# Prerequisites: crane (https://github.com/google/go-containerregistry/tree/main/cmd/crane)
+#   or skopeo (https://github.com/containers/skopeo)
+#
+# Usage:
+#   ./scripts/mirror-images.sh --target-registry my-registry.internal.io
+#   ./scripts/mirror-images.sh --target-registry my-registry.internal.io --source-file cockroachdb-parent/images.txt
+#   ./scripts/mirror-images.sh --target-registry my-registry.internal.io --tool skopeo
+#   ./scripts/mirror-images.sh --target-registry my-registry.internal.io --dry-run
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TARGET_REGISTRY=""
+SOURCE_FILE="${REPO_ROOT}/cockroachdb-parent/images.txt"
+TOOL="crane"
+DRY_RUN=false
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Mirror CockroachDB Helm chart images to an internal registry.
+
+Options:
+  --target-registry REGISTRY   Target registry to push images to (required)
+  --source-file FILE           Path to images.txt manifest (default: cockroachdb-parent/images.txt)
+  --tool TOOL                  Tool to use for mirroring: crane or skopeo (default: crane)
+  --dry-run                    Print commands without executing
+  -h, --help                   Show this help message
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target-registry) TARGET_REGISTRY="$2"; shift 2 ;;
+    --source-file)     SOURCE_FILE="$2"; shift 2 ;;
+    --tool)            TOOL="$2"; shift 2 ;;
+    --dry-run)         DRY_RUN=true; shift ;;
+    -h|--help)         usage; exit 0 ;;
+    *)                 echo "Unknown option: $1"; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "${TARGET_REGISTRY}" ]]; then
+  echo "Error: --target-registry is required"
+  usage
+  exit 1
+fi
+
+if [[ ! -f "${SOURCE_FILE}" ]]; then
+  echo "Error: source file not found: ${SOURCE_FILE}"
+  exit 1
+fi
+
+if [[ "${TOOL}" != "crane" && "${TOOL}" != "skopeo" ]]; then
+  echo "Error: --tool must be 'crane' or 'skopeo'"
+  exit 1
+fi
+
+if ! command -v "${TOOL}" &>/dev/null; then
+  echo "Error: ${TOOL} not found in PATH"
+  echo "Install instructions:"
+  if [[ "${TOOL}" == "crane" ]]; then
+    echo "  https://github.com/google/go-containerregistry/tree/main/cmd/crane#installation"
+  else
+    echo "  https://github.com/containers/skopeo/blob/main/install.md"
+  fi
+  exit 1
+fi
+
+# Compute the target image reference from a source reference.
+# Strips the source registry (and project/repo paths for GAR and GCR) to produce
+# a flat image name, then prepends the target registry.
+# For digest references (@sha256:...), preserves the digest.
+compute_target() {
+  local src="$1"
+  local repo_and_ref
+
+  # Strip registry and any intermediate project/repo path segments.
+  # DockerHub: strip registry host, keep org/image.
+  # GCR: strip registry host and project, keep image.
+  # GAR: strip registry host, project, and repo, keep image.
+  # Examples:
+  #   docker.io/cockroachdb/cockroachdb-operator-v2:1.0.0-rc.1 -> cockroachdb/cockroachdb-operator-v2:1.0.0-rc.1
+  #   docker.io/cockroachdb/cockroach:v26.1.3 -> cockroachdb/cockroach:v26.1.3
+  #   gcr.io/cockroachlabs-helm-charts/cockroach-self-signer-cert:1.9 -> cockroach-self-signer-cert:1.9
+  #   us-docker.pkg.dev/releases-prod/self-hosted/cockroachdb-operator:v1.0.0 -> cockroachdb-operator:v1.0.0
+  case "${src}" in
+    us-docker.pkg.dev/*/*/*)
+      # Google Artifact Registry: us-docker.pkg.dev/project/repo/image
+      # Strip us-docker.pkg.dev/project/repo/ to keep only image:tag or image@digest
+      local without_host="${src#us-docker.pkg.dev/}"
+      local without_project="${without_host#*/}"
+      repo_and_ref="${without_project#*/}"
+      ;;
+    gcr.io/*)
+      # GCR: gcr.io/project/image
+      repo_and_ref="${src#gcr.io/*/}"
+      ;;
+    docker.io/*)
+      repo_and_ref="${src#docker.io/}"
+      ;;
+    *)
+      # Fallback: strip first path segment as registry
+      repo_and_ref="${src#*/}"
+      ;;
+  esac
+
+  echo "${TARGET_REGISTRY}/${repo_and_ref}"
+}
+
+echo "Mirroring images from: ${SOURCE_FILE}"
+echo "Target registry: ${TARGET_REGISTRY}"
+echo "Tool: ${TOOL}"
+echo ""
+
+SUCCESS=0
+FAILED=0
+
+while IFS= read -r line; do
+  # Skip comments and blank lines
+  [[ "${line}" =~ ^[[:space:]]*# ]] && continue
+  [[ -z "${line// /}" ]] && continue
+
+  src="${line}"
+  dst="$(compute_target "${src}")"
+
+  echo "Mirroring: ${src}"
+  echo "      --> ${dst}"
+
+  if [[ "${DRY_RUN}" == true ]]; then
+    if [[ "${TOOL}" == "crane" ]]; then
+      echo "  [dry-run] crane copy ${src} ${dst}"
+    else
+      echo "  [dry-run] skopeo copy docker://${src} docker://${dst}"
+    fi
+    echo ""
+    continue
+  fi
+
+  if [[ "${TOOL}" == "crane" ]]; then
+    if crane copy "${src}" "${dst}"; then
+      echo "  OK"
+      ((++SUCCESS))
+    else
+      echo "  FAILED"
+      ((++FAILED))
+    fi
+  else
+    if skopeo copy "docker://${src}" "docker://${dst}"; then
+      echo "  OK"
+      ((++SUCCESS))
+    else
+      echo "  FAILED"
+      ((++FAILED))
+    fi
+  fi
+  echo ""
+done < "${SOURCE_FILE}"
+
+echo "================================"
+echo "Mirroring complete: ${SUCCESS} succeeded, ${FAILED} failed"
+
+if [[ "${FAILED}" -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/k3d/dev-multi-cluster.sh
+++ b/tests/k3d/dev-multi-cluster.sh
@@ -35,9 +35,9 @@ REQUIRED_IMAGES=(
     "quay.io/jetstack/cert-manager-ctl:v1.11.0"
     "coredns/coredns:1.9.2"
     "$(bin/yq '.cockroachdb.crdbCluster.image.name' ./cockroachdb-parent/charts/cockroachdb/values.yaml)"
-    "us-docker.pkg.dev/releases-prod/self-hosted/inotifywait@sha256:94db3d416e3df8d1ee2605f05b0526b3bd7217ae69b4eeb147929fe0b77aeafc"
+    "docker.io/cockroachdb/cockroachdb-cert-reloader:1.0.0-rc.1"
     "bash:latest"
-    "us-docker.pkg.dev/releases-prod/self-hosted/init-container@sha256:bcfc9312af84c7966f017c2325981b30314c0c293491f942e54da1667bedaf69"
+    "docker.io/cockroachdb/cockroachdb-init-container:1.0.0-rc.1"
     "${REGISTRY}/${REPOSITORY}:$(bin/yq '.cockroachdb.tls.selfSigner.image.tag' ./cockroachdb-parent/charts/cockroachdb/values.yaml)"
 )
 

--- a/tests/kind/dev-multi-cluster.sh
+++ b/tests/kind/dev-multi-cluster.sh
@@ -33,9 +33,9 @@ REQUIRED_IMAGES=(
     "quay.io/jetstack/cert-manager-ctl:v1.11.0"
     "coredns/coredns:1.9.2"
     "$(bin/yq '.cockroachdb.crdbCluster.image.name' ./cockroachdb-parent/charts/cockroachdb/values.yaml)"
-    "us-docker.pkg.dev/releases-prod/self-hosted/inotifywait@sha256:94db3d416e3df8d1ee2605f05b0526b3bd7217ae69b4eeb147929fe0b77aeafc"
+    "docker.io/cockroachdb/cockroachdb-cert-reloader:1.0.0-rc.1"
     "bash:latest"
-    "us-docker.pkg.dev/releases-prod/self-hosted/init-container@sha256:bcfc9312af84c7966f017c2325981b30314c0c293491f942e54da1667bedaf69"
+    "docker.io/cockroachdb/cockroachdb-init-container:1.0.0-rc.1"
     "${REGISTRY}/${REPOSITORY}:$(bin/yq '.cockroachdb.tls.selfSigner.image.tag' ./cockroachdb-parent/charts/cockroachdb/values.yaml)"
 )
 


### PR DESCRIPTION
## Summary

This commit replaces hardcoded kubectl images in pre-upgrade validation hooks with
configurable values via `hooks.kubectlImage` for air-gapped environments.

Additionally:
- Image manifest (`images.txt`) listing all images used in both charts
- Mirror script (`scripts/mirror-images.sh`) for air-gapped image mirroring
- Operator image switched from GAR SHA digests to DockerHub semantic version tags (1.0.0-rc.1)
- All operator-managed images (init-container, cert-reloader) updated to DockerHub RC tags
- Self-signer image build workflow now pushes to DockerHub alongside GCR
- Pre-upgrade hook templates use fallback defaults for `hooks.kubectlImage` to remain
  safe under `helm upgrade --reuse-values` from older chart versions
- Charts bumped to 26.1.3-preview+1 with changelog