### PR TITLE
[CC-35895] e2e/operator: add encryption provider interface and GCP advanced test infrastructure

### DIFF
--- a/.github/actions/slack-test-notification/action.yaml
+++ b/.github/actions/slack-test-notification/action.yaml
@@ -1,0 +1,99 @@
+name: Slack Test Notification
+description: Parse test results and send a Slack notification with pass/fail summary
+
+inputs:
+  test-name:
+    description: Label for the status message (e.g., "Multi-region e2e")
+    required: true
+  provider:
+    description: Provider name from matrix (shown as a field when non-empty)
+    required: false
+    default: ""
+  slack-webhook-url:
+    description: Slack webhook URL
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Send Slack notification
+      shell: bash
+      run: |
+        if [ ! -f test_output.json ]; then
+          grep -E "=== RUN|--- PASS:|--- FAIL:" test_output.log | awk '
+            /=== RUN/ {
+              test_name = $3
+              tests[test_name] = "running"
+            }
+            /--- PASS:/ {
+              test_name = $3
+              if (test_name in tests) {
+                print "{\"Action\":\"pass\",\"Test\":\"" test_name "\"}"
+              }
+            }
+            /--- FAIL:/ {
+              test_name = $3
+              if (test_name in tests) {
+                print "{\"Action\":\"fail\",\"Test\":\"" test_name "\"}"
+              }
+            }' > test_output.json
+        fi
+
+        PASSED_TESTS=$(jq -r 'select(.Action=="pass") | .Test' test_output.json | sed 's|.*/||' | grep '^Test' | grep -v '^TestOperatorIn' | sort | uniq | head -n 20 | paste -sd ", " -)
+        FAILED_TESTS=$(jq -r 'select(.Action=="fail") | .Test' test_output.json | sed 's|.*/||' | grep '^Test' | grep -v '^TestOperatorIn' | sort | uniq | head -n 20 | paste -sd ", " -)
+        PASSED_COUNT=$(jq -r 'select(.Action=="pass") | .Test' test_output.json | sed 's|.*/||' | grep '^Test' | grep -v '^TestOperatorIn' | sort | uniq | wc -l)
+        FAILED_COUNT=$(jq -r 'select(.Action=="fail") | .Test' test_output.json | sed 's|.*/||' | grep '^Test' | grep -v '^TestOperatorIn' | sort | uniq | wc -l)
+
+        TEST_NAME="${{ inputs.test-name }}"
+        if [ "$FAILED_COUNT" -gt 0 ]; then
+          STATUS="❌ *${TEST_NAME} tests failed!*"
+          COLOR="#ff0000"
+        else
+          STATUS="✅ *${TEST_NAME} tests passed!*"
+          COLOR="#36a64f"
+        fi
+
+        # Build fields array with optional provider
+        PROVIDER_FIELD=""
+        if [ -n "${{ inputs.provider }}" ]; then
+          PROVIDER_FIELD='{"title": "Provider", "value": "${{ inputs.provider }}", "short": true},'
+        fi
+
+        PAYLOAD=$(jq -n \
+          --arg text "$STATUS" \
+          --arg color "$COLOR" \
+          --arg repo "${{ github.repository }}" \
+          --arg branch "${{ github.ref_name }}" \
+          --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+          --arg passed "$PASSED_COUNT" \
+          --arg failed "$FAILED_COUNT" \
+          --arg passed_tests "$PASSED_TESTS" \
+          --arg failed_tests "$FAILED_TESTS" \
+          --argjson provider_field "${PROVIDER_FIELD:-null}" \
+          '{
+            text: $text,
+            attachments: [
+              {
+                color: $color,
+                fields: [
+                  {"title": "Repository", "value": $repo, "short": true},
+                  {"title": "Branch", "value": $branch, "short": true},
+                  {"title": "✅ Passed", "value": $passed, "short": true},
+                  {"title": "❌ Failed", "value": $failed, "short": true},
+                  {"title": "❌ Failed Tests", "value": (if $failed_tests == "" then "None" else $failed_tests end), "short": false},
+                  {"title": "✅ Passed Tests", "value": (if $passed_tests == "" then "None" else $passed_tests end), "short": false},
+                  {"title": "Run URL", "value": $url, "short": false}
+                ]
+              }
+            ]
+          }')
+
+        # Inject provider field if present
+        if [ -n "${{ inputs.provider }}" ]; then
+          PAYLOAD=$(echo "$PAYLOAD" | jq --arg provider "${{ inputs.provider }}" \
+            '.attachments[0].fields |= [.[0], .[1], {"title": "Provider", "value": $provider, "short": true}] + .[2:]')
+        fi
+
+        curl -X POST -H 'Content-type: application/json' \
+          --data "$PAYLOAD" \
+          "${{ inputs.slack-webhook-url }}"

--- a/.github/workflows/advanced-features-tests.yaml
+++ b/.github/workflows/advanced-features-tests.yaml
@@ -1,70 +1,19 @@
-name: integration-tests
+name: advanced-features-tests
 
 on:
   schedule:
-    - cron: "15 6 * * 1"  # Run at 6:15 AM on every Monday UTC to avoid peak times
+    - cron: "15 8 * * 2"  # Run at 8:15 AM on every Tuesday UTC to avoid peak times
   # Allow manual trigger on any branch
   workflow_dispatch:
 
 jobs:
-  integration-tests-multi-region:
+  advanced-features-single-region:
     runs-on: ubuntu-latest-4-core
     strategy:
       fail-fast: false
       matrix:
-        provider: [kind, gcp]
-    timeout-minutes: 90
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    env:
-      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.26
-      - name: Authenticate to Google Cloud
-        uses: 'google-github-actions/auth@v2'
-        id: auth
-        with:
-          token_format: access_token
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v2
-      - name: Install gke-gcloud-auth-plugin
-        run: |
-          gcloud components install gke-gcloud-auth-plugin
-      - name: Run tests (multi-region)
-        env:
-          PROVIDER: ${{ matrix.provider }}
-          USE_GKE_GCLOUD_AUTH_PLUGIN: True
-        run: |
-          set -euo pipefail
-          make test/e2e/multi-region | tee test_output.log
-      - name: Archive test results
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: multi-region-test-results-${{ matrix.provider }}
-          path: |
-            test_output.log
-            test_output.json
-      - name: Slack notification (multi-region)
-        if: ${{ always() && github.ref_name == 'master' }}
-        uses: ./.github/actions/slack-test-notification
-        with:
-          test-name: "Multi-region e2e"
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-  integration-tests-single-region:
-    runs-on: ubuntu-latest-4-core
-    strategy:
-      fail-fast: false
-      matrix:
-        provider: [kind, gcp]
-    timeout-minutes: 90
+        provider: [k3d, kind, gcp]
+    timeout-minutes: 120
     permissions:
       contents: read
       id-token: write
@@ -89,24 +38,81 @@ jobs:
       - name: Install gke-gcloud-auth-plugin
         run: |
           gcloud components install gke-gcloud-auth-plugin
-      - name: Run tests (single-region)
+      - name: Run tests (advanced features - single region)
         env:
           PROVIDER: ${{ matrix.provider }}
+          TEST_ADVANCED_FEATURES: true
           USE_GKE_GCLOUD_AUTH_PLUGIN: True
         run: |
           set -euo pipefail
-          make test/e2e/single-region | tee test_output.log
+          make test/nightly-e2e/advanced/single-region | tee test_output.log
       - name: Archive test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: single-region-test-results-${{ matrix.provider }}
+          name: advanced-single-region-results-${{ matrix.provider }}
           path: |
             test_output.log
             test_output.json
-      - name: Slack notification (single-region)
+      - name: Slack notification
         if: ${{ always() && github.ref_name == 'master' }}
         uses: ./.github/actions/slack-test-notification
         with:
