### PR TITLE
e2e/operator: Add CloudProvider encryption interface

### DIFF
--- a/tests/e2e/operator/encryption/types.go
+++ b/tests/e2e/operator/encryption/types.go
@@ -1,0 +1,113 @@
+package encryption
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/stretchr/testify/require"
+)
+
+// EncryptionPlatformConfig holds provider-specific encryption configuration defaults
+type EncryptionPlatformConfig struct {
+	// Platform is the KMS platform type: "AWS_KMS", "GCP_CLOUD_KMS", or "UNKNOWN_KEY_TYPE"
+	Platform string
+
+	// RequiresCredentialsSecret indicates if cmekCredentialsSecretName is required
+	// True for AWS_KMS and GCP_KMS, false for UNKNOWN_KEY_TYPE (file-based)
+	RequiresCredentialsSecret bool
+
+	// DefaultCredentialsSecretName is the default name for the credentials secret
+	// Used when RequiresCredentialsSecret is true
+	DefaultCredentialsSecretName string
+}
+
+// Provider defines the encryption-related methods that cloud providers must implement
+// for encryption-at-rest testing. Providers handle all encryption details internally.
+type Provider interface {
+	// SetupEncryptionInfrastructure creates cloud KMS resources (keys, roles, policies)
+	// Returns a cleanup function that should be deferred to ensure proper resource cleanup
+	// Called once during test setup, before any encryption secrets are created
+	SetupEncryptionInfrastructure(t *testing.T) (cleanup func(), err error)
+
+	// SetupEncryptionSecrets creates all necessary Kubernetes secrets for encryption.
+	// This includes:
+	//   - Key secret with encrypted/encoded key data and provider-specific metadata
+	//   - Credentials secret (if required by the provider)
+	// The provider manages key generation, encryption, secret names, and all other details internally.
+	// clusterRegion identifies which cluster/region this is for (used for KMS key selection in multi-region)
+	SetupEncryptionSecrets(t *testing.T, kubectlOptions *k8s.KubectlOptions, clusterRegion string) error
+
+	// GetEncryptionPlatformConfig returns provider-specific encryption platform configuration
+	GetEncryptionPlatformConfig() *EncryptionPlatformConfig
+}
+
+// GenerateAndEncodeEncryptionKey generates a 256-bit AES encryption key and returns both
+// the raw bytes and base64-encoded string. This is a utility function for providers using
+// UNKNOWN_KEY_TYPE (file-based encryption) to generate and encode keys consistently.
+func GenerateAndEncodeEncryptionKey(t *testing.T) (rawKey []byte, base64Key string) {
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "store.key")
+
+	// Generate 256-bit AES key using cockroach gen encryption-key
+	cmd := shell.Command{
+		Command:    "cockroach",
+		Args:       []string{"gen", "encryption-key", "--size", "256", "store.key"},
+		WorkingDir: tempDir,
+	}
+
+	_, err := shell.RunCommandAndGetOutputE(t, cmd)
+	require.NoError(t, err, "Failed to generate encryption key")
+
+	// Read the generated key file
+	keyBytes, err := os.ReadFile(keyPath)
+	require.NoError(t, err, "Failed to read encryption key file")
+
+	// Base64 encode the key (removing any newlines)
+	base64Encoded := base64.StdEncoding.EncodeToString(keyBytes)
+	base64Encoded = strings.ReplaceAll(base64Encoded, "\n", "")
+
+	return keyBytes, base64Encoded
+}
+
+// SetupFileBasedEncryptionSecrets is a utility function for providers using UNKNOWN_KEY_TYPE
+// (file-based encryption). It generates a key, creates the Kubernetes secret, and verifies it.
+// This is the common implementation for Local and GCP providers (when not using cloud KMS).
+func SetupFileBasedEncryptionSecrets(t *testing.T, kubectlOptions *k8s.KubectlOptions, providerName string) error {
+	t.Logf("%s provider: Setting up file-based encryption secrets", providerName)
+
+	// Generate and encode encryption key
+	_, base64Key := GenerateAndEncodeEncryptionKey(t)
+	t.Logf("Generated encryption key (base64 length: %d)", len(base64Key))
+
+	// Create Kubernetes secret with base64-encoded key
+	// Use default secret name for file-based encryption
+	secretName := "cmek-key-secret"
+
+	err := k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", secretName,
+		fmt.Sprintf("--from-literal=StoreKeyData=%s", base64Key))
+	if err != nil {
+		return fmt.Errorf("failed to create encryption key secret: %w", err)
+	}
+
+	// Verify secret was created with data
+	secretSize, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "secret", secretName,
+		"-o", "jsonpath={.data.StoreKeyData}")
+	if err != nil {
+		return fmt.Errorf("failed to verify encryption secret: %w", err)
+	}
+	if len(secretSize) == 0 {
+		return fmt.Errorf("encryption secret StoreKeyData is empty")
+	}
+
+	t.Logf("Created encryption secret %s with key data (%d bytes)", secretName, len(secretSize))
+
+	// No credentials secret needed for file-based encryption (UNKNOWN_KEY_TYPE)
+	return nil
+}

