### PR TITLE
ci: block auto-merge for major/minor CRDB version changes

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -34,6 +34,7 @@ jobs:
           set -euxo pipefail
           version="$(cat cockroachdb/Chart.yaml | yq -r '.version')"
           appVersion="$(cat cockroachdb/Chart.yaml | yq -r '.appVersion')"
+          pr_operator_version="$(cat cockroachdb-parent/charts/operator/Chart.yaml | yq -r '.version')"
           git checkout origin/master -- cockroachdb cockroachdb-parent
           git restore --staged cockroachdb cockroachdb-parent
           master_version="$(cat cockroachdb/Chart.yaml | yq -r '.version')"
@@ -41,13 +42,31 @@ jobs:
           latest_version="$(echo -e "$version\n$master_version" | sort --version-sort -r | head -n1)"
           latest_appVersion="$(echo -e "$appVersion\n$master_appVersion" | sort --version-sort -r | head -n1)"
           if [[ $latest_version != $version ]]; then
-            echo "Downgrades are not permitteed in automatic mode, $version < $latest_version"
+            echo "Downgrades are not permitted in automatic mode, $version < $latest_version"
             exit 1
           fi
           if [[ $latest_appVersion != $appVersion ]]; then
-            echo "Downgrades are not permitteed in automatic mode, $appVersion < $latest_appVersion"
+            echo "Downgrades are not permitted in automatic mode, $appVersion < $latest_appVersion"
             exit 1
           fi
+
+          # Block auto-merge for CRDB major or minor version changes.
+          # These require manual review to validate operator compatibility.
+          master_major_minor=$(echo "$master_appVersion" | cut -d. -f1-2)
+          pr_major_minor=$(echo "$appVersion" | cut -d. -f1-2)
+          if [[ "$master_major_minor" != "$pr_major_minor" ]]; then
+            echo "CRDB major/minor version change detected ($master_appVersion -> $appVersion). Manual review required."
+            exit 1
+          fi
+
+          # Block auto-merge if the operator chart version changed.
+          # Operator chart updates always require manual review.
+          master_operator_version="$(cat cockroachdb-parent/charts/operator/Chart.yaml | yq -r '.version')"
+          if [[ "$master_operator_version" != "$pr_operator_version" ]]; then
+            echo "Operator chart version changed ($master_operator_version -> $pr_operator_version). Manual review required."
+            exit 1
+          fi
+
           make bump/$appVersion
           # `helm dependency update` is not idempotent and bumps the
           # `generated` field with the current date/TZ. Let's checkout the


### PR DESCRIPTION
## Summary
- Auto-merge now only proceeds for CRDB patch bumps (e.g., 26.1.3 to 26.1.4)
- CRDB major or minor version changes (e.g., 26.1.x to 26.2.0) exit with a message requiring manual review
- Operator chart version changes are blocked from auto-merge entirely

## Context
Part of the GA versioning work ([CRDB-59251](https://cockroachlabs.atlassian.net/browse/CRDB-59251)). The auto-merge bot should only handle safe, routine CRDB patch bumps. Major/minor CRDB upgrades need manual validation that the operator supports the new version. Operator chart changes follow a separate release process.

Depends on #622 (per-chart versioning).

## Test plan
- [ ] Verify existing CRDB patch auto-merge still works (e.g., 26.1.3 to 26.1.4)
- [ ] Verify CRDB minor bump PR (e.g., 26.1.x to 26.2.0) fails the workflow with "Manual review required"
- [ ] Verify operator chart version change fails the workflow with "Manual review required"