### PR TITLE
[CRDB-59251] build: per-chart versioning for GA release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+The operator and cockroachdb charts are versioned independently. The operator supports all
+CockroachDB chart versions. Any exceptions, such as a minimum operator version required for
+new CockroachDB features or unsupported CockroachDB settings, will be explicitly noted in the
+relevant changelog entry. See [VERSIONING.md](cockroachdb-parent/docs/VERSIONING.md) for details.
+
+Each chart maintains its own changelog:
+- [Operator chart CHANGELOG](cockroachdb-parent/charts/operator/CHANGELOG.md)
+- [CockroachDB chart CHANGELOG](cockroachdb-parent/charts/cockroachdb/CHANGELOG.md)
+
+Historical entries from the preview era (before per-chart versioning) are preserved below.
+
 ## [cockroachdb-parent-26.1.3-preview+1] 2026-04-24
 ### Added
 - Hook images (`bitnami/kubectl`, `dtzar/helm-kubectl`) are now configurable via

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,19 @@ build-and-push-bundle-image:
 	docker buildx build --platform=linux/amd64,linux/arm64 \
 		-t $(QUAY_DOCKER_REGISTRY)/$(QUAY_PROJECT)/$(BUNDLE_IMAGE):$(VERSION) --push -f build/docker-image/olm-catalog/bundle.Dockerfile ./
 