--- a/tests/e2e/operator/infra/gcp.go
+++ b/tests/e2e/operator/infra/gcp.go
@@ -228,9 +228,6 @@ func (r *GcpRegion) SetUpInfra(t *testing.T) {
 	require.NoError(t, err)
 	err = r.deployAndConfigureCoreDNS(t, kubeConfigPath)
 	require.NoError(t, err, "failed to deploy and configure CoreDNS")
-
-	// 8) Set the encryption provider on the region so it's available for advanced installs
-	r.Region.SetEncryptionProvider(r.GetEncryptionProvider())
 }
 
 // TeardownInfra deletes all GCP resources created by SetUpInfra.

--- a/tests/e2e/operator/infra/gcp.go
+++ b/tests/e2e/operator/infra/gcp.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
 	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/encryption"
 )
 
 // ─── GCP CONSTANTS ───────────────────────────────────────────────────────────────
@@ -227,6 +228,9 @@ func (r *GcpRegion) SetUpInfra(t *testing.T) {
 	require.NoError(t, err)
 	err = r.deployAndConfigureCoreDNS(t, kubeConfigPath)
 	require.NoError(t, err, "failed to deploy and configure CoreDNS")
+
+	// 8) Set the encryption provider on the region so it's available for advanced installs
+	r.Region.SetEncryptionProvider(r.GetEncryptionProvider())
 }
 
 // TeardownInfra deletes all GCP resources created by SetUpInfra.
@@ -316,6 +320,43 @@ func (r *GcpRegion) ScaleNodePool(t *testing.T, location string, nodeCount, inde
 
 func (r *GcpRegion) CanScale() bool {
 	return false
+}
+
+// ─── Encryption At Rest Methods ─────────────────────────────────────────────────
+
+// GetEncryptionProvider returns the GCP provider itself as it implements encryption.Provider
+func (r *GcpRegion) GetEncryptionProvider() encryption.Provider {
+	return r
+}
+
+// SetupEncryptionInfrastructure is simplified for GCP (uses file-based encryption for now)
+// TODO: Implement full GCP Cloud KMS support similar to AWS
+// Returns a no-op cleanup function
+func (r *GcpRegion) SetupEncryptionInfrastructure(t *testing.T) (func(), error) {
+	t.Log("GCP provider: Using file-based encryption (UNKNOWN_KEY_TYPE)")
+	t.Log("TODO: Implement full GCP Cloud KMS support for production use")
+	// Return no-op cleanup function
+	return func() {
+		t.Log("GCP provider: No KMS infrastructure to clean up")
+	}, nil
+}
+
+// GetEncryptionPlatformConfig returns GCP-specific encryption platform configuration
+// Currently uses UNKNOWN_KEY_TYPE (file-based) - can be extended to GCP_CLOUD_KMS
+func (r *GcpRegion) GetEncryptionPlatformConfig() *encryption.EncryptionPlatformConfig {
+	// TODO: Switch to GCP_CLOUD_KMS and implement full KMS support
+	return &encryption.EncryptionPlatformConfig{
+		Platform:                     "UNKNOWN_KEY_TYPE",
+		RequiresCredentialsSecret:    false,
+		DefaultCredentialsSecretName: "",
+	}
+}
+
+// SetupEncryptionSecrets creates Kubernetes secrets for file-based encryption (UNKNOWN_KEY_TYPE)
+// TODO: Implement GCP Cloud KMS support (encrypt with GCP KMS, add KMS metadata to secret)
+func (r *GcpRegion) SetupEncryptionSecrets(t *testing.T, kubectlOptions *k8s.KubectlOptions, clusterRegion string) error {
+	// Use shared utility for file-based encryption (UNKNOWN_KEY_TYPE)
+	return encryption.SetupFileBasedEncryptionSecrets(t, kubectlOptions, "GCP")
 }
 
 // createGKEClusters handles the complex logic of creating GKE clusters in parallel.

--- a/tests/e2e/operator/infra/local.go
+++ b/tests/e2e/operator/infra/local.go
@@ -9,10 +9,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/helm-charts/tests/e2e/calico"
-	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
-	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
-	"github.com/cockroachdb/helm-charts/tests/testutil"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/shell"
@@ -23,6 +19,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/calico"
+	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/encryption"
+	"github.com/cockroachdb/helm-charts/tests/testutil"
 )
 
 // LocalRegion implements CloudProvider for local Kubernetes providers (K3d and Kind)