-          test-name: "Single-region e2e"
+          test-name: "Advanced features single-region"
+          provider: ${{ matrix.provider }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  advanced-features-multi-region:
+    runs-on: ubuntu-latest-4-core
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: [k3d, kind, gcp]
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.26
+      - name: Authenticate to Google Cloud
+        uses: 'google-github-actions/auth@v2'
+        id: auth
+        with:
+          token_format: access_token
+          project_id: 'cockroach-helm-testing'
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Install gke-gcloud-auth-plugin
+        run: |
+          gcloud components install gke-gcloud-auth-plugin
+      - name: Run tests (advanced features - multi region)
+        env:
+          PROVIDER: ${{ matrix.provider }}
+          TEST_ADVANCED_FEATURES: true
+          USE_GKE_GCLOUD_AUTH_PLUGIN: True
+        run: |
+          set -euo pipefail
+          make test/nightly-e2e/advanced/multi-region | tee test_output.log
+      - name: Archive test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: advanced-multi-region-results-${{ matrix.provider }}
+          path: |
+            test_output.log
+            test_output.json
+      - name: Slack notification
+        if: ${{ always() && github.ref_name == 'master' }}
+        uses: ./.github/actions/slack-test-notification
+        with:
+          test-name: "Advanced features multi-region"
+          provider: ${{ matrix.provider }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/tests/e2e/migrate/helm_chart_to_cockroachdb_operator_test.go
+++ b/tests/e2e/migrate/helm_chart_to_cockroachdb_operator_test.go
@@ -178,18 +178,8 @@ func initMigrationClient() error {
 }
 
 // providerCloudRegion returns the cloud region for the active provider.
-func providerCloudRegion() string {
-	p := strings.TrimSpace(strings.ToLower(os.Getenv("PROVIDER")))
-	switch p {
-	case "k3d", "": // default to k3d when PROVIDER is unset
-		return infra.RegionCodes[infra.ProviderK3D][0]
-	case "kind":
-		return infra.RegionCodes[infra.ProviderKind][0]
-	case "gcp":
-		return infra.RegionCodes[infra.ProviderGCP][0]
-	default:
-		return ""
-	}
+func providerCloudRegion(t *testing.T) string {
+	return infra.RegionCodes[infra.ResolveProvider(t)][0]
 }
 
 func TestHelmChartToOperatorMigration(t *testing.T) {
@@ -253,7 +243,7 @@ func (h *HelmChartToOperator) TestDefaultMigration(t *testing.T) {
 		k8s.RunKubectl(t, kubectlOptions, "delete", "priorityclass", "crdb-critical")
 	}()
 
-	operator.InstallCockroachDBOperatorScopedForMigration(t, kubectlOptions, h.Namespace, providerCloudRegion())
+	operator.InstallCockroachDBOperatorScopedForMigration(t, kubectlOptions, h.Namespace, providerCloudRegion(t))
 	defer func() {
 		t.Log("helm uninstall the crdbcluster CR from the helm chart")
 		h.Uninstall(t)
@@ -371,7 +361,7 @@ func (h *HelmChartToOperator) TestCertManagerMigration(t *testing.T) {
 		k8s.RunKubectl(t, kubectlOptions, "delete", "priorityclass", "crdb-critical")
 	}()
 
-	operator.InstallCockroachDBOperatorScopedForMigration(t, kubectlOptions, h.Namespace, providerCloudRegion())
+	operator.InstallCockroachDBOperatorScopedForMigration(t, kubectlOptions, h.Namespace, providerCloudRegion(t))
 	defer func() {
 		t.Log("helm uninstall the crdbcluster CR from the helm chart")
 		h.Uninstall(t)
@@ -484,7 +474,7 @@ func (h *HelmChartToOperator) TestDedicatedLogsPVCMigration(t *testing.T) {
 		k8s.RunKubectl(t, kubectlOptions, "delete", "priorityclass", "crdb-critical")
 	}()
 
-	operator.InstallCockroachDBOperatorScopedForMigration(t, kubectlOptions, h.Namespace, providerCloudRegion())
+	operator.InstallCockroachDBOperatorScopedForMigration(t, kubectlOptions, h.Namespace, providerCloudRegion(t))
 	defer func() {
 		t.Log("helm uninstall the crdbcluster CR from the helm chart")
 		h.Uninstall(t)
@@ -582,7 +572,7 @@ func (h *HelmChartToOperator) TestPCRPrimaryMigration(t *testing.T) {
 		k8s.RunKubectl(t, kubectlOptions, "delete", "priorityclass", "crdb-critical")
 	}()
 
-	operator.InstallCockroachDBOperatorScopedForMigration(t, kubectlOptions, h.Namespace, providerCloudRegion())
+	operator.InstallCockroachDBOperatorScopedForMigration(t, kubectlOptions, h.Namespace, providerCloudRegion(t))
 	defer func() {
 		t.Log("helm uninstall the crdbcluster CR from the helm chart")
 		h.Uninstall(t)

--- a/tests/e2e/migrate/public_operator_to_cockroachdb_operator_test.go
+++ b/tests/e2e/migrate/public_operator_to_cockroachdb_operator_test.go
@@ -157,7 +157,7 @@ func (o *PublicOperatorToCockroachDbOperator) TestDefaultMigration(t *testing.T)
 	k8s.KubectlApply(t, kubectlOptions, filepath.Join(manifestsDirPath, "rbac.yaml"))
 
 	t.Log("Install the CockroachDB operator")
-	operator.InstallCockroachDBOperatorScopedForMigration(t, kubectlOptions, o.Namespace, providerCloudRegion())
+	operator.InstallCockroachDBOperatorScopedForMigration(t, kubectlOptions, o.Namespace, providerCloudRegion(t))
 	defer func() {
 		t.Log("helm uninstall the crdb cluster")
 		o.Uninstall(t)

--- a/tests/e2e/operator/encryption/types.go
+++ b/tests/e2e/operator/encryption/types.go
@@ -1,0 +1,160 @@
+package encryption
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/stretchr/testify/require"
+)
+
+type PlatformConfig struct {
+	// Platform is the KMS platform type: "AWS_KMS", "GCP_CLOUD_KMS", or "UNKNOWN_KEY_TYPE"
+	Platform string
+
+	// RequiresCredentialsSecret indicates if cmekCredentialsSecretName is required
+	// True for AWS_KMS and GCP_KMS, false for UNKNOWN_KEY_TYPE (file-based)
+	RequiresCredentialsSecret bool
+
+	// DefaultCredentialsSecretName is the default name for the credentials secret
+	// Used when RequiresCredentialsSecret is true
+	DefaultCredentialsSecretName string
+}
+
+// Provider defines the encryption-related methods that cloud providers must implement
+// for encryption-at-rest testing. Providers return configuration, not implementation.
+type Provider interface {
+	// SetupEncryptionInfrastructure creates cloud KMS resources (keys, roles, policies)
+	// Returns a cleanup function that should be deferred to ensure proper resource cleanup
+	// Called once during test setup, before any encryption secrets are created
+	SetupEncryptionInfrastructure(t *testing.T) (cleanup func(), err error)
+
+	// GetEncryptionPlatformConfig returns provider-specific encryption platform configuration
+	GetEncryptionPlatformConfig() *PlatformConfig
+
+	// ─── CMEK Encryption Methods ─────────────────────────────────────────────────
+	// The following methods are only called for cloud KMS providers (AWS_KMS, GCP_CLOUD_KMS).
+	// File-based providers (UNKNOWN_KEY_TYPE) should return errors indicating lack of support.
+
+	// EncryptKey encrypts a plaintext key using the provider's KMS
+	// Takes raw key bytes, returns base64-encoded encrypted data
+	EncryptKey(plaintextKey []byte, clusterRegion string) (encryptedKeyBase64 string, err error)
+
+	// CreateKeySecret creates the Kubernetes secret with encrypted key data and provider metadata
+	// (AuthPrincipal, URI, Region, Type, ExternalID, etc.)
+	CreateKeySecret(kubectlOptions *k8s.KubectlOptions, secretName string, encryptedKeyData string, clusterRegion string) error
+
+	// CreateCredentialsSecret creates the Kubernetes secret with cloud credentials
+	// Returns the secret name and any error
+	CreateCredentialsSecret(kubectlOptions *k8s.KubectlOptions) (string, error)
+}
+
+// GenerateAndEncodeEncryptionKey generates a 256-bit AES encryption key and returns both
+// the raw bytes and base64-encoded string. This is a utility function for providers using
+// UNKNOWN_KEY_TYPE (file-based encryption) to generate and encode keys consistently.
+func GenerateAndEncodeEncryptionKey(t *testing.T) (rawKey []byte, base64Key string) {
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "store.key")
+
+	cmd := shell.Command{
+		Command:    "cockroach",
+		Args:       []string{"gen", "encryption-key", "--size", "256", "store.key"},
+		WorkingDir: tempDir,
+	}
+
+	_, err := shell.RunCommandAndGetOutputE(t, cmd)
+	require.NoError(t, err, "Failed to generate encryption key")
+
+	keyBytes, err := os.ReadFile(keyPath)
+	require.NoError(t, err, "Failed to read encryption key file")
+
+	base64Encoded := base64.StdEncoding.EncodeToString(keyBytes)
+	base64Encoded = strings.ReplaceAll(base64Encoded, "\n", "")
+
+	return keyBytes, base64Encoded
+}
+
+// SetupEncryptionSecretsWithName dispatches to the appropriate setup path based on platform type.
+// CMEK providers (GCP_CLOUD_KMS, AWS_KMS) go through KMS encryption; file-based (UNKNOWN_KEY_TYPE)
+// writes raw key bytes directly.
+func SetupEncryptionSecretsWithName(t *testing.T, provider Provider, kubectlOptions *k8s.KubectlOptions, clusterRegion string, secretName string) error {
+	platformConfig := provider.GetEncryptionPlatformConfig()
+
+	if platformConfig.Platform == "UNKNOWN_KEY_TYPE" {
+		return setupFileBasedEncryptionSecretsWithName(t, kubectlOptions, platformConfig.Platform, secretName)
+	}
+
+	return setupCMEKEncryptionSecretsWithName(t, provider, kubectlOptions, clusterRegion, secretName)
+}
+
+func setupCMEKEncryptionSecretsWithName(
+	t *testing.T,
+	provider Provider,
+	kubectlOptions *k8s.KubectlOptions,
+	clusterRegion string,
+	secretName string,
+) error {
+	platformConfig := provider.GetEncryptionPlatformConfig()
+	t.Logf("Setting up KMS envelope encryption for cluster %s (platform: %s, secret: %s)", clusterRegion, platformConfig.Platform, secretName)
+
+	plaintextKey, _ := GenerateAndEncodeEncryptionKey(t)
+
+	encryptedKey, err := provider.EncryptKey(plaintextKey, clusterRegion)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt store key with KMS: %w", err)
+	}
+
+	if err := provider.CreateKeySecret(kubectlOptions, secretName, encryptedKey, clusterRegion); err != nil {
+		return fmt.Errorf("failed to create encryption key secret %s: %w", secretName, err)
+	}
+
+	credentialsSecretName, err := provider.CreateCredentialsSecret(kubectlOptions)
+	if err != nil {
+		if !strings.Contains(err.Error(), "AlreadyExists") && !strings.Contains(err.Error(), "already exists") {
+			return fmt.Errorf("failed to create credentials secret: %w", err)
+		}
+		t.Logf("Credentials secret already exists, reusing existing secret for KMS authentication")
+	} else {
+		t.Logf("Created credentials secret %s for KMS authentication", credentialsSecretName)
+	}
+
+	return nil
+}
+
+func setupFileBasedEncryptionSecretsWithName(t *testing.T, kubectlOptions *k8s.KubectlOptions, providerName string, secretName string) error {
+	t.Logf("%s provider: Setting up file-based encryption secrets (secret: %s)", providerName, secretName)
+
+	rawKey, _ := GenerateAndEncodeEncryptionKey(t)
+	t.Logf("Generated encryption key (%d bytes)", len(rawKey))
+
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "StoreKeyData")
+	if err := os.WriteFile(keyPath, rawKey, 0600); err != nil {
+		return fmt.Errorf("failed to write key to temp file: %w", err)
+	}
+
+	err := k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", secretName,
+		fmt.Sprintf("--from-file=StoreKeyData=%s", keyPath))
+	if err != nil {
+		return fmt.Errorf("failed to create encryption key secret: %w", err)
+	}
+
+	secretSize, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "secret", secretName,
+		"-o", "jsonpath={.data.StoreKeyData}")
+	if err != nil {
+		return fmt.Errorf("failed to verify encryption secret: %w", err)
+	}
+	if len(secretSize) == 0 {
+		return fmt.Errorf("encryption secret StoreKeyData is empty")
+	}
+
+	t.Logf("Created encryption secret %s with key data (%d bytes)", secretName, len(secretSize))
+
+	return nil
+}

--- a/tests/e2e/operator/infra/gcp.go
+++ b/tests/e2e/operator/infra/gcp.go
@@ -2,6 +2,7 @@ package infra
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
+	cloudkms "google.golang.org/api/cloudkms/v1"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/container/v1"
 	"google.golang.org/api/googleapi"
@@ -24,6 +26,7 @@ import (
 
 	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
 	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/encryption"
 )
 
 // ─── GCP CONSTANTS ───────────────────────────────────────────────────────────────
@@ -44,11 +47,14 @@ const (
 // Default project ID to use if not specified in the environment.
 const defaultProjectID = "helm-testing"
 
-// getNodeServiceAccount returns the GKE node service account from the environment.
-// If empty, gcloud falls back to the project's default Compute Engine service account.
 func getNodeServiceAccount() string {
 	return os.Getenv("GCP_NODE_SERVICE_ACCOUNT")
 }
+
+const (
+	gcpKMSKeyRingID   = "cockroachdb-cmek-test"
+	gcpKMSCryptoKeyID = "cockroachdb-cmek-key"
+)
 
 // getProjectID returns the GCP project ID from the environment variable or falls back to default.
 func getProjectID() string {
@@ -131,7 +137,8 @@ var clusterConfigurations = []ClusterSetupConfig{
 // GcpRegion wraps operator.Region and manages GCP infra.
 type GcpRegion struct {
 	*operator.Region
-	vpcName string
+	vpcName   string
+	kmsKeyURI string
 }
 
 // SetUpInfra creates VPC, subnet, static IP, firewall rules, GKE clusters, and deploys CoreDNS
@@ -233,6 +240,160 @@ func (r *GcpRegion) SetUpInfra(t *testing.T) {
 	require.NoError(t, err)
 	err = r.deployAndConfigureCoreDNS(t, kubeConfigPath)
 	require.NoError(t, err, "failed to deploy and configure CoreDNS")
+}
+
+func (r *GcpRegion) GetEncryptionProvider() encryption.Provider {
+	return r
+}
+
+func (r *GcpRegion) SetupEncryptionInfrastructure(t *testing.T) (func(), error) {
+	ctx := context.Background()
+	svc, err := cloudkms.NewService(ctx, gcpKMSCredentialOptions()...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCP KMS client: %w", err)
+	}
+
+	project := getProjectID()
+	location := gcpKMSLocation()
+	parent := fmt.Sprintf("projects/%s/locations/%s", project, location)
+
+	t.Logf("GCP provider: ensuring KMS key ring %s/%s", parent, gcpKMSKeyRingID)
+	_, err = svc.Projects.Locations.KeyRings.Create(parent, &cloudkms.KeyRing{}).
+		KeyRingId(gcpKMSKeyRingID).Context(ctx).Do()
+	if err != nil && !IsResourceConflict(err) {
+		return nil, fmt.Errorf("failed to create GCP KMS key ring: %w", err)
+	}
+
+	keyRingName := fmt.Sprintf("%s/keyRings/%s", parent, gcpKMSKeyRingID)
+
+	t.Logf("GCP provider: ensuring KMS crypto key %s/%s", keyRingName, gcpKMSCryptoKeyID)
+	_, err = svc.Projects.Locations.KeyRings.CryptoKeys.Create(keyRingName, &cloudkms.CryptoKey{
+		Purpose: "ENCRYPT_DECRYPT",
+		VersionTemplate: &cloudkms.CryptoKeyVersionTemplate{
+			Algorithm: "GOOGLE_SYMMETRIC_ENCRYPTION",
+		},
+	}).CryptoKeyId(gcpKMSCryptoKeyID).Context(ctx).Do()
+	if err != nil && !IsResourceConflict(err) {
+		return nil, fmt.Errorf("failed to create GCP KMS crypto key: %w", err)
+	}
+
+	r.kmsKeyURI = fmt.Sprintf("%s/cryptoKeys/%s", keyRingName, gcpKMSCryptoKeyID)
+	t.Logf("GCP provider: KMS crypto key ready at %s", r.kmsKeyURI)
+
+	return func() {
+		t.Logf("GCP provider: KMS key %s retained (GCP keys cannot be deleted)", r.kmsKeyURI)
+	}, nil
+}
+
+func (r *GcpRegion) GetEncryptionPlatformConfig() *encryption.PlatformConfig {
+	return &encryption.PlatformConfig{
+		Platform:                     "GCP_CLOUD_KMS",
+		RequiresCredentialsSecret:    true,
+		DefaultCredentialsSecretName: "cmek-gcp-credentials",
+	}
+}
+
+func (r *GcpRegion) EncryptKey(plaintextKey []byte, clusterRegion string) (string, error) {
+	if r.kmsKeyURI == "" {
+		return "", fmt.Errorf("GCP KMS key URI not set: call SetupEncryptionInfrastructure first")
+	}
+
+	ctx := context.Background()
+	svc, err := cloudkms.NewService(ctx, gcpKMSCredentialOptions()...)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GCP KMS client: %w", err)
+	}
+
+	req := &cloudkms.EncryptRequest{
+		Plaintext: base64.StdEncoding.EncodeToString(plaintextKey),
+	}
+	resp, err := svc.Projects.Locations.KeyRings.CryptoKeys.Encrypt(r.kmsKeyURI, req).Context(ctx).Do()
+	if err != nil {
+		return "", fmt.Errorf("GCP KMS encrypt (%s): %w", r.kmsKeyURI, err)
+	}
+	return resp.Ciphertext, nil
+}
+
+func (r *GcpRegion) CreateKeySecret(kubectlOptions *k8s.KubectlOptions, secretName string, encryptedKeyData string, clusterRegion string) error {
+	if r.kmsKeyURI == "" {
+		return fmt.Errorf("GCP KMS key URI not set: call SetupEncryptionInfrastructure first")
+	}
+	authPrincipal := os.Getenv("GCP_KMS_AUTH_PRINCIPAL")
+	if authPrincipal == "" {
+		return fmt.Errorf("GCP_KMS_AUTH_PRINCIPAL environment variable not set")
+	}
+	kmsRegion := gcpKMSLocation()
+
+	return gcpRunKubectl(kubectlOptions,
+		"create", "secret", "generic", secretName,
+		fmt.Sprintf("--from-literal=StoreKeyData=%s", encryptedKeyData),
+		fmt.Sprintf("--from-literal=URI=%s", r.kmsKeyURI),
+		fmt.Sprintf("--from-literal=AuthPrincipal=%s", authPrincipal),
+		fmt.Sprintf("--from-literal=Region=%s", kmsRegion),
+		"--from-literal=Type=GCP_CLOUD_KMS",
+	)
+}
+
+func (r *GcpRegion) CreateCredentialsSecret(kubectlOptions *k8s.KubectlOptions) (string, error) {
+	const credSecretName = "cmek-gcp-credentials"
+
+	saKeyPath := os.Getenv("GCP_KMS_SA_KEY_PATH")
+	if saKeyPath == "" {
+		saKeyPath = getServiceAccountKeyPath()
+	}
+	if saKeyPath == "" {
+		return "", fmt.Errorf("neither GCP_KMS_SA_KEY_PATH nor GOOGLE_APPLICATION_CREDENTIALS is set")
+	}
+
+	saKeyBytes, err := os.ReadFile(saKeyPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read GCP SA key file %s: %w", saKeyPath, err)
+	}
+
+	if err := gcpRunKubectl(kubectlOptions,
+		"create", "secret", "generic", credSecretName,
+		fmt.Sprintf("--from-literal=gcp_service_account_key=%s", base64.StdEncoding.EncodeToString(saKeyBytes)),
+	); err != nil {
+		return "", fmt.Errorf("failed to create GCP credentials secret: %w", err)
+	}
+	return credSecretName, nil
+}
+
+func gcpKMSLocation() string {
+	if loc := os.Getenv("GCP_KMS_REGION"); loc != "" {
+		return loc
+	}
+	return "us-central1"
+}
+
+func gcpKMSCredentialOptions() []option.ClientOption {
+	if path := os.Getenv("GCP_KMS_SA_KEY_PATH"); path != "" {
+		return []option.ClientOption{option.WithCredentialsFile(path)}
+	}
+	if path := getServiceAccountKeyPath(); path != "" {
+		return []option.ClientOption{option.WithCredentialsFile(path)}
+	}
+	return nil
+}
+
+func gcpRunKubectl(kubectlOptions *k8s.KubectlOptions, args ...string) error {
+	var cmdArgs []string
+	if kubectlOptions.ContextName != "" {
+		cmdArgs = append(cmdArgs, "--context", kubectlOptions.ContextName)
+	}
+	if kubectlOptions.ConfigPath != "" {
+		cmdArgs = append(cmdArgs, "--kubeconfig", kubectlOptions.ConfigPath)
+	}
+	if kubectlOptions.Namespace != "" {
+		cmdArgs = append(cmdArgs, "-n", kubectlOptions.Namespace)
+	}
+	cmdArgs = append(cmdArgs, args...)
+
+	out, err := exec.Command("kubectl", cmdArgs...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("kubectl %s: %w\nOutput: %s", strings.Join(args, " "), err, string(out))
+	}
+	return nil
 }
 
 // TeardownInfra deletes all GCP resources created by SetUpInfra.

--- a/tests/e2e/operator/infra/local.go
+++ b/tests/e2e/operator/infra/local.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/helm-charts/tests/e2e/calico"
 	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
 	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/encryption"
 	"github.com/cockroachdb/helm-charts/tests/testutil"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/retry"
@@ -84,70 +85,67 @@ func (r *LocalRegion) SetUpInfra(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		// For Kind, install MetalLB before creating LoadBalancer services
-		// Calico+BGP provides pod routing; MetalLB provides external LB IPs when needed
-		if r.ProviderType == ProviderKind {
-			// Install MetalLB with Docker network IPs
+		// MetalLB and CoreDNS are only needed for multi-cluster setups.
+		// Single-cluster deployments use the cluster's default DNS and don't need
+		// cross-cluster networking.
+		if r.ProviderType == ProviderKind && len(r.Clusters) > 1 {
 			err = r.installMetalLBWithDockerIPs(t, kubectlOptions, i)
 			require.NoError(t, err)
 		}
 
-		// Create or update CoreDNS deployment.
-		deployment := coredns.CoreDNSDeployment(coreDNSReplicas)
-		// Apply deployment.
-		deploymentYaml := coredns.ToYAML(t, deployment)
-		err = k8s.KubectlApplyFromStringE(t, kubectlOptions, deploymentYaml)
-		require.NoError(t, err)
+		if len(r.Clusters) > 1 {
+			deployment := coredns.CoreDNSDeployment(coreDNSReplicas)
+			deploymentYaml := coredns.ToYAML(t, deployment)
+			err = k8s.KubectlApplyFromStringE(t, kubectlOptions, deploymentYaml)
+			require.NoError(t, err)
 
-		// Wait for deployment to be ready.
-		_, err = retry.DoWithRetryE(t, "waiting for coredns deployment",
-			defaultRetries, defaultRetryInterval,
-			func() (string, error) {
-				return k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
-					"wait", "--for=condition=Available", fmt.Sprintf("deployment/%s", coreDNSDeploymentName))
-			})
-		require.NoError(t, err)
+			_, err = retry.DoWithRetryE(t, "waiting for coredns deployment",
+				defaultRetries, defaultRetryInterval,
+				func() (string, error) {
+					return k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+						"wait", "--for=condition=Available", fmt.Sprintf("deployment/%s", coreDNSDeploymentName))
+				})
+			require.NoError(t, err)
 
-		// Create a CoreDNS service.
-		service := coredns.CoreDNSService(nil, GetLoadBalancerAnnotations(r.ProviderType))
-		serviceYaml := coredns.ToYAML(t, service)
-		// Apply service.
-		err = k8s.KubectlApplyFromStringE(t, kubectlOptions, serviceYaml)
-		require.NoError(t, err)
+			service := coredns.CoreDNSService(nil, GetLoadBalancerAnnotations(r.ProviderType))
+			serviceYaml := coredns.ToYAML(t, service)
+			err = k8s.KubectlApplyFromStringE(t, kubectlOptions, serviceYaml)
+			require.NoError(t, err)
 
-		// Now get the DNS IPs.
-		ips, err := WaitForCoreDNSServiceIPs(t, kubectlOptions)
-		require.NoError(t, err)
+			ips, err := WaitForCoreDNSServiceIPs(t, kubectlOptions)
+			require.NoError(t, err)
 
-		r.CorednsClusterOptions[operator.CustomDomains[i]] = coredns.CoreDNSClusterOption{
-			IPs:       ips,
-			Namespace: r.Namespace[cluster],
-			Domain:    operator.CustomDomains[i],
+			r.CorednsClusterOptions[operator.CustomDomains[i]] = coredns.CoreDNSClusterOption{
+				IPs:       ips,
+				Namespace: r.Namespace[cluster],
+				Domain:    operator.CustomDomains[i],
+			}
+		} else {
+			t.Logf("[%s] Skipping CoreDNS/MetalLB setup for single-cluster deployment", r.ProviderType)
 		}
 		if !r.IsMultiRegion {
 			break
 		}
 	}
 
-	// Update Coredns config.
-	for i, cluster := range r.Clusters {
-		// Create or update CoreDNS configmap.
-		kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, coreDNSNamespace)
-		cm := coredns.CoreDNSConfigMap(operator.CustomDomains[i], r.CorednsClusterOptions)
+	// Update CoreDNS config (only for multi-cluster).
+	if len(r.Clusters) > 1 {
+		for i, cluster := range r.Clusters {
+			kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, coreDNSNamespace)
+			cm := coredns.CoreDNSConfigMap(operator.CustomDomains[i], r.CorednsClusterOptions)
 
-		// Apply the updated ConfigMap to Kubernetes.
-		cmYaml := coredns.ToYAML(t, cm)
-		err := k8s.KubectlApplyFromStringE(t, kubectlOptions, cmYaml)
-		require.NoError(t, err)
+			cmYaml := coredns.ToYAML(t, cm)
+			err := k8s.KubectlApplyFromStringE(t, kubectlOptions, cmYaml)
+			require.NoError(t, err)
 
-		// restart coredns pods.
-		err = k8s.RunKubectlE(t, kubectlOptions, "rollout", "restart", "deployment", coreDNSDeploymentName)
-		require.NoError(t, err)
-		if !r.IsMultiRegion {
-			r.Clients = clients
-			r.ReusingInfra = true
-			return
+			err = k8s.RunKubectlE(t, kubectlOptions, "rollout", "restart", "deployment", coreDNSDeploymentName)
+			require.NoError(t, err)
 		}
+	}
+	if !r.IsMultiRegion {
+		r.Clients = clients
+		r.ReusingInfra = true
+		return
 	}
 	r.Clients = clients
 	r.ReusingInfra = true
@@ -212,6 +210,37 @@ func (r *LocalRegion) TeardownInfra(t *testing.T) {
 	} else {
 		t.Logf("[%s] Successfully tore down %s clusters", r.ProviderType, r.ProviderType)
 	}
+}
+
+func (r *LocalRegion) GetEncryptionProvider() encryption.Provider {
+	return r
+}
+
+func (r *LocalRegion) SetupEncryptionInfrastructure(t *testing.T) (func(), error) {
+	t.Logf("[%s] No KMS infrastructure needed for file-based encryption (UNKNOWN_KEY_TYPE)", r.ProviderType)
+	return func() {
+		t.Logf("[%s] No KMS infrastructure to clean up", r.ProviderType)
+	}, nil
+}
+
+func (r *LocalRegion) GetEncryptionPlatformConfig() *encryption.PlatformConfig {
+	return &encryption.PlatformConfig{
+		Platform:                     "UNKNOWN_KEY_TYPE",
+		RequiresCredentialsSecret:    false,
+		DefaultCredentialsSecretName: "",
+	}
+}
+
+func (r *LocalRegion) EncryptKey(plaintextKey []byte, clusterRegion string) (string, error) {
+	return "", fmt.Errorf("EncryptKey not supported for %s (file-based encryption / UNKNOWN_KEY_TYPE)", r.ProviderType)
+}
+
+func (r *LocalRegion) CreateKeySecret(kubectlOptions *k8s.KubectlOptions, secretName string, encryptedKeyData string, clusterRegion string) error {
+	return fmt.Errorf("CreateKeySecret not supported for %s (file-based encryption / UNKNOWN_KEY_TYPE)", r.ProviderType)
+}
+
+func (r *LocalRegion) CreateCredentialsSecret(kubectlOptions *k8s.KubectlOptions) (string, error) {
+	return "", fmt.Errorf("CreateCredentialsSecret not supported for %s (file-based encryption / UNKNOWN_KEY_TYPE)", r.ProviderType)
 }
 
 // ScaleNodePool scales the node pool in a local cluster

--- a/tests/e2e/operator/infra/provider.go
+++ b/tests/e2e/operator/infra/provider.go
@@ -1,45 +1,71 @@
 package infra
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/encryption"
 )
 
-// CloudProvider defines the interface that all cloud providers must implement
+// CloudProvider defines the interface that all cloud providers must implement.
 // Some methods are optional - providers that don't support certain operations
 // can implement them as no-ops with appropriate logging.
 type CloudProvider interface {
-	// SetUpInfra creates the necessary infrastructure for the tests
+	// SetUpInfra creates the necessary infrastructure for the tests.
 	SetUpInfra(t *testing.T)
 
-	// TeardownInfra cleans up all resources created by SetUpInfra
+	// TeardownInfra cleans up all resources created by SetUpInfra.
 	TeardownInfra(t *testing.T)
 
-	// ScaleNodePool scales the node pool in a cluster
-	// Optional: providers that don't support scaling/ if auto-scaling is enabled can implement as no-op
+	// ScaleNodePool scales the node pool in a cluster.
+	// Optional: providers that don't support scaling can implement as a no-op.
 	ScaleNodePool(t *testing.T, location string, nodeCount, index int)
 
 	// CanScale checks if the provider supports scaling.
 	CanScale() bool
+
+	GetEncryptionProvider() encryption.Provider
 }
 
-// ProviderFactory creates a CloudProvider instance for the given provider type.
+// ResolveProvider reads the PROVIDER env var and returns the matching provider
+// constant. Defaults to ProviderK3D if not set.
+func ResolveProvider(t *testing.T) string {
+	if p := strings.TrimSpace(strings.ToLower(os.Getenv("PROVIDER"))); p != "" {
+		switch p {
+		case ProviderK3D, ProviderKind, ProviderGCP:
+			return p
+		default:
+			t.Fatalf("Unsupported provider override: %s", p)
+		}
+	}
+	return ProviderK3D
+}
+
+// ProviderFactory creates a CloudProvider instance for the given provider type
+// and automatically wires the encryption provider into the region so that
+// InstallChartsWithAdvancedConfig can use it without any manual setup.
 func ProviderFactory(providerType string, region *operator.Region) CloudProvider {
+	var cp CloudProvider
+
 	switch providerType {
 	case ProviderK3D:
-		provider := LocalRegion{Region: region, ProviderType: ProviderK3D}
-		provider.RegionCodes = GetRegionCodes(providerType)
-		return &provider
+		p := LocalRegion{Region: region, ProviderType: ProviderK3D}
+		p.RegionCodes = GetRegionCodes(providerType)
+		cp = &p
 	case ProviderKind:
-		provider := LocalRegion{Region: region, ProviderType: ProviderKind}
-		provider.RegionCodes = GetRegionCodes(providerType)
-		return &provider
+		p := LocalRegion{Region: region, ProviderType: ProviderKind}
+		p.RegionCodes = GetRegionCodes(providerType)
+		cp = &p
 	case ProviderGCP:
-		provider := GcpRegion{Region: region}
-		provider.RegionCodes = GetRegionCodes(providerType)
-		return &provider
+		p := GcpRegion{Region: region}
+		p.RegionCodes = GetRegionCodes(providerType)
+		cp = &p
 	default:
 		return nil
 	}
+
+	region.SetEncryptionProvider(cp.GetEncryptionProvider())
+	return cp
 }

--- a/tests/e2e/operator/multiRegion/cockroachdb_multi_region_advanced_features_test.go
+++ b/tests/e2e/operator/multiRegion/cockroachdb_multi_region_advanced_features_test.go
@@ -75,50 +75,25 @@ func (r *multiRegion) TestWALFailoverMultiRegion(t *testing.T) {
 	t.Logf("WAL failover multi-region test completed successfully")
 }
 
-// TestEncryptionAtRestMultiRegion tests encryption at rest with different secrets per region
-// Region 0: Encryption enabled with secret "cmek-key-secret-region-0"
+// TestEncryptionAtRestMultiRegion tests encryption at rest with different configs per region:
+// Region 0: Encryption enabled with default secret
 // Region 1: Encryption disabled (no encryption)
 func (r *multiRegion) TestEncryptionAtRestMultiRegion(t *testing.T) {
 	// Setup namespaces and CA for each region
 	cleanup := r.SetupMultiClusterWithCA(t)
 	defer cleanup()
 
-	// Generate encryption key for region 0
-	encryptionKeyB64 := r.GenerateEncryptionKey(t)
-	t.Logf("Generated encryption key for region 0 (base64 length: %d)", len(encryptionKeyB64))
-
-	// Region 0: Install with encryption at rest enabled
 	cluster0 := r.Clusters[0]
-	secretName0 := "cmek-key-secret-region-0"
-
-	encryptionRegions0 := []map[string]interface{}{
-		{
-			"code":          r.RegionCodes[0],
-			"cloudProvider": r.Provider,
-			"nodes":         r.NodeCount,
-			"namespace":     r.Namespace[cluster0],
-			"domain":        operator.CustomDomains[0],
-			"encryptionAtRest": map[string]interface{}{
-				"platform":      "UNKNOWN_KEY_TYPE",
-				"keySecretName": secretName0,
-			},
-		},
-	}
-
 	t.Logf("Installing region 0 (%s) with encryption at rest enabled", cluster0)
-	config0 := operator.AdvancedInstallConfig{
-		EncryptionEnabled:       true,
-		EncryptionKeySecret:     encryptionKeyB64,
-		EncryptionKeySecretName: secretName0,
-		CustomRegions:           encryptionRegions0,
-	}
-	r.InstallChartsWithAdvancedConfig(t, cluster0, 0, config0)
+	r.InstallChartsWithAdvancedConfig(t, cluster0, 0, operator.AdvancedInstallConfig{
+		EncryptionEnabled: true,
+		CustomRegions:     r.BuildEncryptionRegions(cluster0, 0, r.EncryptionOverridesFromProvider()),
+	})
 
 	// Region 1: Install without encryption
 	cluster1 := r.Clusters[1]
 	t.Logf("Installing region 1 (%s) without encryption at rest", cluster1)
-	config1 := operator.AdvancedInstallConfig{}
-	r.InstallChartsWithAdvancedConfig(t, cluster1, 1, config1)
+	r.InstallChartsWithAdvancedConfig(t, cluster1, 1, operator.AdvancedInstallConfig{})
 
 	// Validate CockroachDB cluster health in both regions
 	for _, cluster := range r.Clusters {
@@ -128,13 +103,8 @@ func (r *multiRegion) TestEncryptionAtRestMultiRegion(t *testing.T) {
 	// Validate multi-region setup
 	r.ValidateMultiRegionSetup(t)
 
-	// Validate encryption in region 0
 	t.Log("Validating encryption at rest in region 0")
-	r.ValidateEncryptionAtRest(t, cluster0, &operator.AdvancedValidationConfig{
-		EncryptionAtRest: operator.EncryptionAtRestValidation{
-			SecretName: secretName0,
-		},
-	})
+	r.ValidateEncryptionAtRest(t, cluster0, nil)
 
 	// Validate NO encryption in region 1
 	t.Log("Validating NO encryption at rest in region 1")

--- a/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
+++ b/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
@@ -30,20 +30,7 @@ func newMultiRegion() *multiRegion {
 
 // TestOperatorInMultiRegion tests CockroachDB operator functionality across multiple regions
 func TestOperatorInMultiRegion(t *testing.T) {
-	// Fetch provider from env
-	var provider string
-	if p := strings.TrimSpace(strings.ToLower(os.Getenv("PROVIDER"))); p != "" {
-		switch p {
-		case "kind":
-			provider = infra.ProviderKind
-		case "gcp":
-			provider = infra.ProviderGCP
-		default:
-			t.Fatalf("Unsupported provider override: %s", p)
-		}
-	} else {
-		provider = infra.ProviderK3D
-	}
+	provider := infra.ResolveProvider(t)
 
 	t.Run(provider, func(t *testing.T) {
 		t.Parallel()
@@ -139,11 +126,8 @@ func (r *multiRegion) TestHelmInstall(t *testing.T) {
 	// Cleanup resources.
 	defer r.CleanupResources(t)
 
-	// Create CA certificate.
-	err := r.CreateCACertificate(t)
-	require.NoError(t, err)
-
-	defer r.CleanUpCACertificate(t)
+	cleanupCA := r.RequireCACertificate(t)
+	defer cleanupCA()
 
 	// Apply operator, CockroachDB charts on each cluster.
 	for i, cluster := range r.Clusters {
@@ -181,11 +165,8 @@ func (r *multiRegion) TestHelmUpgrade(t *testing.T) {
 	// Cleanup resources.
 	defer r.CleanupResources(t)
 
-	// Create CA certificate.
-	err := r.CreateCACertificate(t)
-	require.NoError(t, err)
-
-	defer r.CleanUpCACertificate(t)
+	cleanupCA := r.RequireCACertificate(t)
+	defer cleanupCA()
 
 	// Apply operator, CockroachDB charts on each cluster.
 	for i, cluster := range r.Clusters {
@@ -247,11 +228,8 @@ func (r *multiRegion) TestClusterRollingRestart(t *testing.T) {
 	// Cleanup resources.
 	defer r.CleanupResources(t)
 
-	// Create CA certificate.
-	err := r.CreateCACertificate(t)
-	require.NoError(t, err)
-
-	defer r.CleanUpCACertificate(t)
+	cleanupCA := r.RequireCACertificate(t)
+	defer cleanupCA()
 
 	// Apply operator, CockroachDB charts on each cluster.
 	for i, cluster := range r.Clusters {
@@ -292,18 +270,11 @@ func (r *multiRegion) TestClusterRollingRestart(t *testing.T) {
 		pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
 			LabelSelector: operator.LabelSelector,
 		})
-		if len(pods) == 0 {
-			require.Fail(t, "No initial pods found for deployment")
-		}
-
-		// Capture the creation timestamp of the last pod.
-		if len(pods) < 3 {
-			require.Fail(t, "Expected at least 3 pods but found %d", len(pods))
-		}
+		require.True(t, len(pods) >= 3, "Expected at least 3 pods but found %d", len(pods))
 		initialTimestamp := pods[len(pods)-1].CreationTimestamp.Time
 
 		// Verify if the pods are restarted after helm upgrade.
-		err = r.VerifyHelmUpgrade(t, initialTimestamp, kubectlOptions)
+		err := r.VerifyHelmUpgrade(t, initialTimestamp, kubectlOptions)
 		require.NoError(t, err)
 
 		crdbCluster := testutil.CockroachCluster{
@@ -336,11 +307,8 @@ func (r *multiRegion) TestKillingCockroachNode(t *testing.T) {
 	// Cleanup resources.
 	defer r.CleanupResources(t)
 
-	// Create CA certificate.
-	err := r.CreateCACertificate(t)
-	require.NoError(t, err)
-
-	defer r.CleanUpCACertificate(t)
+	cleanupCA := r.RequireCACertificate(t)
+	defer cleanupCA()
 
 	// Apply operator, CockroachDB charts on each cluster.
 	for i, cluster := range r.Clusters {
@@ -400,11 +368,8 @@ func (r *multiRegion) TestClusterScaleUp(t *testing.T, cloudProvider infra.Cloud
 	// Cleanup resources.
 	defer r.CleanupResources(t)
 
-	// Create CA certificate.
-	err := r.CreateCACertificate(t)
-	require.NoError(t, err)
-
-	defer r.CleanUpCACertificate(t)
+	cleanupCA := r.RequireCACertificate(t)
+	defer cleanupCA()
 
 	// Apply Operator, CockroachDB charts on each cluster.
 	for i, cluster := range r.Clusters {

--- a/tests/e2e/operator/region.go
+++ b/tests/e2e/operator/region.go
@@ -1,16 +1,17 @@
 package operator
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/encryption"
 	"github.com/cockroachdb/helm-charts/tests/testutil"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -31,7 +32,7 @@ const (
 	Namespace             = "cockroach-ns"
 	LabelSelector         = "app=cockroachdb"
 	OperatorLabelSelector = "app=cockroach-operator"
-	testOperatorRegistry  = "us-docker.pkg.dev/releases-prod/self-hosted"
+	testOperatorRegistry = "us-docker.pkg.dev/releases-prod/self-hosted"
 	testOperatorRepo      = "cockroachdb-operator"
 	testInitContainerRepo = "init-container"
 	testInotifywaitRepo   = "inotifywait"
@@ -91,6 +92,32 @@ type Region struct {
 	// OperatorNamespace tracks the namespace in which the operator was installed,
 	// keyed by cluster name.
 	OperatorNamespace map[string]string
+
+	encryptionProvider    encryption.Provider
+	encryptionInfraSetup  bool
+	encryptionCleanupFunc func()
+}
+
+func (r *Region) SetEncryptionProvider(p encryption.Provider) {
+	r.encryptionProvider = p
+}
+
+func (r *Region) CleanupEncryptionInfra() {
+	if r.encryptionCleanupFunc != nil {
+		r.encryptionCleanupFunc()
+	}
+}
+
+func (r *Region) EncryptionOverridesFromProvider() map[string]interface{} {
+	if r.encryptionProvider == nil {
+		return map[string]interface{}{}
+	}
+	cfg := r.encryptionProvider.GetEncryptionPlatformConfig()
+	overrides := map[string]interface{}{"platform": cfg.Platform}
+	if cfg.RequiresCredentialsSecret {
+		overrides["cmekCredentialsSecretName"] = cfg.DefaultCredentialsSecretName
+	}
+	return overrides
 }
 
 // InstallCharts Installs both Operator and CockroachDB charts by providing custom CA secret
@@ -469,6 +496,10 @@ func (r *Region) CleanupResources(t *testing.T) {
 			t.Logf("Warning: failed to delete namespace %s (cluster may be unreachable): %v", namespace, err)
 		}
 	}
+
+	// Release any encryption infrastructure (KMS keys, IAM bindings, etc.)
+	// that was provisioned during InstallChartsWithAdvancedConfig.
+	r.CleanupEncryptionInfra()
 }
 
 // OperatorRegions returns the regions config based on the index
@@ -649,6 +680,13 @@ func waitForCockroachDBOperator(
 	k8s.WaitUntilServiceAvailable(t, kubectlOptions, "cockroach-operator", 30, 5*time.Second)
 	k8s.WaitUntilServiceAvailable(t, kubectlOptions, "cockroach-webhook-service", 30, 5*time.Second)
 	testutil.RequireServiceEndpointsAvailable(t, kubectlOptions, "cockroach-webhook-service", 2*time.Minute)
+
+	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		LabelSelector: OperatorLabelSelector,
+	})
+	for i := range pods {
+		testutil.RequirePodToBeCreatedAndReady(t, operatorOpts.KubectlOptions, pods[i].Name, 300*time.Second)
+	}
 }
 
 // ExtendOperatorWatchNamespace patches the operator deployment in operatorNamespace to also
@@ -770,6 +808,8 @@ type PCRValidation struct {
 	Cluster          string
 	PrimaryNamespace string
 	StandbyNamespace string
+	// PrimaryClusterDomain overrides the cluster domain for the primary connection URI.
+	PrimaryClusterDomain string
 }
 
 // DefaultAdvancedValidationConfig returns default validation values used when a test does not override them.
@@ -848,6 +888,7 @@ func (r *Region) SetupSingleClusterWithCA(t *testing.T, cluster string) func() {
 	r.AssignRandomNamespace(cluster)
 	cleanupCA := r.RequireCACertificate(t)
 	return func() {
+		r.CleanupEncryptionInfra()
 		r.CleanupResources(t)
 		cleanupCA()
 	}
@@ -858,6 +899,7 @@ func (r *Region) SetupMultiClusterWithCA(t *testing.T) func() {
 	r.AssignRandomNamespacesWithPrefix(Namespace)
 	cleanupCA := r.RequireCACertificate(t)
 	return func() {
+		r.CleanupEncryptionInfra()
 		r.CleanupResources(t)
 		cleanupCA()
 	}
@@ -915,16 +957,13 @@ func (r *Region) BuildEncryptionRegions(
 	return []map[string]interface{}{region}
 }
 
-// AdvancedInstallConfig holds configuration for advanced feature installations
+// AdvancedInstallConfig holds configuration for advanced feature installations.
 type AdvancedInstallConfig struct {
 	// WAL Failover configuration
 	WALFailoverEnabled bool
 	WALFailoverSize    string
 
-	// Encryption at Rest configuration
-	EncryptionEnabled       bool
-	EncryptionKeySecret     string
-	EncryptionKeySecretName string // defaults to "cmek-key-secret" if empty
+	EncryptionEnabled bool
 
 	// Virtual Cluster configuration (for PCR)
 	VirtualClusterMode string // "primary", "standby", or ""
@@ -965,27 +1004,18 @@ func (r *Region) InstallChartsWithAdvancedConfig(
 		"--from-file=ca.key")
 	require.NoError(t, err)
 
-	// Create encryption key secret if encryption is enabled
-	if config.EncryptionEnabled && config.EncryptionKeySecret != "" {
-		encryptionSecretName := config.EncryptionKeySecretName
-		if encryptionSecretName == "" {
-			encryptionSecretName = DefaultEncryptionSecret
+	if config.EncryptionEnabled && r.encryptionProvider != nil {
+		if !r.encryptionInfraSetup {
+			t.Log("Setting up encryption infrastructure")
+			cleanup, err := r.encryptionProvider.SetupEncryptionInfrastructure(t)
+			require.NoError(t, err, "Failed to setup encryption infrastructure")
+			r.encryptionCleanupFunc = cleanup
+			r.encryptionInfraSetup = true
+			t.Log("Encryption infrastructure setup complete")
 		}
 
-		// Use --from-literal with the base64-encoded key string. Kubernetes base64-encodes
-		// secret values for storage, so the pod receives the original base64 string when
-		// the secret is mounted — which the init container then decodes to get the raw key.
-		err = k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", encryptionSecretName,
-			fmt.Sprintf("--from-literal=StoreKeyData=%s", config.EncryptionKeySecret))
-		require.NoError(t, err)
-
-		// Verify secret was created with data
-		secretSize, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
-			"get", "secret", encryptionSecretName,
-			"-o", "jsonpath={.data.StoreKeyData}")
-		require.NoError(t, err)
-		require.True(t, len(secretSize) > 0, "Secret StoreKeyData should be >0")
-		t.Logf("Created encryption secret %s with size: %d bytes", encryptionSecretName, len(secretSize))
+		err = encryption.SetupEncryptionSecretsWithName(t, r.encryptionProvider, kubectlOptions, r.RegionCodes[index], DefaultEncryptionSecret)
+		require.NoError(t, err, "Failed to setup encryption secrets")
 	}
 
 	// Install the operator when it is not skipped and not already marked as installed.
@@ -1106,9 +1136,7 @@ func (r *Region) ValidateWALFailover(t *testing.T, cluster string, cfg *Advanced
 	volumes, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
 		"get", "pod", podName, "-o", "jsonpath={.spec.volumes[*].name}")
 	require.NoError(t, err)
-	// The volume name is always "wal-failover" regardless of the custom path or PVC name
 	require.Contains(t, volumes, "wal-failover", "WAL failover volume should be mounted")
-	t.Log("WAL failover volume is properly mounted")
 
 	// 4. Verify the custom WAL failover path exists in the container
 	t.Logf("Verifying custom WAL failover path %s exists in container", expectedPath)
@@ -1119,30 +1147,11 @@ func (r *Region) ValidateWALFailover(t *testing.T, cluster string, cfg *Advanced
 	t.Log("WAL failover validation completed successfully")
 }
 
-// GenerateEncryptionKey generates a 256-bit AES encryption key and returns base64 encoded value
-func (r *Region) GenerateEncryptionKey(t *testing.T) string {
-	tempDir := t.TempDir()
-	keyPath := filepath.Join(tempDir, "store.key")
-
-	// Generate 256-bit AES key using cockroach gen encryption-key
-	cmd := shell.Command{
-		Command:    "cockroach",
-		Args:       []string{"gen", "encryption-key", "--size", "256", "store.key"},
-		WorkingDir: tempDir,
+func (r *Region) CreateEncryptionKeySecret(t *testing.T, kubectlOptions *k8s.KubectlOptions, secretName string, clusterRegion string) error {
+	if r.encryptionProvider == nil {
+		return fmt.Errorf("no encryption provider configured")
 	}
-
-	_, err := shell.RunCommandAndGetOutputE(t, cmd)
-	require.NoError(t, err)
-
-	// Read the generated key file
-	keyBytes, err := os.ReadFile(keyPath)
-	require.NoError(t, err)
-
-	// Base64 encode the key (removing any newlines)
-	storeKeyB64 := base64.StdEncoding.EncodeToString(keyBytes)
-	storeKeyB64 = strings.ReplaceAll(storeKeyB64, "\n", "")
-
-	return storeKeyB64
+	return encryption.SetupEncryptionSecretsWithName(t, r.encryptionProvider, kubectlOptions, clusterRegion, secretName)
 }
 
 // ValidateEncryptionAtRest verifies that encryption at rest is properly configured by checking flags and encryption status.
@@ -1179,12 +1188,11 @@ func (r *Region) ValidateEncryptionAtRest(
 
 	// 2. Verify the encryption key secret exists and has data
 	t.Logf("Verifying encryption key secret %s", secretName)
-	secretSize, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+	secretData, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
 		"get", "secret", secretName,
 		"-o", "jsonpath={.data.StoreKeyData}")
 	require.NoError(t, err)
-	require.True(t, len(secretSize) > 0, "Secret StoreKeyData should not be empty")
-	t.Logf("Encryption key secret %s exists with data", secretName)
+	require.True(t, len(secretData) > 0, "Secret StoreKeyData should not be empty")
 
 	// 3. Verify cockroach start command contains encryption flags
 	t.Log("Verifying cockroach start command contains encryption flags")
@@ -1203,6 +1211,10 @@ func (r *Region) ValidateEncryptionAtRest(
 	t.Log("Encryption flag verified: path, key, and old-key are all present")
 
 	// 5. Verify encryption algorithm via node metrics.
+	// TODO(CC-35895): investigate why "cockroach debug encryption-active-key" does not work in
+	// the test environment. It would be a more direct validation than relying on rocksdb metrics.
+	// TODO(CC-35895): rocksdb.encryption.algorithm is a legacy metric name. Evaluate whether a
+	// pebble-native metric is available in newer CRDB versions.
 	// rocksdb.encryption.algorithm: 0=Plaintext, 1=AES-128-CTR, 2=AES-192-CTR, 3=AES-256-CTR
 	t.Log("Verifying encryption algorithm via node metrics")
 	encAlgorithm, err := execSQL(t, kubectlOptions, podName,
@@ -1210,7 +1222,6 @@ func (r *Region) ValidateEncryptionAtRest(
 	require.NoError(t, err)
 	require.Contains(t, encAlgorithm, "3", "rocksdb.encryption.algorithm should be 3 (AES-256-CTR)")
 	t.Logf("Encryption algorithm verified: AES-256-CTR (value=3)")
-
 	t.Log("Encryption at rest validation completed successfully")
 }
 
@@ -1220,19 +1231,51 @@ func generateLocalTenantURI(cluster string) string {
 	return fmt.Sprintf("postgresql://root:root@localhost:26257?options=-ccluster%%3D%s", cluster)
 }
 
-// generateExternalConnectionURI creates external connection URI using cockroach convert-url
-// This is used for cross-cluster connections (e.g., replication from primary to standby)
-// Format: cockroach convert-url 'postgresql://USERNAME:PASSWORD@HOST' [flags]
-func generateExternalConnectionURI(
-	t *testing.T, kubectlOpts *k8s.KubectlOptions, pod string, connString string,
-) string {
+// TODO(CC-35895): once all supported CRDB versions ship convert-url, drop the encode-uri fallback.
+func generateExternalConnectionURI(t *testing.T, kubectlOpts *k8s.KubectlOptions, pod string, connString string) string {
+	versionOutput, err := execInCockroachdbContainer(t, kubectlOpts, pod,
+		"/cockroach/cockroach", "version", "--build-tag")
+	require.NoError(t, err, "failed to get CRDB version from pod")
+	version := strings.TrimSpace(versionOutput)
+
+	if crdbVersionAtLeast(version, 26, 2) {
+		output, err := execInCockroachdbContainer(t, kubectlOpts, pod,
+			"/cockroach/cockroach", "convert-url",
+			"--url", connString,
+			"--ca-cert=/cockroach/cockroach-certs/ca.crt",
+			"--inline")
+		require.NoError(t, err, "failed to run cockroach convert-url")
+		return strings.TrimSpace(output)
+	}
+
 	output, err := execInCockroachdbContainer(t, kubectlOpts, pod,
-		"/cockroach/cockroach", "convert-url",
-		"--url", connString, // Format: postgresql://user:pass@host:port
+		"/cockroach/cockroach", "encode-uri",
+		connString,
 		"--ca-cert=/cockroach/cockroach-certs/ca.crt",
 		"--inline")
-	require.NoError(t, err)
+	require.NoError(t, err, "failed to run cockroach encode-uri")
 	return strings.TrimSpace(output)
+}
+
+// crdbVersionAtLeast reports whether a CRDB version string (e.g. "v26.1.3") is >= major.minor.
+func crdbVersionAtLeast(version string, major, minor int) bool {
+	v := strings.TrimPrefix(version, "v")
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) < 2 {
+		return false
+	}
+	maj, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false
+	}
+	min, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return false
+	}
+	if maj != major {
+		return maj > major
+	}
+	return min >= minor
 }
 
 // execInCockroachdbContainer runs any command inside the cockroachdb container of a pod.
@@ -1434,7 +1477,11 @@ func (r *Region) ValidatePCR(t *testing.T, cfg *AdvancedValidationConfig) {
 	// Step 4a: Generate external connection URI for replication
 	// Following: https://www.cockroachlabs.com/docs/stable/set-up-physical-cluster-replication#step-4-start-replication
 	t.Log("Generating connection URI for primary cluster using cockroach convert-url")
-	primaryHost := fmt.Sprintf("cockroachdb-public.%s.svc.%s:26257", primaryNamespace, CustomDomains[0])
+	primaryClusterDomain := validationConfig.PCR.PrimaryClusterDomain
+	if primaryClusterDomain == "" {
+		primaryClusterDomain = CustomDomains[0]
+	}
+	primaryHost := fmt.Sprintf("cockroachdb-public.%s.svc.%s:26257", primaryNamespace, primaryClusterDomain)
 	primaryConnString := fmt.Sprintf("postgresql://%s:%s@%s?options=-ccluster%%3Dsystem", pcrSourceUser, pcrSourcePassword, primaryHost)
 	t.Logf("Primary connection string format: postgresql://pcr_source:***@%s?options=-ccluster%%3Dsystem", primaryHost)
 

--- a/tests/e2e/operator/singleRegion/cockroachdb_single_region_advanced_features_test.go
+++ b/tests/e2e/operator/singleRegion/cockroachdb_single_region_advanced_features_test.go
@@ -35,7 +35,7 @@ func (r *singleRegion) TestWALFailover(t *testing.T) {
 	// Validate WAL failover with workload and metrics monitoring
 	r.ValidateWALFailover(t, cluster, nil)
 
-	t.Logf("WAL failover test completed successfully")
+	t.Log("WAL failover test completed successfully")
 }
 
 // TestWALFailoverDisable tests disabling WAL failover via helm upgrade by:
@@ -125,64 +125,30 @@ func (r *singleRegion) TestWALFailoverDisable(t *testing.T) {
 		"get", "pvc", "-o", "jsonpath={.items[*].metadata.name}")
 	require.NoError(t, err)
 	require.Contains(t, pvcs, "datadir-wal-failover", "WAL failover PVC should still exist after disable")
-	t.Logf("PVCs after disable: %s", pvcs)
 
-	t.Log("WAL failover successfully disabled")
-	t.Logf("WAL failover disable test completed successfully")
+	t.Log("WAL failover disable test completed successfully")
 }
 
 // TestEncryptionAtRestEnable tests encryption at rest functionality by:
-// 1. Generating a proper 256-bit AES encryption key
-// 2. Creating encryption key secret
-// 3. Installing CockroachDB with encryption at rest enabled
-// 4. Verifying the cluster is healthy and encryption is active
+// 1. Installing CockroachDB with encryption at rest enabled (key generation handled by provider)
+// 2. Verifying the cluster is healthy and encryption is active
 func (r *singleRegion) TestEncryptionAtRestEnable(t *testing.T) {
 	cluster := r.Clusters[0]
 	cleanup := r.SetupSingleClusterWithCA(t, cluster)
 	defer cleanup()
 
-	// Generate proper 256-bit AES encryption key
-	t.Log("Generating 256-bit AES encryption key")
-	encryptionKeyB64 := r.GenerateEncryptionKey(t)
-	t.Logf("Generated encryption key (base64 length: %d)", len(encryptionKeyB64))
-
-	// Configure encryption at rest regions
-	encryptionRegions := r.BuildEncryptionRegions(cluster, 0, nil)
-
-	// Install CockroachDB with encryption at rest enabled using common method
-	config := operator.AdvancedInstallConfig{
-		EncryptionEnabled:   true,
-		EncryptionKeySecret: encryptionKeyB64,
-		CustomRegions:       encryptionRegions,
-	}
-	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
+	encryptionRegions := r.BuildEncryptionRegions(cluster, 0, r.EncryptionOverridesFromProvider())
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, operator.AdvancedInstallConfig{
+		EncryptionEnabled: true,
+		CustomRegions:     encryptionRegions,
+	})
 
 	// Validate CockroachDB cluster is healthy
 	r.ValidateCRDB(t, cluster)
 
-	// Validate encryption at rest is active
 	r.ValidateEncryptionAtRest(t, cluster, nil)
 
-	// Additional validation: Verify key and old-key in the encryption flag
-	kubeConfig, _ := r.GetCurrentContext(t)
-	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
-
-	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
-		LabelSelector: operator.LabelSelector,
-	})
-	require.True(t, len(pods) > 0, "No CockroachDB pods found")
-	podName := pods[0].Name
-
-	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
-		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
-	require.NoError(t, err)
-
-	// Verify encryption flag format: key should point to the secret, old-key should be "plain" for initial setup
-	require.Contains(t, podCommand, "key=/etc/cockroach-key/", "Encryption flag should contain key path")
-	require.Contains(t, podCommand, "old-key=plain", "Encryption flag should have old-key=plain for initial setup")
-	t.Logf("Verified encryption flag format with key and old-key=plain")
-
-	t.Logf("Encryption at rest enable test completed successfully")
+	t.Log("Encryption at rest enable test completed successfully")
 }
 
 // TestEncryptionAtRestDisable tests transitioning from encrypted to plaintext by:
@@ -200,18 +166,10 @@ func (r *singleRegion) TestEncryptionAtRestDisable(t *testing.T) {
 
 	// Step 1: Install CockroachDB with encryption at rest enabled
 	t.Log("Installing CockroachDB with encryption at rest enabled")
-	encryptionKeyB64 := r.GenerateEncryptionKey(t)
-	t.Logf("Generated encryption key (base64 length: %d)", len(encryptionKeyB64))
-
-	// Configure encryption at rest regions
-	encryptionRegions := r.BuildEncryptionRegions(cluster, 0, nil)
-
-	config := operator.AdvancedInstallConfig{
-		EncryptionEnabled:   true,
-		EncryptionKeySecret: encryptionKeyB64,
-		CustomRegions:       encryptionRegions,
-	}
-	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, operator.AdvancedInstallConfig{
+		EncryptionEnabled: true,
+		CustomRegions:     r.BuildEncryptionRegions(cluster, 0, r.EncryptionOverridesFromProvider()),
+	})
 
 	// Validate CockroachDB cluster is healthy
 	r.ValidateCRDB(t, cluster)
@@ -234,13 +192,16 @@ func (r *singleRegion) TestEncryptionAtRestDisable(t *testing.T) {
 	require.True(t, len(pods) > 0, "No CockroachDB pods found")
 	initialTimestamp := pods[0].CreationTimestamp.Time
 
-	// keySecretName="" is deleted from the map by EncryptionAtRestConfig (nil/empty → omit from JSON).
-	// An absent keySecretName is interpreted by the operator as "plain" (no new key).
-	// oldKeySecretName tells the operator to reference the previous key during the transition.
-	regions := r.BuildEncryptionRegions(cluster, 0, map[string]interface{}{
-		"keySecretName":    "",
-		"oldKeySecretName": operator.DefaultEncryptionSecret,
-	})
+	// Absent keySecretName = operator uses "plain". oldKeySecretName references the
+	// previous encrypted key so the transition can decrypt it.
+	disableOverrides := r.EncryptionOverridesFromProvider()
+	disableOverrides["keySecretName"] = ""
+	disableOverrides["oldKeySecretName"] = operator.DefaultEncryptionSecret
+	// oldCmekCredentialsSecretName is required for the operator to set OLD_CMEK_PLATFORM.
+	if credSecretName, ok := disableOverrides["cmekCredentialsSecretName"]; ok {
+		disableOverrides["oldCmekCredentialsSecretName"] = credSecretName
+	}
+	regions := r.BuildEncryptionRegions(cluster, 0, disableOverrides)
 
 	upgradeOptions := &helm.Options{
 		KubectlOptions: kubectlOptions,
@@ -307,18 +268,10 @@ func (r *singleRegion) TestEncryptionAtRestModifySecret(t *testing.T) {
 
 	// Step 1: Install CockroachDB with encryption at rest enabled
 	t.Log("Installing CockroachDB with encryption at rest enabled")
-	encryptionKeyB64 := r.GenerateEncryptionKey(t)
-	t.Logf("Generated initial encryption key (base64 length: %d)", len(encryptionKeyB64))
-
-	// Configure encryption at rest regions
-	encryptionRegions := r.BuildEncryptionRegions(cluster, 0, nil)
-
-	config := operator.AdvancedInstallConfig{
-		EncryptionEnabled:   true,
-		EncryptionKeySecret: encryptionKeyB64,
-		CustomRegions:       encryptionRegions,
-	}
-	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, operator.AdvancedInstallConfig{
+		EncryptionEnabled: true,
+		CustomRegions:     r.BuildEncryptionRegions(cluster, 0, r.EncryptionOverridesFromProvider()),
+	})
 
 	// Validate CockroachDB cluster is healthy
 	r.ValidateCRDB(t, cluster)
@@ -326,20 +279,13 @@ func (r *singleRegion) TestEncryptionAtRestModifySecret(t *testing.T) {
 	// Validate encryption at rest is active
 	r.ValidateEncryptionAtRest(t, cluster, nil)
 
-	// Step 2: Generate new encryption key and create new secret
-	t.Log("Generating new encryption key and creating new secret")
+	// Step 2: Create new encryption key secret for rotation
+	t.Log("Creating new encryption key secret for rotation...")
 	kubeConfig, _ := r.GetCurrentContext(t)
 	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
 
-	newEncryptionKeyB64 := r.GenerateEncryptionKey(t)
-	t.Logf("Generated new encryption key (base64 length: %d)", len(newEncryptionKeyB64))
-
-	// Create new secret using --from-literal with the base64-encoded key string.
-	// Kubernetes base64-encodes secret values for storage, so the pod receives the
-	// original base64 string when mounted — which the init container then decodes.
-	err := k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", operator.DefaultRotatedEncryptionSecret,
-		fmt.Sprintf("--from-literal=StoreKeyData=%s", newEncryptionKeyB64))
-	require.NoError(t, err)
+	err := r.CreateEncryptionKeySecret(t, kubectlOptions, operator.DefaultRotatedEncryptionSecret, r.RegionCodes[0])
+	require.NoError(t, err, "failed to create new encryption key secret")
 
 	t.Logf("Created new encryption key secret: %s", operator.DefaultRotatedEncryptionSecret)
 
@@ -351,14 +297,16 @@ func (r *singleRegion) TestEncryptionAtRestModifySecret(t *testing.T) {
 	initialTimestamp := pods[0].CreationTimestamp.Time
 
 	// Step 3: Configure regions with key rotation - new key in keySecretName, old key in oldKeySecretName
-	t.Log("Upgrading with key rotation configuration")
+	t.Log("Upgrading with key rotation configuration...")
 	helmChartPath, _ := operator.HelmChartPaths()
 
-	// Configure regions with both new and old keys for rotation
-	rotationRegions := r.BuildEncryptionRegions(cluster, 0, map[string]interface{}{
-		"keySecretName":    operator.DefaultRotatedEncryptionSecret,
-		"oldKeySecretName": operator.DefaultEncryptionSecret,
-	})
+	rotationOverrides := r.EncryptionOverridesFromProvider()
+	rotationOverrides["keySecretName"] = operator.DefaultRotatedEncryptionSecret
+	rotationOverrides["oldKeySecretName"] = operator.DefaultEncryptionSecret
+	if credSecretName, ok := rotationOverrides["cmekCredentialsSecretName"]; ok {
+		rotationOverrides["oldCmekCredentialsSecretName"] = credSecretName
+	}
+	rotationRegions := r.BuildEncryptionRegions(cluster, 0, rotationOverrides)
 
 	upgradeOptions := &helm.Options{
 		KubectlOptions: kubectlOptions,
@@ -391,38 +339,16 @@ func (r *singleRegion) TestEncryptionAtRestModifySecret(t *testing.T) {
 		},
 	})
 
-	// Verify new secret exists and is being used
-	newSecretData, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+	// Verify both secrets exist after rotation
+	_, err = k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
 		"get", "secret", operator.DefaultRotatedEncryptionSecret, "-o", "jsonpath={.data.StoreKeyData}")
-	require.NoError(t, err)
-	t.Logf("New secret key length: %d", len(newSecretData))
+	require.NoError(t, err, "new encryption key secret should exist")
 
-	// Verify old secret still exists (referenced in oldKeySecretName)
-	oldSecretData, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+	_, err = k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
 		"get", "secret", operator.DefaultEncryptionSecret, "-o", "jsonpath={.data.StoreKeyData}")
-	require.NoError(t, err)
-	t.Logf("Old secret key length: %d", len(oldSecretData))
+	require.NoError(t, err, "old encryption key secret should still exist")
 
-	// Verify pod command contains encryption flag with both key references
-	pods = k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
-		LabelSelector: operator.LabelSelector,
-	})
-	require.True(t, len(pods) > 0, "No CockroachDB pods found")
-	podName := pods[0].Name
-
-	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
-		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
-	require.NoError(t, err)
-	require.Contains(t, podCommand, "--enterprise-encryption", "Pod command should contain --enterprise-encryption flag")
-
-	// Verify encryption flag format: key should point to new secret, old-key should point to old secret
-	require.Contains(t, podCommand, "key=/etc/cockroach-key/", "Encryption flag should contain new key path")
-	require.Contains(t, podCommand, "old-key=/etc/cockroach-key/", "Encryption flag should contain old key path for rotation")
-	t.Logf("Verified encryption flag format with both new key and old-key during rotation")
-	t.Logf("Encryption flag after key rotation: %s", podCommand)
-
-	t.Log("Encryption at rest successfully working with rotated key")
-	t.Logf("Encryption at rest modify secret test completed successfully")
+	t.Log("Encryption at rest modify secret test completed successfully")
 }
 
 // TestWALFailoverWithEncryption tests WAL failover with encryption at rest by:
@@ -436,85 +362,33 @@ func (r *singleRegion) TestWALFailoverWithEncryption(t *testing.T) {
 	cleanup := r.SetupSingleClusterWithCA(t, cluster)
 	defer cleanup()
 
-	// Step 1: Generate encryption key
-	t.Log("Generating 256-bit AES encryption key")
-	encryptionKeyB64 := r.GenerateEncryptionKey(t)
-	t.Logf("Generated encryption key (base64 length: %d)", len(encryptionKeyB64))
-
-	// Configure encryption at rest regions
-	encryptionRegions := r.BuildEncryptionRegions(cluster, 0, nil)
-
-	// Install CockroachDB with both WAL failover and encryption enabled
-	config := operator.AdvancedInstallConfig{
-		WALFailoverEnabled:  true,
-		WALFailoverSize:     "5Gi",
-		EncryptionEnabled:   true,
-		EncryptionKeySecret: encryptionKeyB64,
-		CustomRegions:       encryptionRegions,
-	}
-	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
+	r.InstallChartsWithAdvancedConfig(t, cluster, 0, operator.AdvancedInstallConfig{
+		WALFailoverEnabled: true,
+		WALFailoverSize:    "5Gi",
+		EncryptionEnabled:  true,
+		CustomRegions:      r.BuildEncryptionRegions(cluster, 0, r.EncryptionOverridesFromProvider()),
+	})
 
 	// Validate CockroachDB cluster is healthy
 	r.ValidateCRDB(t, cluster)
 
-	// Step 2: Verify WAL failover is configured
-	t.Log("Verifying WAL failover configuration")
+	r.ValidateWALFailover(t, cluster, nil)
+	r.ValidateEncryptionAtRest(t, cluster, nil)
+
+	// Unique to WAL+encryption: verify the WAL path is also covered by the encryption flag
 	kubeConfig, _ := r.GetCurrentContext(t)
 	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
-
 	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
 		LabelSelector: operator.LabelSelector,
 	})
 	require.True(t, len(pods) > 0, "No CockroachDB pods found")
-	podName := pods[0].Name
-
-	// Verify --wal-failover flag exists
 	podCommand, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
-		"get", "pod", podName, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
+		"get", "pod", pods[0].Name, "-o", "jsonpath={.spec.containers[?(@.name=='cockroachdb')].command}")
 	require.NoError(t, err)
-	require.Contains(t, podCommand, "--wal-failover=path=/cockroach/cockroach-wal-failover",
-		"Pod command should contain --wal-failover flag with custom path")
-
-	// Step 3: Verify encryption is configured for both data store and WAL path
-	t.Log("Verifying encryption is configured for data store and WAL path")
-	// Encryption flag is part of the command
-	require.Contains(t, podCommand, "--enterprise-encryption",
-		"Pod command should contain --enterprise-encryption flag")
-
-	// The encryption flag should reference the WAL failover path
-	// Format: --enterprise-encryption=path=cockroach-data,key=...,old-key=plain;path=/cockroach/cockroach-wal-failover,key=...,old-key=plain
-	require.Contains(t, podCommand, "cockroach-data",
-		"Encryption flag should include data store path")
 	require.Contains(t, podCommand, "/cockroach/cockroach-wal-failover",
-		"Encryption flag should include WAL failover path for encryption")
-
-	// Verify encryption flag format: both data and WAL paths should have key=/etc/cockroach-key/ and old-key=plain
-	require.Contains(t, podCommand, "key=/etc/cockroach-key/", "Encryption flag should contain key path for both data and WAL")
-	require.Contains(t, podCommand, "old-key=plain", "Encryption flag should have old-key=plain for initial setup")
-	t.Logf("Verified encryption flag format with key and old-key=plain for both data store and WAL path")
-
-	// Step 4: Verify encryption algorithm via node metrics.
-	// rocksdb.encryption.algorithm: 0=Plaintext, 1=AES-128-CTR, 2=AES-192-CTR, 3=AES-256-CTR
-	t.Log("Verifying encryption algorithm via node metrics")
-	encAlgorithm, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
-		"exec", podName, "-c", "cockroachdb", "--",
-		"/cockroach/cockroach", "sql",
-		"--certs-dir=/cockroach/cockroach-certs",
-		"--host=localhost:26257",
-		"-e", "SET allow_unsafe_internals = true; SELECT value FROM crdb_internal.node_metrics WHERE name = 'rocksdb.encryption.algorithm';")
-	require.NoError(t, err)
-	require.Contains(t, encAlgorithm, "3", "rocksdb.encryption.algorithm should be 3 (AES-256-CTR)")
-	t.Logf("Encryption algorithm verified: AES-256-CTR (value=3)")
-
-	// Verify both PVCs exist
-	pvcs, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
-		"get", "pvc", "-o", "jsonpath={.items[*].metadata.name}")
-	require.NoError(t, err)
-	require.Contains(t, pvcs, "datadir", "Data PVC should exist")
-	require.Contains(t, pvcs, "datadir-wal-failover", "WAL failover PVC should exist")
+		"Encryption flag should include WAL failover path")
 
 	t.Log("WAL failover with encryption at rest test completed successfully")
-	t.Logf("Verified both data store and WAL path are encrypted")
 }
 
 // TestPCR tests Physical Cluster Replication by:
@@ -577,7 +451,7 @@ func (r *singleRegion) TestPCR(t *testing.T) {
 		}
 	}()
 
-	// Step 3: Set up replication and test failover/failback
+	// Step 3: Set up replication and test failover/failback.
 	r.ValidatePCR(t, &operator.AdvancedValidationConfig{
 		PCR: operator.PCRValidation{
 			Cluster:          cluster,
@@ -588,4 +462,3 @@ func (r *singleRegion) TestPCR(t *testing.T) {
 
 	t.Logf("PCR (Physical Cluster Replication) test completed successfully")
 }
-

--- a/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
+++ b/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
@@ -27,21 +27,7 @@ func newSingleRegion() *singleRegion {
 	return &singleRegion{}
 }
 func TestOperatorInSingleRegion(t *testing.T) {
-	// Fetch provider from env
-	var provider string
-	os.Setenv("PROVIDER", "gcp")
-	if p := strings.TrimSpace(strings.ToLower(os.Getenv("PROVIDER"))); p != "" {
-		switch p {
-		case "kind":
-			provider = infra.ProviderKind
-		case "gcp":
-			provider = infra.ProviderGCP
-		default:
-			t.Fatalf("Unsupported provider override: %s", p)
-		}
-	} else {
-		provider = infra.ProviderK3D
-	}
+	provider := infra.ResolveProvider(t)
 
 	t.Run(provider, func(t *testing.T) {
 		// Run tests for different providers in parallel.
@@ -70,7 +56,7 @@ func TestOperatorInSingleRegion(t *testing.T) {
 			t.Fatalf("Unsupported provider: %s", provider)
 		}
 
-		// Use t.Cleanup for guaranteed cleanup even on test timeout/panic
+		// Use t.Cleanup for guaranteed cleanup even on test timeout/panic.
 		t.Cleanup(func() {
 			t.Logf("Starting infrastructure cleanup for provider: %s", provider)
 			cloudProvider.TeardownInfra(t)
@@ -93,12 +79,12 @@ func TestOperatorInSingleRegion(t *testing.T) {
 			testCases["TestPCR"] = providerRegion.TestPCR
 		} else {
 			testCases["TestHelmInstall"] = providerRegion.TestHelmInstall
-			//testCases["TestHelmInstallVirtualCluster"] = providerRegion.TestHelmInstallVirtualCluster
-			//testCases["TestHelmUpgrade"] = providerRegion.TestHelmUpgrade
-			//testCases["TestClusterRollingRestart"] = providerRegion.TestClusterRollingRestart
-			//testCases["TestKillingCockroachNode"] = providerRegion.TestKillingCockroachNode
-			//testCases["TestClusterScaleUp"] = func(t *testing.T) { providerRegion.TestClusterScaleUp(t, cloudProvider) }
-			//testCases["TestInstallWithCertManager"] = providerRegion.TestInstallWithCertManager
+			testCases["TestHelmInstallVirtualCluster"] = providerRegion.TestHelmInstallVirtualCluster
+			testCases["TestHelmUpgrade"] = providerRegion.TestHelmUpgrade
+			testCases["TestClusterRollingRestart"] = providerRegion.TestClusterRollingRestart
+			testCases["TestKillingCockroachNode"] = providerRegion.TestKillingCockroachNode
+			testCases["TestClusterScaleUp"] = func(t *testing.T) { providerRegion.TestClusterScaleUp(t, cloudProvider) }
+			testCases["TestInstallWithCertManager"] = providerRegion.TestInstallWithCertManager
 		}
 
 		// Run tests sequentially within a provider.
@@ -136,11 +122,8 @@ func (r *singleRegion) TestHelmInstall(t *testing.T) {
 	// Cleanup resources.
 	defer r.CleanupResources(t)
 
-	// Create CA certificate.
-	err := r.CreateCACertificate(t)
-	require.NoError(t, err)
-
-	defer r.CleanUpCACertificate(t)
+	cleanupCA := r.RequireCACertificate(t)
+	defer cleanupCA()
 
 	// Install Operator and CockroachDB charts.
 	r.InstallCharts(t, cluster, 0)
@@ -159,12 +142,26 @@ func (r *singleRegion) TestHelmInstall(t *testing.T) {
 // for both primary and standby virtual clusters and verifies if
 // CockroachDB service is up and running.
 func (r *singleRegion) TestHelmInstallVirtualCluster(t *testing.T) {
-	// Create CA certificate.
-	err := r.CreateCACertificate(t)
-	require.NoError(t, err)
+	cluster := r.Clusters[0]
+
+	cleanupCA := r.RequireCACertificate(t)
+	defer cleanupCA()
+
 	var (
 		operatorNamespace, standByNamespace string
 	)
+
+	// Register cleanup before the test loop so it runs even if the loop panics.
+	defer r.CleanupResources(t)
+	defer func() {
+		if standByNamespace != "" {
+			kubeConfig, _ := r.GetCurrentContext(t)
+			kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, standByNamespace)
+			if err := k8s.DeleteNamespaceE(t, kubectlOptions, standByNamespace); err != nil {
+				t.Logf("Warning: failed to delete standby namespace %s: %v", standByNamespace, err)
+			}
+		}
+	}()
 
 	tests := []struct {
 		name                string
@@ -189,7 +186,6 @@ func (r *singleRegion) TestHelmInstallVirtualCluster(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r.IsOperatorInstalled = tt.IsOperatorInstalled
-			cluster := r.Clusters[0]
 			namespace := fmt.Sprintf("%s-%s", operator.Namespace, strings.ToLower(random.UniqueId()))
 			r.Namespace[cluster] = namespace
 
@@ -197,7 +193,7 @@ func (r *singleRegion) TestHelmInstallVirtualCluster(t *testing.T) {
 			if !tt.isPrimary {
 				vcMode = "standby"
 				r.VirtualClusterModeStandby = true
-				standByNamespace = r.Namespace[cluster]
+				standByNamespace = namespace
 				defer func() {
 					r.VirtualClusterModeStandby = false
 					r.IsOperatorInstalled = false
@@ -206,15 +202,12 @@ func (r *singleRegion) TestHelmInstallVirtualCluster(t *testing.T) {
 				operatorNamespace = namespace
 			}
 
-			// Install Operator and CockroachDB charts.
 			r.InstallChartsWithAdvancedConfig(t, cluster, 0, operator.AdvancedInstallConfig{
 				VirtualClusterMode:  vcMode,
 				SkipOperatorInstall: tt.IsOperatorInstalled,
 			})
 
-			// Get the current context name.
 			kubeConfig, rawConfig := r.GetCurrentContext(t)
-
 			if _, ok := rawConfig.Contexts[cluster]; !ok {
 				t.Fatalf("cluster context '%s' not found in kubeconfig", cluster)
 			}
@@ -223,19 +216,10 @@ func (r *singleRegion) TestHelmInstallVirtualCluster(t *testing.T) {
 			r.ValidateCRDB(t, cluster)
 
 			kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, operatorNamespace)
-
-			// Verify init command in logs
 			operator.VerifyInitCommandInOperatorLogs(t, kubectlOptions, tt.initCommand)
 			r.Namespace[cluster] = operatorNamespace
 		})
 	}
-	defer r.CleanupResources(t)
-	defer func() {
-		kubectlOptions := k8s.NewKubectlOptions("", "", standByNamespace)
-		k8s.DeleteNamespace(t, kubectlOptions, standByNamespace)
-	}()
-	defer r.CleanUpCACertificate(t)
-
 }
 
 // TestHelmUpgrade will upgrade the existing charts in a single region
@@ -247,11 +231,8 @@ func (r *singleRegion) TestHelmUpgrade(t *testing.T) {
 	// Cleanup resources.
 	defer r.CleanupResources(t)
 
-	// Create CA certificate.
-	err := r.CreateCACertificate(t)
-	require.NoError(t, err)
-
-	defer r.CleanUpCACertificate(t)
+	cleanupCA := r.RequireCACertificate(t)
+	defer cleanupCA()
 
 	// Install Operator and CockroachDB charts.
 	r.InstallCharts(t, cluster, 0)
@@ -301,11 +282,8 @@ func (r *singleRegion) TestClusterRollingRestart(t *testing.T) {
 	// Cleanup resources.
 	defer r.CleanupResources(t)
 
-	// Create CA certificate.
-	err := r.CreateCACertificate(t)
-	require.NoError(t, err)
-
-	defer r.CleanUpCACertificate(t)
+	cleanupCA := r.RequireCACertificate(t)
+	defer cleanupCA()
 
 	// Install Operator and CRDB charts.
 	r.InstallCharts(t, cluster, 0)
@@ -342,18 +320,11 @@ func (r *singleRegion) TestClusterRollingRestart(t *testing.T) {
 	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
 		LabelSelector: operator.LabelSelector,
 	})
-	if len(pods) == 0 {
-		require.Fail(t, "No initial pods found for deployment")
-	}
-
-	// Capture the creation timestamp of the last pod.
-	if len(pods) < 3 {
-		require.Fail(t, "Expected at least 3 pods but found %d", len(pods))
-	}
+	require.True(t, len(pods) >= 3, "Expected at least 3 pods but found %d", len(pods))
 	initialTimestamp := pods[2].CreationTimestamp.Time
 
 	// Verify if the pods are restarted after helm upgrade.
-	err = r.VerifyHelmUpgrade(t, initialTimestamp, kubectlOptions)
+	err := r.VerifyHelmUpgrade(t, initialTimestamp, kubectlOptions)
 	require.NoError(t, err)
 
 	crdbCluster := testutil.CockroachCluster{
@@ -379,11 +350,8 @@ func (r *singleRegion) TestKillingCockroachNode(t *testing.T) {
 	// Cleanup resources.
 	defer r.CleanupResources(t)
 
-	// Create CA certificate.
-	err := r.CreateCACertificate(t)
-	require.NoError(t, err)
-
-	defer r.CleanUpCACertificate(t)
+	cleanupCA := r.RequireCACertificate(t)
+	defer cleanupCA()
 
 	// Install Operator and CRDB charts.
 	r.InstallCharts(t, cluster, 0)
@@ -407,7 +375,7 @@ func (r *singleRegion) TestKillingCockroachNode(t *testing.T) {
 	})
 
 	// Kill a node in the cluster.
-	err = k8s.RunKubectlE(t, kubectlOptions, "delete", "pod", pods[0].Name)
+	err := k8s.RunKubectlE(t, kubectlOptions, "delete", "pod", pods[0].Name)
 	require.NoError(t, err)
 
 	// Wait till the reconciliation is done and all the pods are up and running.
@@ -434,11 +402,8 @@ func (r *singleRegion) TestClusterScaleUp(t *testing.T, cloudProvider infra.Clou
 	// Cleanup resources.
 	defer r.CleanupResources(t)
 
-	// Create CA certificate.
-	err := r.CreateCACertificate(t)
-	require.NoError(t, err)
-
-	defer r.CleanUpCACertificate(t)
+	cleanupCA := r.RequireCACertificate(t)
+	defer cleanupCA()
 
 	// Install Operator and CockroachDB charts.
 	r.InstallCharts(t, cluster, 0)


### PR DESCRIPTION
Introduces an encryption.Provider interface to abstract KMS and secret setup behind infra-level provider types, and adds GCP-specific test infrastructure support including version-gated PCR connection URI generation.

JIRA : https://cockroachlabs.atlassian.net/browse/CC-35895