-bump/%:
+bump/cockroachdb/%: ## bump cockroachdb chart for new CRDB version
+	@bazel build //build
+	$$(bazel info bazel-bin)/build/build_/build bump --chart cockroachdb $*
+	@helm dependency update ./cockroachdb-parent
+	@rm -rf ./cockroachdb-parent/charts/*.tgz
+
+bump/operator/%: ## bump operator chart version
+	@bazel build //build
+	$$(bazel info bazel-bin)/build/build_/build bump --chart operator $*
+	@helm dependency update ./cockroachdb-parent
+	@rm -rf ./cockroachdb-parent/charts/*.tgz
+
+bump/%: ## bump CRDB version (cockroachdb + legacy charts)
 	@bazel build //build
 	$$(bazel info bazel-bin)/build/build_/build bump $*
 	@helm dependency update ./cockroachdb-parent

--- a/build/build.go
+++ b/build/build.go
@@ -29,13 +29,26 @@ import (
 )
 
 const usage = `Usage:
-// Bump cockroachdb app and chart version in Chart.yaml file.
-- go run build/build.go bump <crdbversion>
-// Bump cockroachdb chart version in Chart.yaml file.
-- go run build/build.go bump helm
-// Generate files based on templates in build/templates directory.
-- go run build/build.go generate
+- go run build/build.go bump <crdbversion>                      Bump CRDB version (cockroachdb + legacy charts)
+- go run build/build.go bump --chart cockroachdb <crdbversion>  Bump cockroachdb chart for new CRDB version
+- go run build/build.go bump --chart cockroachdb helm           Cockroachdb chart-only fix (patch bump, appVersion unchanged)
+- go run build/build.go bump --chart operator <version>         Bump operator chart version (version + appVersion)
+- go run build/build.go bump helm                               Chart-only fix (patch bump, no appVersion change)
+- go run build/build.go generate                                Regenerate files from templates
 `
+
+type chartKind int
+
+const (
+	chartKindLegacy      chartKind = iota // cockroachdb/
+	chartKindCockroachDB                  // cockroachdb-parent/charts/cockroachdb/
+	chartKindOperator                     // cockroachdb-parent/charts/operator/
+	chartKindParent                       // cockroachdb-parent/
+)
+
+func (k chartKind) String() string {
+	return [...]string{"legacy", "cockroachdb", "operator", "parent"}[k]
+}
 
 type parsedVersion struct {
 	*semver.Version
@@ -46,8 +59,10 @@ type versions struct {
 }
 
 type templateArgs struct {
-	Version    string
-	AppVersion string
+	Version            string
+	AppVersion         string
+	OperatorVersion    string
+	CockroachDBVersion string
 }
 
 // UnmarshalYAML implements the Unmarshaller interface for the version fields
@@ -73,35 +88,80 @@ func main() {
 			os.Exit(1)
 		}
 
-		if err := generate(os.Args[2]); err != nil {
+		chartTarget := ""
+		version := ""
+
+		if os.Args[2] == "--chart" {
+			if len(os.Args) < 5 {
+				fmt.Print(usage)
+				os.Exit(1)
+			}
+			chartTarget = os.Args[3]
+			version = os.Args[4]
+		} else {
+			version = os.Args[2]
+		}
+
+		if err := validateChartTarget(chartTarget); err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+			os.Exit(1)
+		}
+
+		if err := generate(chartTarget, version); err != nil {
 			fmt.Fprintf(os.Stderr, "cannot run: %s", err)
 			os.Exit(1)
 		}
-		return
 	case "generate":
-		if len(os.Args) < 2 {
-			fmt.Print(usage)
-			os.Exit(1)
-		}
-
-		if err := generate(""); err != nil {
+		if err := generate("", ""); err != nil {
 			fmt.Fprintf(os.Stderr, "cannot run: %s", err)
 			os.Exit(1)
 		}
-		return
+	default:
+		fmt.Print(usage)
+		os.Exit(1)
 	}
-
-	fmt.Print(usage)
-	os.Exit(1)
 }
 
-// regenerate destination files based on templates, which should
-// result in a zero diff, if template is up-to-date with destination files.
-// If version is specified, it will be used to bump the version in Chart.yaml file.
-func generate(version string) error {
+var chartPaths = map[chartKind]string{
+	chartKindLegacy:      "cockroachdb/Chart.yaml",
+	chartKindCockroachDB: "cockroachdb-parent/charts/cockroachdb/Chart.yaml",
+	chartKindOperator:    "cockroachdb-parent/charts/operator/Chart.yaml",
+	chartKindParent:      "cockroachdb-parent/Chart.yaml",
+}
+
+func validateChartTarget(target string) error {
+	switch target {
+	case "", "cockroachdb", "operator":
+		return nil
+	default:
+		return fmt.Errorf("unknown chart target %q, must be 'cockroachdb' or 'operator'", target)
+	}
+}
+
+func validateNoDowngrade(current, proposed *semver.Version, component string) error {
+	if proposed.LessThan(current) {
+		return fmt.Errorf("cannot downgrade %s from %s to %s", component, current, proposed)
+	}
+	return nil
+}
+
+func chartKindFromPath(relPath string) chartKind {
+	normalized := filepath.ToSlash(relPath)
+	switch {
+	case strings.HasPrefix(normalized, "cockroachdb-parent/charts/operator"):
+		return chartKindOperator
+	case strings.HasPrefix(normalized, "cockroachdb-parent/charts/cockroachdb"):
+		return chartKindCockroachDB
+	case strings.HasPrefix(normalized, "cockroachdb-parent"):
+		return chartKindParent
+	default:
+		return chartKindLegacy
+	}
+}
+
+func generate(chartTarget, version string) error {
 	const templatesDir = "build/templates"
 	const outputDir = "."
-	var args templateArgs
 
 	dirInfo, err := os.Stat(templatesDir)
 	if err != nil {
@@ -111,15 +171,19 @@ func generate(version string) error {
 		return fmt.Errorf("%s is not a directory", templatesDir)
 	}
 
+	allArgs, err := computeAllArgs(chartTarget, version)
+	if err != nil {
+		return fmt.Errorf("cannot compute chart versions: %w", err)
+	}
+
 	return filepath.Walk(templatesDir, func(filePath string, fileInfo os.FileInfo, e error) error {
 		if e != nil {
 			return e
 		}
-		// Skip directories
 		if !fileInfo.Mode().IsRegular() {
 			return nil
 		}
-		// calculate file directory relative to the given root directory.
+
 		dir := filepath.Dir(filePath)
 		fileName := filepath.Base(filePath)
 		relDir, err := filepath.Rel(templatesDir, dir)
@@ -128,12 +192,10 @@ func generate(version string) error {
 		}
 		destDir := filepath.Join(outputDir, relDir)
 		destFile := filepath.Join(destDir, fileInfo.Name())
-		if fileName == "Chart.yaml" {
-			args, err = buildTemplateArgs(destFile, version)
-			if err != nil {
-				return err
-			}
-		}
+
+		kind := chartKindFromPath(relDir)
+		args := allArgs[kind]
+
 		doNotEditStatement := fmt.Sprintf("# Generated file, DO NOT EDIT. Source: %s\n", filePath)
 		if fileName == "README.md" {
 			doNotEditStatement = fmt.Sprintf("<!--- Generated file, DO NOT EDIT. Source: %s --->\n", filePath)
@@ -151,38 +213,110 @@ func generate(version string) error {
 	})
 }
 
-// buildTemplateArgs reads the Chart.yaml file and returns the template arguments.
-func buildTemplateArgs(destFile, version string) (templateArgs, error) {
-	chart, err := getVersions(destFile)
+func computeAllArgs(chartTarget, version string) (map[chartKind]templateArgs, error) {
+	result := make(map[chartKind]templateArgs)
+
+	legacyChart, err := getVersions(chartPaths[chartKindLegacy])
 	if err != nil {
-		return templateArgs{}, fmt.Errorf("cannot get chart versions: %w", err)
+		return nil, fmt.Errorf("cannot read legacy chart: %w", err)
 	}
-	if version == "" {
-		return templateArgs{
-			Version:    chart.Version.String(),
-			AppVersion: chart.AppVersion.String(),
-		}, nil
+	cockroachdbChart, err := getVersions(chartPaths[chartKindCockroachDB])
+	if err != nil {
+		return nil, fmt.Errorf("cannot read cockroachdb chart: %w", err)
+	}
+	operatorChart, err := getVersions(chartPaths[chartKindOperator])
+	if err != nil {
+		return nil, fmt.Errorf("cannot read operator chart: %w", err)
 	}
 
-	crdbVersion := semver.MustParse(chart.AppVersion.String())
-	if version != "helm" {
-		crdbVersion, err = semver.NewVersion(strings.TrimPrefix(version, "v"))
+	if version == "" {
+		result[chartKindLegacy] = templateArgs{
+			Version:    legacyChart.Version.String(),
+			AppVersion: legacyChart.AppVersion.String(),
+		}
+		result[chartKindCockroachDB] = templateArgs{
+			Version:    cockroachdbChart.Version.String(),
+			AppVersion: cockroachdbChart.AppVersion.String(),
+		}
+		result[chartKindOperator] = templateArgs{
+			Version:    operatorChart.Version.String(),
+			AppVersion: operatorChart.AppVersion.String(),
+		}
+	} else if chartTarget == "operator" {
+		newVersion := strings.TrimPrefix(version, "v")
+		newVer, err := semver.NewVersion(newVersion)
 		if err != nil {
-			return templateArgs{}, fmt.Errorf("cannot parse version %s: %w", version, err)
+			return nil, fmt.Errorf("cannot parse operator version %s: %w", version, err)
+		}
+		if err := validateNoDowngrade(operatorChart.Version.Version, newVer, "operator chart"); err != nil {
+			return nil, err
+		}
+		result[chartKindOperator] = templateArgs{
+			Version:    newVersion,
+			AppVersion: newVersion,
+		}
+		result[chartKindCockroachDB] = templateArgs{
+			Version:    cockroachdbChart.Version.String(),
+			AppVersion: cockroachdbChart.AppVersion.String(),
+		}
+		result[chartKindLegacy] = templateArgs{
+			Version:    legacyChart.Version.String(),
+			AppVersion: legacyChart.AppVersion.String(),
+		}
+	} else {
+		crdbVersion := cockroachdbChart.AppVersion.Version
+		if version != "helm" {
+			crdbVersion, err = semver.NewVersion(strings.TrimPrefix(version, "v"))
+			if err != nil {
+				return nil, fmt.Errorf("cannot parse CRDB version %s: %w", version, err)
+			}
+			if err := validateNoDowngrade(cockroachdbChart.AppVersion.Version, crdbVersion, "CRDB version"); err != nil {
+				return nil, err
+			}
+		}
+
+		newCockroachDBVersion, err := bumpCockroachDBChart(cockroachdbChart, crdbVersion)
+		if err != nil {
+			return nil, fmt.Errorf("cannot bump cockroachdb chart: %w", err)
+		}
+		result[chartKindCockroachDB] = templateArgs{
+			Version:    newCockroachDBVersion,
+			AppVersion: crdbVersion.Original(),
+		}
+
+		// Legacy chart only bumps in compat mode (no --chart flag).
+		if chartTarget == "" {
+			newLegacyVersion, err := bumpLegacyChart(legacyChart, crdbVersion)
+			if err != nil {
+				return nil, fmt.Errorf("cannot bump legacy chart: %w", err)
+			}
+			result[chartKindLegacy] = templateArgs{
+				Version:    newLegacyVersion,
+				AppVersion: crdbVersion.Original(),
+			}
+		} else {
+			result[chartKindLegacy] = templateArgs{
+				Version:    legacyChart.Version.String(),
+				AppVersion: legacyChart.AppVersion.String(),
+			}
+		}
+
+		result[chartKindOperator] = templateArgs{
+			Version:    operatorChart.Version.String(),
+			AppVersion: operatorChart.AppVersion.String(),
 		}
 	}
 
-	newChartVersion, err := bumpVersion(chart, crdbVersion)
-	if err != nil {
-		return templateArgs{}, fmt.Errorf("cannot bump chart version: %w", err)
+	result[chartKindParent] = templateArgs{
+		Version:            result[chartKindCockroachDB].AppVersion,
+		AppVersion:         result[chartKindCockroachDB].AppVersion,
+		OperatorVersion:    result[chartKindOperator].Version,
+		CockroachDBVersion: result[chartKindCockroachDB].Version,
 	}
-	return templateArgs{
-		Version:    newChartVersion,
-		AppVersion: crdbVersion.Original(),
-	}, nil
+
+	return result, nil
 }
 
-// processTemplate reads a template file, applies the template arguments and writes it to the specified location
 func processTemplate(
 	templateFile string, outputFile string, args templateArgs, header string,
 ) error {
@@ -205,71 +339,25 @@ func processTemplate(
 	return nil
 }
 
-// bumpVersion increases the patch release version (the last digit) of a given version
-func bumpVersion(chart versions, newCRDBVersion *semver.Version) (string, error) {
-	isOperatorBasedChart := isEnterpriseOperatorChart(chart)
-	// Bump chart major version in case appVersion changes its major or minor version
-	// For example, 22.1.0 or 22.2.0 should trigger this behaviour. \
-	// This is applicable only for the old chart, not for the enterprise operator chart.
-	if !isOperatorBasedChart &&
-		(chart.AppVersion.Major() != newCRDBVersion.Major() || chart.AppVersion.Minor() != newCRDBVersion.Minor()) {
-		nextMajor := chart.Version.IncMajor()
-		nextVersion, err := semver.NewVersion(fmt.Sprintf("%d.0.0", nextMajor.Major()))
-		if err != nil {
-			return "", fmt.Errorf("cannot parse next version: %w", err)
-		}
-		return nextVersion.Original(), nil
+// Locked major.minor: chart major.minor follows CRDB, patch increments independently.
+func bumpCockroachDBChart(chart versions, newCRDBVersion *semver.Version) (string, error) {
+	if chart.AppVersion.Major() != newCRDBVersion.Major() || chart.AppVersion.Minor() != newCRDBVersion.Minor() {
+		return fmt.Sprintf("%d.%d.0", newCRDBVersion.Major(), newCRDBVersion.Minor()), nil
 	}
-
-	// For enterprise operator charts, if appVersion changes, set the chart version to the new CRDB version,
-	// preserving any existing prerelease information from the current chart version.
-	if isOperatorBasedChart && (chart.AppVersion.String() != newCRDBVersion.String()) {
-		newVer := newCRDBVersion.String()
-		if chart.Version.Prerelease() != "" {
-			newVer = fmt.Sprintf("%s-%s", newVer, chart.Version.Prerelease())
-		}
-		nextVersion, err := semver.NewVersion(newVer)
-		if err != nil {
-			return "", err
-		}
-		return nextVersion.Original(), nil
-	}
-
-	// If the chart version is the same as the new CRDB version, we increment the BUILD number.
-	// Increment BUILD number for the new chart version where AppVersion and Version are the same.
-	if chart.AppVersion.String() == newCRDBVersion.String() && chart.Version.Major() == chart.AppVersion.Major() {
-		build := chart.Version.Metadata()
-		newBuild := "1"
-		if build != "" {
-			parts := strings.Split(build, ".")
-			if len(parts) == 1 {
-				if n, err := fmt.Sscanf(parts[0], "%s", &newBuild); n == 1 && err == nil {
-					var val int
-					_, _ = fmt.Sscanf(parts[0], "%d", &val)
-					newBuild = fmt.Sprintf("%d", val+1)
-				}
-			}
-		}
-
-		baseVersionStr := fmt.Sprintf("%d.%d.%d", chart.Version.Major(), chart.Version.Minor(), chart.Version.Patch())
-		if chart.Version.Prerelease() != "" {
-			baseVersionStr = fmt.Sprintf("%s-%s", baseVersionStr, chart.Version.Prerelease())
-		}
-
-		v, err := semver.NewVersion(fmt.Sprintf("%s+%s", baseVersionStr, newBuild))
-		if err != nil {
-			return "", fmt.Errorf("cannot parse new version with build metadata: %w", err)
-		}
-		// Construct the new version string
-		return v.Original(), nil
-	}
-
-	// This will be executed for the old chart versions, where we just increment the patch version.
-	nextVersion := chart.Version.IncPatch()
-	return nextVersion.Original(), nil
+	nextPatch := chart.Version.IncPatch()
+	return nextPatch.Original(), nil
 }
 
-// getVersions reads chart and app versions from Chart.yaml file
+// Preserves old statefulset chart behavior: major bump on CRDB major.minor change.
+func bumpLegacyChart(chart versions, newCRDBVersion *semver.Version) (string, error) {
+	if chart.AppVersion.Major() != newCRDBVersion.Major() || chart.AppVersion.Minor() != newCRDBVersion.Minor() {
+		nextMajor := chart.Version.IncMajor()
+		return fmt.Sprintf("%d.0.0", nextMajor.Major()), nil
+	}
+	nextPatch := chart.Version.IncPatch()
+	return nextPatch.Original(), nil
+}
+
 func getVersions(chartPath string) (versions, error) {
 	chartContents, err := os.ReadFile(chartPath)
 	if err != nil {
@@ -280,10 +368,4 @@ func getVersions(chartPath string) (versions, error) {
 		return versions{}, fmt.Errorf("cannot unmarshal %s: %w", chartPath, err)
 	}
 	return chart, nil
-}
-
-// isEnterpriseOperatorChart checks if the chart is an enterprise operator chart.
-func isEnterpriseOperatorChart(chart versions) bool {
-	return chart.Version.Major() == chart.AppVersion.Major() && chart.Version.Minor() == chart.AppVersion.Minor() &&
-		chart.Version.Patch() == chart.AppVersion.Patch()
 }

--- a/build/build_test.go
+++ b/build/build_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -14,155 +16,55 @@ func mustVer(s string) parsedVersion {
 	return parsedVersion{v}
 }
 
-func TestBumpVersion_MajorOrMinorChange(t *testing.T) {
-	testcases := []struct {
-		name         string
-		chartVersion string
-		appVersion   string
-		newCRDB      string
-		gotVersion   string
-	}{
-		{
-			name:         "bump major version calendar year",
-			chartVersion: "25.1.6",
-			appVersion:   "25.1.6",
-			newCRDB:      "26.0.0",
-			gotVersion:   "26.0.0",
-		},
-		{
-			name:         "bump major version series",
-			chartVersion: "25.1.6",
-			appVersion:   "25.1.6",
-			newCRDB:      "25.2.0",
-			gotVersion:   "25.2.0",
-		},
-		{
-			name:         "bump major version calendar year with preview",
-			chartVersion: "25.1.6-preview",
-			appVersion:   "25.1.6",
-			newCRDB:      "26.0.0",
-			gotVersion:   "26.0.0-preview",
-		},
-		{
-			name:         "bump major version series with preview",
-			chartVersion: "25.1.6-preview",
-			appVersion:   "25.1.6",
-			newCRDB:      "25.2.0",
-			gotVersion:   "25.2.0-preview",
-		},
-		{
-			name:         "bump major version calendar year for old chart version",
-			chartVersion: "16.1.0",
-			appVersion:   "25.1.6",
-			newCRDB:      "26.0.0",
-			gotVersion:   "17.0.0",
-		},
-		{
-			name:         "bump major version series for old chart version",
-			chartVersion: "16.1.0",
-			appVersion:   "25.1.6",
-			newCRDB:      "25.2.0",
-			gotVersion:   "17.0.0",
-		},
-	}
-
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			chart := versions{
-				Version:    mustVer(tc.chartVersion),
-				AppVersion: mustVer(tc.appVersion),
-			}
-			newCRDB := semver.MustParse(tc.newCRDB)
-			got, err := bumpVersion(chart, newCRDB)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if got != tc.gotVersion {
-				t.Errorf("expected %s, got %s", tc.gotVersion, got)
-			}
-		})
-	}
-}
-
-func TestBumpVersion_BuildMetadata(t *testing.T) {
-	testCases := []struct {
-		name         string
-		chartVersion string
-		appVersion   string
-		gotVersion   string
-	}{
-		{
-			name:         "bump build metadata first time",
-			chartVersion: "25.1.6",
-			appVersion:   "25.1.6",
-			gotVersion:   "25.1.6+1",
-		},
-		{
-			name:         "bump build metadata first time with preview",
-			chartVersion: "25.1.6-preview",
-			appVersion:   "25.1.6",
-			gotVersion:   "25.1.6-preview+1",
-		},
-		{
-			name:         "bump build metadata with existing metadata",
-			chartVersion: "25.1.6+1",
-			appVersion:   "25.1.6",
-			gotVersion:   "25.1.6+2",
-		},
-		{
-			name:         "bump build metadata with existing metadata and preview",
-			chartVersion: "25.1.6-preview+1",
-			appVersion:   "25.1.6",
-			gotVersion:   "25.1.6-preview+2",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			chart := versions{
-				Version:    mustVer(tc.chartVersion),
-				AppVersion: mustVer(tc.appVersion),
-			}
-			newCRDB := semver.MustParse(tc.appVersion)
-			got, err := bumpVersion(chart, newCRDB)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if got != tc.gotVersion {
-				t.Errorf("expected %s, got %s", tc.gotVersion, got)
-			}
-		})
-	}
-}
-
-func TestBumpVersion_DefaultPatch(t *testing.T) {
+func TestBumpCockroachDBChart(t *testing.T) {
 	testCases := []struct {
 		name         string
 		chartVersion string
 		appVersion   string
 		newCRDB      string
-		gotVersion   string
+		wantVersion  string
 	}{
 		{
-			name:         "bump patch version for operator based chart",
-			chartVersion: "25.1.6",
-			appVersion:   "25.1.6",
-			newCRDB:      "25.1.7",
-			gotVersion:   "25.1.7",
+			name:         "CRDB patch bump increments chart patch",
+			chartVersion: "26.1.0",
+			appVersion:   "26.1.3",
+			newCRDB:      "26.1.4",
+			wantVersion:  "26.1.1",
 		},
 		{
-			name:         "bump patch version for old chart version",
-			chartVersion: "16.1.0",
-			appVersion:   "25.1.6",
-			newCRDB:      "25.1.7",
-			gotVersion:   "16.1.1",
+			name:         "second CRDB patch bump",
+			chartVersion: "26.1.1",
+			appVersion:   "26.1.4",
+			newCRDB:      "26.1.5",
+			wantVersion:  "26.1.2",
 		},
 		{
-			name:         "bump patch version with preview",
-			chartVersion: "25.1.6-preview",
-			appVersion:   "25.1.6",
-			newCRDB:      "25.1.7",
-			gotVersion:   "25.1.7-preview",
+			name:         "chart-only fix (same CRDB version)",
+			chartVersion: "26.1.0",
+			appVersion:   "26.1.3",
+			newCRDB:      "26.1.3",
+			wantVersion:  "26.1.1",
+		},
+		{
+			name:         "CRDB minor bump starts new chart line",
+			chartVersion: "26.1.2",
+			appVersion:   "26.1.5",
+			newCRDB:      "26.2.0",
+			wantVersion:  "26.2.0",
+		},
+		{
+			name:         "CRDB major bump starts new chart line",
+			chartVersion: "26.1.2",
+			appVersion:   "26.1.5",
+			newCRDB:      "27.1.0",
+			wantVersion:  "27.1.0",
+		},
+		{
+			name:         "first release of new series",
+			chartVersion: "25.2.3",
+			appVersion:   "25.2.7",
+			newCRDB:      "26.1.0",
+			wantVersion:  "26.1.0",
 		},
 	}
 
@@ -173,12 +75,235 @@ func TestBumpVersion_DefaultPatch(t *testing.T) {
 				AppVersion: mustVer(tc.appVersion),
 			}
 			newCRDB := semver.MustParse(tc.newCRDB)
-			got, err := bumpVersion(chart, newCRDB)
+			got, err := bumpCockroachDBChart(chart, newCRDB)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if got != tc.gotVersion {
-				t.Errorf("expected %s, got %s", tc.gotVersion, got)
+			if got != tc.wantVersion {
+				t.Errorf("got %s, want %s", got, tc.wantVersion)
+			}
+		})
+	}
+}
+
+func TestBumpLegacyChart(t *testing.T) {
+	testCases := []struct {
+		name         string
+		chartVersion string
+		appVersion   string
+		newCRDB      string
+		wantVersion  string
+	}{
+		{
+			name:         "CRDB patch bump increments chart patch",
+			chartVersion: "20.0.4",
+			appVersion:   "26.1.3",
+			newCRDB:      "26.1.4",
+			wantVersion:  "20.0.5",
+		},
+		{
+			name:         "CRDB minor bump increments chart major",
+			chartVersion: "20.0.4",
+			appVersion:   "26.1.3",
+			newCRDB:      "26.2.0",
+			wantVersion:  "21.0.0",
+		},
+		{
+			name:         "CRDB major bump increments chart major",
+			chartVersion: "20.0.4",
+			appVersion:   "26.1.3",
+			newCRDB:      "27.1.0",
+			wantVersion:  "21.0.0",
+		},
+		{
+			name:         "chart-only fix (same CRDB version)",
+			chartVersion: "20.0.4",
+			appVersion:   "26.1.3",
+			newCRDB:      "26.1.3",
+			wantVersion:  "20.0.5",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			chart := versions{
+				Version:    mustVer(tc.chartVersion),
+				AppVersion: mustVer(tc.appVersion),
+			}
+			newCRDB := semver.MustParse(tc.newCRDB)
+			got, err := bumpLegacyChart(chart, newCRDB)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantVersion {
+				t.Errorf("got %s, want %s", got, tc.wantVersion)
+			}
+		})
+	}
+}
+
+func TestValidateChartTarget(t *testing.T) {
+	testCases := []struct {
+		target  string
+		wantErr bool
+	}{
+		{"", false},
+		{"cockroachdb", false},
+		{"operator", false},
+		{"foobar", true},
+		{"legacy", true},
+		{"parent", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.target, func(t *testing.T) {
+			err := validateChartTarget(tc.target)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateChartTarget(%q) error = %v, wantErr %v", tc.target, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateNoDowngrade(t *testing.T) {
+	testCases := []struct {
+		name     string
+		current  string
+		proposed string
+		wantErr  bool
+	}{
+		{"upgrade allowed", "1.0.0", "1.1.0", false},
+		{"same version allowed", "1.0.0", "1.0.0", false},
+		{"patch upgrade allowed", "26.1.3", "26.1.4", false},
+		{"major upgrade allowed", "1.0.0", "2.0.0", false},
+		{"downgrade rejected", "1.1.0", "1.0.0", true},
+		{"patch downgrade rejected", "26.1.3", "26.1.2", true},
+		{"major downgrade rejected", "2.0.0", "1.9.9", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			current := semver.MustParse(tc.current)
+			proposed := semver.MustParse(tc.proposed)
+			err := validateNoDowngrade(current, proposed, "test")
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateNoDowngrade(%s, %s) error = %v, wantErr %v", tc.current, tc.proposed, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestComputeAllArgs(t *testing.T) {
+	if err := os.Chdir(".."); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir("build") })
+
+	testCases := []struct {
+		name        string
+		chartTarget string
+		version     string
+		wantErr     string
+		check       func(t *testing.T, result map[chartKind]templateArgs)
+	}{
+		{
+			name:        "operator helm shortcut rejected",
+			chartTarget: "operator",
+			version:     "helm",
+			wantErr:     "cannot parse operator version",
+		},
+		{
+			name:        "cockroachdb bump does not change legacy",
+			chartTarget: "cockroachdb",
+			version:     "26.1.4",
+			check: func(t *testing.T, result map[chartKind]templateArgs) {
+				legacy := result[chartKindLegacy]
+				if legacy.Version != "20.0.4" {
+					t.Errorf("legacy version changed to %s, want 20.0.4", legacy.Version)
+				}
+				if legacy.AppVersion != "26.1.3" {
+					t.Errorf("legacy appVersion changed to %s, want 26.1.3", legacy.AppVersion)
+				}
+				crdb := result[chartKindCockroachDB]
+				if crdb.AppVersion != "26.1.4" {
+					t.Errorf("cockroachdb appVersion = %s, want 26.1.4", crdb.AppVersion)
+				}
+			},
+		},
+		{
+			name:        "unscoped bump changes both cockroachdb and legacy",
+			chartTarget: "",
+			version:     "26.1.4",
+			check: func(t *testing.T, result map[chartKind]templateArgs) {
+				legacy := result[chartKindLegacy]
+				if legacy.Version == "20.0.4" {
+					t.Error("legacy version should have bumped but stayed at 20.0.4")
+				}
+				if legacy.AppVersion != "26.1.4" {
+					t.Errorf("legacy appVersion = %s, want 26.1.4", legacy.AppVersion)
+				}
+				crdb := result[chartKindCockroachDB]
+				if crdb.AppVersion != "26.1.4" {
+					t.Errorf("cockroachdb appVersion = %s, want 26.1.4", crdb.AppVersion)
+				}
+			},
+		},
+		{
+			name:        "operator explicit version sets both version and appVersion",
+			chartTarget: "operator",
+			version:     "1.0.0-rc.2",
+			check: func(t *testing.T, result map[chartKind]templateArgs) {
+				op := result[chartKindOperator]
+				if op.Version != "1.0.0-rc.2" {
+					t.Errorf("operator version = %s, want 1.0.0-rc.2", op.Version)
+				}
+				if op.AppVersion != "1.0.0-rc.2" {
+					t.Errorf("operator appVersion = %s, want 1.0.0-rc.2", op.AppVersion)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := computeAllArgs(tc.chartTarget, tc.version)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			tc.check(t, result)
+		})
+	}
+}
+
+func TestChartKindFromPath(t *testing.T) {
+	testCases := []struct {
+		path string
+		want chartKind
+	}{
+		{"cockroachdb", chartKindLegacy},
+		{"cockroachdb/Chart.yaml", chartKindLegacy},
+		{"cockroachdb-parent", chartKindParent},
+		{"cockroachdb-parent/Chart.yaml", chartKindParent},
+		{"cockroachdb-parent/charts/cockroachdb", chartKindCockroachDB},
+		{"cockroachdb-parent/charts/cockroachdb/Chart.yaml", chartKindCockroachDB},
+		{"cockroachdb-parent/charts/operator", chartKindOperator},
+		{"cockroachdb-parent/charts/operator/Chart.yaml", chartKindOperator},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.path, func(t *testing.T) {
+			got := chartKindFromPath(tc.path)
+			if got != tc.want {
+				t.Errorf("chartKindFromPath(%q) = %s, want %s", tc.path, got, tc.want)
 			}
 		})
 	}

--- a/build/templates/cockroachdb-parent/Chart.yaml
+++ b/build/templates/cockroachdb-parent/Chart.yaml
@@ -5,11 +5,12 @@ type: application
 version: {{ .Version }}
 appVersion: {{ .AppVersion }}
 dependencies:
-  - name: operator
-    version: {{ .Version }}
+  - name: cockroachdb-operator
+    alias: operator
+    version: {{ .OperatorVersion }}
     condition: operator.enabled
     repository: "file://charts/operator"
   - name: cockroachdb
-    version: {{ .Version }}
+    version: {{ .CockroachDBVersion }}
     condition: cockroachdb.enabled
     repository: "file://charts/cockroachdb"

--- a/build/templates/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/build/templates/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -468,7 +468,7 @@ cockroachdb:
         # # initContainers captures the list of init containers for CockroachDB pods.
         # initContainers:
         #   - name : cockroachdb-init
-        #     image: docker.io/cockroachdb/cockroachdb-init-container:1.0.0-rc.1
+        #     image: docker.io/cockroachdb/cockroachdb-init-container:v1.0.0-rc.1
         # containers captures the list of containers for CockroachDB pods.
         containers:
           - name: cockroachdb
@@ -483,8 +483,8 @@ cockroachdb:
             resources: {}
             # image: cockroachdb/cockroach:v{{ .AppVersion }}
             # - name: cert-reloader
-            #   image: docker.io/cockroachdb/cockroachdb-cert-reloader:1.0.0-rc.1
-        
+            #   image: docker.io/cockroachdb/cockroachdb-cert-reloader:v1.0.0-rc.1
+
         # topologySpreadConstraints captures pod topology spread constraints.
         # It is recommended to spread CockroachDB pods across zones to ensure high availability.
         topologySpreadConstraints:

--- a/build/templates/cockroachdb-parent/charts/operator/Chart.yaml
+++ b/build/templates/cockroachdb-parent/charts/operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: operator
+name: cockroachdb-operator
 description: A Helm chart for managing the CockroachDB operator.
 type: application
 appVersion: {{ .AppVersion }}

--- a/build/templates/cockroachdb-parent/charts/operator/values.yaml
+++ b/build/templates/cockroachdb-parent/charts/operator/values.yaml
@@ -9,7 +9,7 @@ image:
   # pullPolicy specifies the image pull policy.
   pullPolicy: IfNotPresent
   # tag is the image tag.
-  tag: "1.0.0-rc.1"
+  tag: "v{{ .AppVersion }}"
 # certificate defines the certificate settings for the Operator.
 certificate:
   # validForDays specifies the number of days the certificate is valid for.

--- a/cockroachdb-parent/Chart.lock
+++ b/cockroachdb-parent/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: operator
+- name: cockroachdb-operator
   repository: file://charts/operator
-  version: 26.1.3-preview+1
+  version: 1.0.0-rc.1
 - name: cockroachdb
   repository: file://charts/cockroachdb
-  version: 26.1.3-preview+1
-digest: sha256:ffa153440956e2bcfee5b900e64a73aa227ad4e28f8f282dc0d65b052bad03ae
-generated: "2026-04-23T22:25:58.065803+05:30"
+  version: 26.1.3
+digest: sha256:191176fa3adbfb2ddd5466ee8921e52d62e5d41145b7a8145917dcda020c43bb
+generated: "2026-04-27T23:43:51.149883+05:30"

--- a/cockroachdb-parent/Chart.yaml
+++ b/cockroachdb-parent/Chart.yaml
@@ -3,14 +3,15 @@ apiVersion: v2
 name: cockroachdb-parent
 description: A parent Helm chart for CockroachDB and its operator using helm-spray
 type: application
-version: 26.1.3-preview+1
+version: 26.1.3
 appVersion: 26.1.3
 dependencies:
-  - name: operator
-    version: 26.1.3-preview+1
+  - name: cockroachdb-operator
+    alias: operator
+    version: 1.0.0-rc.1
     condition: operator.enabled
     repository: "file://charts/operator"
   - name: cockroachdb
-    version: 26.1.3-preview+1
+    version: 26.1.3
     condition: cockroachdb.enabled
     repository: "file://charts/cockroachdb"

--- a/cockroachdb-parent/charts/cockroachdb/CHANGELOG.md
+++ b/cockroachdb-parent/charts/cockroachdb/CHANGELOG.md
@@ -1,0 +1,16 @@
+# CockroachDB Chart — CHANGELOG
+
+## [26.1.3] — Unreleased
+### Changed
+- **Per-chart versioning**: The CockroachDB chart's major.minor now tracks the CockroachDB database
+  series (e.g., chart 26.1.x is for CockroachDB 26.1). The patch version increments independently.
+  Check `appVersion` in Chart.yaml for the exact CockroachDB version bundled.
+- Hook images (`bitnami/kubectl`, `dtzar/helm-kubectl`) are now configurable via
+  `hooks.kubectlImage.{registry,repository,tag,pullPolicy}` for air-gapped deployments.
+
+### Upgrade Notes
+- Users must be on the latest preview version (`26.1.3-preview+1`) before upgrading.
+- `helm upgrade <release> cockroachdb/cockroachdb --version 26.1.3`
+
+### Previous releases
+For changes prior to per-chart versioning, see the [root CHANGELOG](../../../CHANGELOG.md).

--- a/cockroachdb-parent/charts/cockroachdb/Chart.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 26.1.3-preview+1
+version: 26.1.3
 appVersion: 26.1.3
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -469,7 +469,7 @@ cockroachdb:
         # # initContainers captures the list of init containers for CockroachDB pods.
         # initContainers:
         #   - name : cockroachdb-init
-        #     image: docker.io/cockroachdb/cockroachdb-init-container:1.0.0-rc.1
+        #     image: docker.io/cockroachdb/cockroachdb-init-container:v1.0.0-rc.1
         # containers captures the list of containers for CockroachDB pods.
         containers:
           - name: cockroachdb
@@ -484,8 +484,8 @@ cockroachdb:
             resources: {}
             # image: cockroachdb/cockroach:v26.1.3
             # - name: cert-reloader
-            #   image: docker.io/cockroachdb/cockroachdb-cert-reloader:1.0.0-rc.1
-        
+            #   image: docker.io/cockroachdb/cockroachdb-cert-reloader:v1.0.0-rc.1
+
         # topologySpreadConstraints captures pod topology spread constraints.
         # It is recommended to spread CockroachDB pods across zones to ensure high availability.
         topologySpreadConstraints:

--- a/cockroachdb-parent/charts/operator/CHANGELOG.md
+++ b/cockroachdb-parent/charts/operator/CHANGELOG.md
@@ -1,0 +1,18 @@
+# CockroachDB Operator Chart — CHANGELOG
+
+## [1.0.0-rc.1] — Unreleased
+### Changed
+- **Per-chart versioning**: The operator chart now uses independent semantic versioning, starting
+  at 1.0.0-rc.1. A single operator version supports multiple CockroachDB versions.
+- **Chart renamed** from `operator` to `cockroachdb-operator`.
+- **Image tags**: The operator image now uses semantic version tags (`v1.0.0-rc.1`) instead of
+  SHA digests.
+- **Image registry**: The operator image now defaults to DockerHub (`docker.io/cockroachdb`)
+  instead of Google Artifact Registry.
+
+### Upgrade Notes
+- Users must be on the latest preview version (`26.1.3-preview+1`) before upgrading.
+- `helm upgrade <release> cockroachdb/cockroachdb-operator --version 1.0.0-rc.1`
+
+### Previous releases
+For changes prior to per-chart versioning, see the [root CHANGELOG](../../../CHANGELOG.md).

--- a/cockroachdb-parent/charts/operator/Chart.yaml
+++ b/cockroachdb-parent/charts/operator/Chart.yaml
@@ -1,7 +1,7 @@
 # Generated file, DO NOT EDIT. Source: build/templates/cockroachdb-parent/charts/operator/Chart.yaml
 apiVersion: v2
-name: operator
+name: cockroachdb-operator
 description: A Helm chart for managing the CockroachDB operator.
 type: application
-appVersion: 26.1.3
-version: 26.1.3-preview+1
+appVersion: 1.0.0-rc.1
+version: 1.0.0-rc.1

--- a/cockroachdb-parent/charts/operator/values.yaml
+++ b/cockroachdb-parent/charts/operator/values.yaml
@@ -10,7 +10,7 @@ image:
   # pullPolicy specifies the image pull policy.
   pullPolicy: IfNotPresent
   # tag is the image tag.
-  tag: "1.0.0-rc.1"
+  tag: "v1.0.0-rc.1"
 # certificate defines the certificate settings for the Operator.
 certificate:
   # validForDays specifies the number of days the certificate is valid for.

--- a/cockroachdb-parent/docs/VERSIONING.md
+++ b/cockroachdb-parent/docs/VERSIONING.md
@@ -1,0 +1,138 @@
+# Versioning and Upgrades
+
+This document explains how CockroachDB Helm chart versions work and how to upgrade.
+
+## Chart Versions
+
+There are two charts, each with its own versioning scheme.
+
+### Operator chart
+
+The operator chart uses independent semantic versioning (e.g., 1.0.0, 1.1.0, 2.0.0). The version
+is not tied to any CockroachDB version. A single operator version supports multiple CockroachDB
+versions simultaneously.
+
+| Bump | When |
+|---|---|
+| Patch (1.0.0 → 1.0.1) | Bug fix, operator image update with no CR changes |
+| Minor (1.0.0 → 1.1.0) | New CRD field, new CockroachDB version support |
+| Major (1.0.0 → 2.0.0) | Breaking CRD API change (field removal, storage migration) |
+
+Every operator version bump (`make bump/operator/<version>`) updates both the chart version and
+appVersion together. The operator image tag is derived from appVersion (`v<appVersion>`), so a
+matching operator image must exist before publishing the chart.
+
+For rare chart-only fixes (template or values changes without a new operator image), manually
+edit `version` in `cockroachdb-parent/charts/operator/Chart.yaml` without changing `appVersion`,
+then run `go run build/build.go generate`. Choose a version that will not collide with a future
+operator image release.
+
+#### Release candidates
+
+The operator chart supports release candidate versions (e.g., `1.0.0-rc.1`, `1.0.0-rc.2`).
+RC versions follow standard semver prerelease ordering:
+
+```
+1.0.0-rc.1  <  1.0.0-rc.2  <  1.0.0
+```
+
+RC charts are published and installable like any other version. Upgrading from RC to GA is a
+normal Helm upgrade with no special flags required. The operator and cockroachdb charts are
+independent, so the operator chart can be at an RC version while the cockroachdb chart is GA.
+
+Every RC bump requires a matching operator image. There is no chart-only shortcut for RC versions.
+
+### CockroachDB chart
+
+The CockroachDB chart's major.minor matches the CockroachDB database series. The patch version
+increments independently.
+
+```
+Chart 26.1.x  →  for CockroachDB 26.1
+Chart 26.2.x  →  for CockroachDB 26.2
+```
+
+The chart patch number may differ from the CockroachDB patch number. For example, chart 26.1.3
+might ship CockroachDB 26.1.1. Check `appVersion` in Chart.yaml for the exact CockroachDB
+version bundled with the chart.
+
+## Upgrade Order
+
+Always upgrade the operator chart before the cockroachdb chart.
+
+```bash
+# Step 1: Upgrade operator
+helm upgrade <operator-release> cockroachdb/cockroachdb-operator --version <new-version>
+
+# Step 2: Upgrade cockroachdb
+helm upgrade <cockroachdb-release> cockroachdb/cockroachdb --version <new-version>
+```
+
+The cockroachdb chart includes a pre-upgrade hook that validates the operator is in the expected
+state before proceeding. If the operator is not upgraded first, the hook blocks the upgrade with
+a clear error message.
+
+## Common Upgrade Scenarios
+
+### CockroachDB patch release (e.g., 26.1.1 → 26.1.2)
+
+Only the cockroachdb chart changes. The operator chart stays the same.
+
+```bash
+helm upgrade <cockroachdb-release> cockroachdb/cockroachdb --version <new-chart-version>
+```
+
+No operator upgrade needed. No downtime.
+
+### Operator bug fix or image update
+
+Only the operator chart changes. The cockroachdb chart stays the same.
+
+```bash
+helm upgrade <operator-release> cockroachdb/cockroachdb-operator --version <new-version>
+```
+
+The operator rolls out a new deployment. CockroachDB pods are not affected.
+
+### New CockroachDB series (e.g., 26.1 → 26.2)
+
+A new chart line is created (26.2.x). The operator may or may not need an upgrade depending on
+whether the new CockroachDB version requires operator changes.
+
+```bash
+# Check the chart's compatibility notes for minimum operator version
+helm upgrade <operator-release> cockroachdb/cockroachdb-operator --version <required-version>
+helm upgrade <cockroachdb-release> cockroachdb/cockroachdb --version 26.2.0
+```
+
+### Breaking operator change (major version bump)
+
+Rare. Happens when CRD fields are removed or the API version changes (e.g., v1alpha1 → v1beta1).
+
+1. Upgrade the operator chart to the new major version.
+2. Upgrade the cockroachdb chart, which will have updated templates.
+3. The cockroachdb chart's pre-upgrade hook enforces that the operator is upgraded first.
+
+Follow the migration guide included in the release notes for the specific major version.
+
+## Pre-Upgrade Validation
+
+The cockroachdb chart includes a pre-upgrade hook that runs before every upgrade. The hook checks:
+
+- The CockroachDB CRD (`crdbclusters.crdb.cockroachlabs.com`) exists in the cluster
+- The CRD serves the expected API version (v1beta1)
+- CRD storage migration is complete
+
+If any check fails, the upgrade is blocked with a message explaining what to do.
+
+## Overriding the CockroachDB Image Version
+
+To run a different CockroachDB version than the chart default, override the image name:
+
+```bash
+helm upgrade <release> cockroachdb/cockroachdb \
+  --set cockroachdb.crdbCluster.image.name=cockroachdb/cockroach:v26.1.5
+```
+
+This is useful when a new CockroachDB patch is released before the chart is updated, or when
+running an older CockroachDB version on the same chart line.

--- a/cockroachdb-parent/images.txt
+++ b/cockroachdb-parent/images.txt
@@ -11,7 +11,7 @@
 # === Operator chart images ===
 
 # CockroachDB Operator
-docker.io/cockroachdb/cockroachdb-operator-v2:1.0.0-rc.1
+docker.io/cockroachdb/cockroachdb-operator-v2:v1.0.0-rc.1
 
 # Operator pre-upgrade validation hook
 docker.io/dtzar/helm-kubectl:3.19
@@ -32,7 +32,7 @@ docker.io/dtzar/helm-kubectl:3.19
 # They must also be mirrored for air-gapped environments.
 
 # Init container
-docker.io/cockroachdb/cockroachdb-init-container:1.0.0-rc.1
+docker.io/cockroachdb/cockroachdb-init-container:v1.0.0-rc.1
 
 # Cert reloader (inotifywait)
-docker.io/cockroachdb/cockroachdb-cert-reloader:1.0.0-rc.1
+docker.io/cockroachdb/cockroachdb-cert-reloader:v1.0.0-rc.1


### PR DESCRIPTION
## Summary
- Refactors build.go from single shared version model to independent per-chart versioning
- Operator chart starts at 1.0.0-rc.1 with independent semver, renamed to cockroachdb-operator
- CockroachDB chart at 26.1.3 with locked major.minor to CRDB series
- Legacy chart preserves old behavior, isolated from --chart cockroachdb bumps
- Adds VERSIONING.md documenting versioning scheme, RC workflow, and upgrade paths
- Introduces per-chart CHANGELOGs under each chart directory, root CHANGELOG becomes index
- Fixes images.txt to use correct v-prefixed tags for air-gapped mirroring

### Version transitions
| Chart | Before | After |
|-------|--------|-------|
| operator | 26.1.3-preview (appVersion 26.1.3) | 1.0.0-rc.1 (appVersion 1.0.0-rc.1) |
| cockroachdb | 26.1.3-preview (appVersion 26.1.3) | 26.1.3 (appVersion 26.1.3) |
| legacy | 20.0.4 (unchanged) | 20.0.4 (unchanged) |
| parent | 26.1.3-preview | 26.1.3 |

### Bump command reference
```bash
make bump/cockroachdb/26.1.4       # CRDB patch bump (auto-merged by bot)
make bump/cockroachdb/26.2.0       # CRDB series change (manual review)
make bump/cockroachdb/helm         # CockroachDB chart-only fix
make bump/operator/1.0.0-rc.2     # Operator RC bump (version + appVersion)
make bump/operator/1.0.0          # Operator GA promotion
make bump/26.1.4                  # Legacy compat (bumps cockroachdb + legacy)
```

## Test plan
- [ ] `go run build/build.go bump --chart operator helm` errors (no shortcut for operator)
- [ ] `go run build/build.go bump --chart operator 1.0.0-rc.2` bumps operator only
- [ ] `go run build/build.go bump --chart cockroachdb 26.1.4` does not touch legacy chart
- [ ] `go run build/build.go bump 26.1.4` bumps both cockroachdb and legacy charts
- [ ] `helm dependency update ./cockroachdb-parent` succeeds with renamed chart
- [ ] `helm template test ./cockroachdb-parent --set operator.enabled=true` renders correctly