@@ -124,9 +126,6 @@ func (r *LocalRegion) SetUpInfra(t *testing.T) {
 			Namespace: r.Namespace[cluster],
 			Domain:    operator.CustomDomains[i],
 		}
-		if !r.IsMultiRegion {
-			break
-		}
 	}
 
 	// Update Coredns config.
@@ -143,38 +142,43 @@ func (r *LocalRegion) SetUpInfra(t *testing.T) {
 		// restart coredns pods.
 		err = k8s.RunKubectlE(t, kubectlOptions, "rollout", "restart", "deployment", coreDNSDeploymentName)
 		require.NoError(t, err)
-		if !r.IsMultiRegion {
-			r.Clients = clients
-			r.ReusingInfra = true
-			return
-		}
 	}
 	r.Clients = clients
 	r.ReusingInfra = true
 
-	netConfig := calico.K3dCalicoBGPPeeringOptions{
-		ClusterConfig: map[string]calico.K3dClusterBGPConfig{},
+	// Setup cross-cluster networking only for multi-region deployments
+	// Single-region deployments don't need BGP peering between clusters
+	if len(r.Clusters) > 1 {
+		netConfig := calico.K3dCalicoBGPPeeringOptions{
+			ClusterConfig: map[string]calico.K3dClusterBGPConfig{},
+		}
+
+		// Update network config for each region.
+		for i, region := range r.RegionCodes {
+			rawConfig.CurrentContext = r.Clusters[i]
+			kubectlOptions := k8s.NewKubectlOptions(r.Clusters[i], kubeConfig, coreDNSNamespace)
+			err := r.setupNetworking(t, context.TODO(), region, netConfig, kubectlOptions, i)
+			if err != nil {
+				t.Logf("[%s] Failed to setup networking for region %s: %v", r.ProviderType, region, err)
+			}
+		}
+
+		objectsByRegion := calico.K3dCalicoBGPPeeringObjects(netConfig)
+		// Apply all the objects for each region on to the cluster.
+		for i, region := range r.RegionCodes {
+			ctl := clients[r.Clusters[i]]
+			for _, obj := range objectsByRegion[region] {
+				err := ctl.Create(context.Background(), obj)
+				require.NoError(t, err)
+			}
+		}
+		t.Logf("[%s] Multi-region networking setup complete for %d clusters", r.ProviderType, len(r.Clusters))
+	} else {
+		t.Logf("[%s] Single-region setup - skipping cross-cluster networking", r.ProviderType)
 	}
 
-	// Update network config for each region.
-	for i, region := range r.RegionCodes {
-		rawConfig.CurrentContext = r.Clusters[i]
-		kubectlOptions := k8s.NewKubectlOptions(r.Clusters[i], kubeConfig, coreDNSNamespace)
-		err := r.setupNetworking(t, context.TODO(), region, netConfig, kubectlOptions, i)
-		if err != nil {
-			t.Logf("[%s] Failed to setup networking for region %s: %v", r.ProviderType, region, err)
-		}
-	}
-
-	objectsByRegion := calico.K3dCalicoBGPPeeringObjects(netConfig)
-	// Apply all the objects for each region on to the cluster.
-	for i, region := range r.RegionCodes {
-		ctl := clients[r.Clusters[i]]
-		for _, obj := range objectsByRegion[region] {
-			err := ctl.Create(context.Background(), obj)
-			require.NoError(t, err)
-		}
-	}
+	// Set the encryption provider on the region so it's available for advanced installs
+	r.Region.SetEncryptionProvider(r.GetEncryptionProvider())
 }
 
 // TeardownInfra cleans up all resources created by SetUpInfra
@@ -221,6 +225,38 @@ func (r *LocalRegion) ScaleNodePool(t *testing.T, location string, nodeCount, in
 
 func (r *LocalRegion) CanScale() bool {
 	return false
+}
+
+// ─── Encryption At Rest Methods ─────────────────────────────────────────────────
+
+// GetEncryptionProvider returns the local provider itself as it implements encryption.Provider
+func (r *LocalRegion) GetEncryptionProvider() encryption.Provider {
+	return r
+}
+
+// SetupEncryptionInfrastructure is a no-op for local providers (file-based encryption)
+// Returns a no-op cleanup function
+func (r *LocalRegion) SetupEncryptionInfrastructure(t *testing.T) (func(), error) {
+	t.Log("Local provider: No KMS infrastructure needed for file-based encryption (UNKNOWN_KEY_TYPE)")
+	// Return no-op cleanup function
+	return func() {
+		t.Log("Local provider: No KMS infrastructure to clean up")
+	}, nil
+}
+
+// GetEncryptionPlatformConfig returns file-based encryption platform configuration for local providers
+func (r *LocalRegion) GetEncryptionPlatformConfig() *encryption.EncryptionPlatformConfig {
+	return &encryption.EncryptionPlatformConfig{
+		Platform:                     "UNKNOWN_KEY_TYPE",
+		RequiresCredentialsSecret:    false,
+		DefaultCredentialsSecretName: "", // Not needed for file-based encryption
+	}
+}
+
+// SetupEncryptionSecrets creates Kubernetes secrets for file-based encryption (UNKNOWN_KEY_TYPE)
+func (r *LocalRegion) SetupEncryptionSecrets(t *testing.T, kubectlOptions *k8s.KubectlOptions, clusterRegion string) error {
+	// Use shared utility for file-based encryption (UNKNOWN_KEY_TYPE)
+	return encryption.SetupFileBasedEncryptionSecrets(t, kubectlOptions, r.ProviderType)
 }
 
 // setupNetworking ensures there is cross-cluster network connectivity and

--- a/tests/e2e/operator/infra/local.go
+++ b/tests/e2e/operator/infra/local.go
@@ -176,9 +176,6 @@ func (r *LocalRegion) SetUpInfra(t *testing.T) {
 	} else {
 		t.Logf("[%s] Single-region setup - skipping cross-cluster networking", r.ProviderType)
 	}
-
-	// Set the encryption provider on the region so it's available for advanced installs
-	r.Region.SetEncryptionProvider(r.GetEncryptionProvider())
 }
 
 // TeardownInfra cleans up all resources created by SetUpInfra

--- a/tests/e2e/operator/infra/provider.go
+++ b/tests/e2e/operator/infra/provider.go
@@ -31,21 +31,30 @@ type CloudProvider interface {
 }
 
 // ProviderFactory creates a CloudProvider instance for the given provider type.
+// It also automatically sets the encryption provider on the region so it's available for advanced installs.
 func ProviderFactory(providerType string, region *operator.Region) CloudProvider {
+	var cloudProvider CloudProvider
+
 	switch providerType {
 	case ProviderK3D:
 		provider := LocalRegion{Region: region, ProviderType: ProviderK3D}
 		provider.RegionCodes = GetRegionCodes(providerType)
-		return &provider
+		cloudProvider = &provider
 	case ProviderKind:
 		provider := LocalRegion{Region: region, ProviderType: ProviderKind}
 		provider.RegionCodes = GetRegionCodes(providerType)
-		return &provider
+		cloudProvider = &provider
 	case ProviderGCP:
 		provider := GcpRegion{Region: region}
 		provider.RegionCodes = GetRegionCodes(providerType)
-		return &provider
+		cloudProvider = &provider
 	default:
 		return nil
 	}
+
+	// Automatically set the encryption provider on the region
+	// This makes it available for encryption-enabled advanced installs
+	region.SetEncryptionProvider(cloudProvider.GetEncryptionProvider())
+
+	return cloudProvider
 }

--- a/tests/e2e/operator/infra/provider.go
+++ b/tests/e2e/operator/infra/provider.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/encryption"
 )
 
 // CloudProvider defines the interface that all cloud providers must implement
@@ -22,6 +23,11 @@ type CloudProvider interface {
 
 	// CanScale checks if the provider supports scaling.
 	CanScale() bool
+
+	// GetEncryptionProvider returns an encryption.Provider implementation for this cloud provider.
+	// The provider can return itself since CloudProvider implementations also implement encryption.Provider.
+	// All encryption-related operations are accessed through the returned encryption.Provider interface.
+	GetEncryptionProvider() encryption.Provider
 }
 
 // ProviderFactory creates a CloudProvider instance for the given provider type.

--- a/tests/e2e/operator/region.go
+++ b/tests/e2e/operator/region.go
@@ -1,7 +1,6 @@
 package operator
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -10,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
-	"github.com/cockroachdb/helm-charts/tests/testutil"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
@@ -23,6 +20,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/encryption"
+	"github.com/cockroachdb/helm-charts/tests/testutil"
 )
 
 const (
@@ -83,6 +84,27 @@ type Region struct {
 	VirtualClusterModePrimary bool
 	VirtualClusterModeStandby bool
 	IsOperatorInstalled       bool
+
+	// Encryption infrastructure tracking
+	encryptionProvider       encryption.Provider
+	encryptionInfraSetup     bool
+	encryptionCleanupFunc    func()
+	encryptionPlatformConfig *encryption.EncryptionPlatformConfig
+	encryptionCredSecretName string
+}
+
+// SetEncryptionProvider sets the encryption provider for this region.
+// This should be called by the infrastructure setup code with the provider's GetEncryptionProvider() result.
+func (r *Region) SetEncryptionProvider(provider encryption.Provider) {
+	r.encryptionProvider = provider
+}
+
+// CleanupEncryptionInfra calls the stored encryption cleanup function
+// Call this in test cleanup/defer to clean up KMS resources
+func (r *Region) CleanupEncryptionInfra() {
+	if r.encryptionCleanupFunc != nil {
+		r.encryptionCleanupFunc()
+	}
 }
 
 // InstallCharts Installs both Operator and CockroachDB charts by providing custom CA secret
@@ -795,9 +817,8 @@ type AdvancedInstallConfig struct {
 	WALFailoverSize    string
 
 	// Encryption at Rest configuration
-	EncryptionEnabled      bool
-	EncryptionKeySecret    string
-	EncryptionKeySecretName string // defaults to "cmek-key-secret" if empty
+	// Note: The encryption provider is automatically obtained from the CloudProvider via Region.SetEncryptionProvider()
+	EncryptionEnabled bool
 
 	// Virtual Cluster configuration (for PCR)
 	VirtualClusterMode string // "primary", "standby", or ""
@@ -836,27 +857,29 @@ func (r *Region) InstallChartsWithAdvancedConfig(t *testing.T, cluster string, i
 		"--from-file=ca.key")
 	require.NoError(t, err)
 
-	// Create encryption key secret if encryption is enabled
-	if config.EncryptionEnabled && config.EncryptionKeySecret != "" {
-		encryptionSecretName := config.EncryptionKeySecretName
-		if encryptionSecretName == "" {
-			encryptionSecretName = "cmek-key-secret"
+	// Setup encryption if enabled and provider is available
+	if config.EncryptionEnabled && r.encryptionProvider != nil {
+		// Setup encryption infrastructure once (creates KMS keys, IAM roles, etc.)
+		// This is called once and the cleanup function is stored for later cleanup
+		if !r.encryptionInfraSetup {
+			t.Log("Setting up encryption infrastructure (KMS keys, IAM roles, etc.)")
+			cleanup, err := r.encryptionProvider.SetupEncryptionInfrastructure(t)
+			require.NoError(t, err, "Failed to setup encryption infrastructure")
+			r.encryptionCleanupFunc = cleanup
+			r.encryptionInfraSetup = true
+			t.Log("Encryption infrastructure setup complete")
 		}
 
-		// Use --from-literal with the base64-encoded key string. Kubernetes base64-encodes
-		// secret values for storage, so the pod receives the original base64 string when
-		// the secret is mounted — which the init container then decodes to get the raw key.
-		err = k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", encryptionSecretName,
-			fmt.Sprintf("--from-literal=StoreKeyData=%s", config.EncryptionKeySecret))
-		require.NoError(t, err)
+		// Get platform configuration from provider
+		r.encryptionPlatformConfig = r.encryptionProvider.GetEncryptionPlatformConfig()
+		t.Logf("Using encryption platform: %s (requires credentials: %v)",
+			r.encryptionPlatformConfig.Platform, r.encryptionPlatformConfig.RequiresCredentialsSecret)
 
-		// Verify secret was created with data
-		secretSize, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
-			"get", "secret", encryptionSecretName,
-			"-o", "jsonpath={.data.StoreKeyData}")
-		require.NoError(t, err)
-		require.True(t, len(secretSize) > 0, "Secret StoreKeyData should be >0")
-		t.Logf("Created encryption secret %s with size: %d bytes", encryptionSecretName, len(secretSize))
+		// Create all encryption secrets (key secret + credentials secret if needed)
+		// The provider handles all details: key generation, encryption, secret names, etc.
+		err = r.encryptionProvider.SetupEncryptionSecrets(t, kubectlOptions, cluster)
+		require.NoError(t, err, "Failed to setup encryption secrets")
+		t.Logf("Successfully set up encryption secrets for cluster %s", cluster)
 	}
 
 	// Install the operator when it is not skipped and not already marked as installed.
@@ -983,29 +1006,10 @@ func (r *Region) ValidateWALFailover(t *testing.T, cluster string, cfg *Advanced
 }
 
 // GenerateEncryptionKey generates a 256-bit AES encryption key and returns base64 encoded value
+// This is a convenience wrapper around encryption.GenerateAndEncodeEncryptionKey for backward compatibility
 func (r *Region) GenerateEncryptionKey(t *testing.T) string {
-	tempDir := t.TempDir()
-	keyPath := filepath.Join(tempDir, "store.key")
-
-	// Generate 256-bit AES key using cockroach gen encryption-key
-	cmd := shell.Command{
-		Command:    "cockroach",
-		Args:       []string{"gen", "encryption-key", "--size", "256", "store.key"},
-		WorkingDir: tempDir,
-	}
-
-	_, err := shell.RunCommandAndGetOutputE(t, cmd)
-	require.NoError(t, err)
-
-	// Read the generated key file
-	keyBytes, err := os.ReadFile(keyPath)
-	require.NoError(t, err)
-
-	// Base64 encode the key (removing any newlines)
-	storeKeyB64 := base64.StdEncoding.EncodeToString(keyBytes)
-	storeKeyB64 = strings.ReplaceAll(storeKeyB64, "\n", "")
-
-	return storeKeyB64
+	_, base64Key := encryption.GenerateAndEncodeEncryptionKey(t)
+	return base64Key
 }
 
 // ValidateEncryptionAtRest verifies that encryption at rest is properly configured by checking flags and encryption status.


### PR DESCRIPTION
This commit adds encryption-at-rest methods to the CloudProvider interface and provides implementations for GCP and Local providers using file-based encryption (UNKNOWN_KEY_TYPE).

## Interface Changes

- **CloudProvider Interface** (tests/e2e/operator/infra/provider.go):
  - SetupEncryptionInfrastructure: Create KMS resources (keys, roles, policies)
  - GetEncryptionPlatformConfig: Get provider-specific encryption config
  - EncryptStoreKey: Encrypt plaintext store key using provider's KMS
  - CreateEncryptionKeySecret: Create K8s secret with encrypted key
  - CreateEncryptionCredentialsSecret: Create K8s secret with KMS credentials

## Provider Implementations

- **GCP Provider** (tests/e2e/operator/infra/gcp.go):
  - Implements all encryption methods with file-based encryption
  - Returns UNKNOWN_KEY_TYPE platform (no actual KMS encryption)
  - Includes TODOs for future GCP Cloud KMS support

- **Local Provider** (tests/e2e/operator/infra/local.go):
  - Implements all encryption methods with file-based encryption
  - Returns UNKNOWN_KEY_TYPE platform (base64 encoding only)
  - Used for K3D and Kind local testing environments

Note: AWS provider implementation is in a separate commit/branch.