### PR TITLE
[CRDB-51639] build: install yq for chart publishing scripts

### DIFF
--- a/build/make.sh
+++ b/build/make.sh
@@ -21,24 +21,50 @@ esac
 artifacts_dir="build/artifacts/"
 v2_artifacts_dir="build/artifacts/v2/"
 HELM_INSTALL_DIR=$PWD/bin
+HELM="$HELM_INSTALL_DIR/helm"
+YQ="${YQ:-${PWD}/bin/yq}"
 
 install_helm() {
   mkdir -p "$HELM_INSTALL_DIR"
   curl -fsSL -o "$HELM_INSTALL_DIR/get_helm.sh" https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
   chmod 700 "$HELM_INSTALL_DIR/get_helm.sh"
   export PATH="$HELM_INSTALL_DIR":$PATH
-  HELM_INSTALL_DIR="$HELM_INSTALL_DIR" "$HELM_INSTALL_DIR/get_helm.sh" --no-sudo --version v3.13.3
+  HELM_INSTALL_DIR="$HELM_INSTALL_DIR" "$HELM_INSTALL_DIR/get_helm.sh" --no-sudo --version v3.17.0
+}
+
+install_yq() {
+  if [ -x "$YQ" ]; then
+    return 0
+  fi
+
+  local yq_url
+  case "$(uname -s)" in
+    Linux)
+      yq_url="https://github.com/mikefarah/yq/releases/download/v4.31.2/yq_linux_amd64"
+      ;;
+    Darwin)
+      yq_url="https://github.com/mikefarah/yq/releases/download/v4.31.2/yq_darwin_amd64"
+      ;;
+    *)
+      echo "unsupported OS for yq install: $(uname -s)"
+      return 1
+      ;;
+  esac
+
+  mkdir -p "$(dirname "$YQ")"
+  curl -fsSL -o "$YQ" "$yq_url"
+  chmod +x "$YQ"
 }
 
 # chart_version_exists returns 1 (failure) when the version exists, which is
 # inverted from standard convention. This legacy behavior is preserved to avoid
 # breaking the existing legacy skip logic below.
 chart_version_exists() {
-  helm repo add cockroachdb "https://${charts_hostname}" --force-update
-  helm repo update
+  "$HELM" repo add cockroachdb "https://${charts_hostname}" --force-update
+  "$HELM" repo update
 
-  existing_version=$(bin/yq '.version' cockroachdb/Chart.yaml)
-  if helm search repo cockroachdb/cockroachdb --version "$existing_version" | grep $existing_version; then
+  existing_version=$("$YQ" '.version' cockroachdb/Chart.yaml)
+  if "$HELM" search repo cockroachdb/cockroachdb --version "$existing_version" | grep -q "$existing_version"; then
     echo "Chart version $existing_version already exists in the repository."
     return 1
   fi
@@ -51,8 +77,8 @@ build_chart() {
   curl -fsSL "https://storage.googleapis.com/$gcs_bucket/index.yaml" > "${artifacts_dir}/old-index.yaml"
 
   # Build the charts
-  $HELM_INSTALL_DIR/helm package cockroachdb --destination "${artifacts_dir}"
-  $HELM_INSTALL_DIR/helm repo index "${artifacts_dir}" --url "https://${charts_hostname}" --merge "${artifacts_dir}/old-index.yaml"
+  "$HELM" package cockroachdb --destination "${artifacts_dir}"
+  "$HELM" repo index "${artifacts_dir}" --url "https://${charts_hostname}" --merge "${artifacts_dir}/old-index.yaml"
   diff -u "${artifacts_dir}/old-index.yaml" "${artifacts_dir}/index.yaml" || true
 }
 
@@ -74,20 +100,21 @@ build_v2_charts() {
   # Always package v2 charts, including in prod. The release step treats
   # already-published OCI artifacts as success and GCS uploads overwrite the
   # same chart package, so rerunning a partial publish is safe.
-  $HELM_INSTALL_DIR/helm package cockroachdb-parent/charts/operator --destination "${v2_artifacts_dir}"
-  $HELM_INSTALL_DIR/helm package cockroachdb-parent/charts/cockroachdb --destination "${v2_artifacts_dir}"
+  "$HELM" package cockroachdb-parent/charts/operator --destination "${v2_artifacts_dir}"
+  "$HELM" package cockroachdb-parent/charts/cockroachdb --destination "${v2_artifacts_dir}"
 
-  $HELM_INSTALL_DIR/helm repo index "${v2_artifacts_dir}" --url "https://${charts_hostname}/v2" --merge "${v2_artifacts_dir}/old-index.yaml"
+  "$HELM" repo index "${v2_artifacts_dir}" --url "https://${charts_hostname}/v2" --merge "${v2_artifacts_dir}/old-index.yaml"
   diff -u "${v2_artifacts_dir}/old-index.yaml" "${v2_artifacts_dir}/index.yaml" || true
 }
 
 # When invoked directly (not sourced), run legacy chart build.
 # Use build_v2_charts for v2 chart packaging.
+install_helm
+install_yq
+
 if [[ "${1:-}" == "v2" ]]; then
-  install_helm
   build_v2_charts
 else
-  install_helm
   if [ "$is_prod" = true ] && ! chart_version_exists; then
     echo "Skipping build: chart version already present in production."
     exit 0

--- a/build/release.sh
+++ b/build/release.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 HELM="${HELM:-${PWD}/bin/helm}"
+YQ="${YQ:-${PWD}/bin/yq}"
 
 charts_hostname="${CHARTS_HOSTNAME:-charts.cockroachdb.com}"
 case $charts_hostname in
@@ -37,6 +38,20 @@ gcs_authenticate() {
   gcloud auth activate-service-account --key-file=.google-credentials.json
 }
 
+require_helm() {
+  if [ ! -x "$HELM" ]; then
+    echo "Missing helm binary at ${HELM}. Run build/make.sh before build/release.sh."
+    return 1
+  fi
+}
+
+require_yq() {
+  if [ ! -x "$YQ" ]; then
+    echo "Missing yq binary at ${YQ}. Run build/make.sh before build/release.sh."
+    return 1
+  fi
+}
+
 # release_legacy publishes the legacy statefulset chart (cockroachdb/) to the
 # root of the GCS bucket.
 release_legacy() {
@@ -68,6 +83,8 @@ release_v2() {
     return 0
   fi
 
+  require_helm
+  require_yq
   gcs_authenticate
 
   local release_failed=false
@@ -205,11 +222,11 @@ preserve_gcs_index_entry() {
   local metadata chart_name chart_version entry_file remote_digest
 
   metadata="$("$HELM" show chart "$chart_pkg")"
-  chart_name="$(echo "$metadata" | bin/yq '.name' -)"
-  chart_version="$(echo "$metadata" | bin/yq '.version' -)"
+  chart_name="$(echo "$metadata" | "$YQ" '.name' -)"
+  chart_version="$(echo "$metadata" | "$YQ" '.version' -)"
   entry_file="$(mktemp)"
 
-  if ! CHART_NAME="$chart_name" CHART_VERSION="$chart_version" bin/yq \
+  if ! CHART_NAME="$chart_name" CHART_VERSION="$chart_version" "$YQ" \
     '.entries[strenv(CHART_NAME)][] | select(.version == strenv(CHART_VERSION))' \
     build/artifacts/v2/old-index.yaml > "$entry_file"; then
     rm -f "$entry_file"
@@ -217,7 +234,7 @@ preserve_gcs_index_entry() {
   fi
 
   if [ -s "$entry_file" ]; then
-    if ! CHART_NAME="$chart_name" CHART_VERSION="$chart_version" ENTRY_FILE="$entry_file" bin/yq -i \
+    if ! CHART_NAME="$chart_name" CHART_VERSION="$chart_version" ENTRY_FILE="$entry_file" "$YQ" -i \
       '(.entries[strenv(CHART_NAME)][] | select(.version == strenv(CHART_VERSION))) = load(strenv(ENTRY_FILE))' \
       build/artifacts/v2/index.yaml; then
       rm -f "$entry_file"
@@ -242,10 +259,10 @@ update_gcs_index_digest() {
   local metadata chart_name chart_version
 
   metadata="$("$HELM" show chart "$chart_pkg")"
-  chart_name="$(echo "$metadata" | bin/yq '.name' -)"
-  chart_version="$(echo "$metadata" | bin/yq '.version' -)"
+  chart_name="$(echo "$metadata" | "$YQ" '.name' -)"
+  chart_version="$(echo "$metadata" | "$YQ" '.version' -)"
 
-  if ! CHART_NAME="$chart_name" CHART_VERSION="$chart_version" DIGEST="$digest" bin/yq -i \
+  if ! CHART_NAME="$chart_name" CHART_VERSION="$chart_version" DIGEST="$digest" "$YQ" -i \
     '(.entries[strenv(CHART_NAME)][] | select(.version == strenv(CHART_VERSION)) | .digest) = strenv(DIGEST)' \
     build/artifacts/v2/index.yaml; then
     return 1
@@ -313,8 +330,8 @@ oci_chart_exists() {
   local metadata chart_name chart_version
 
   metadata="$("$HELM" show chart "$chart_pkg")"
-  chart_name="$(echo "$metadata" | bin/yq '.name' -)"
-  chart_version="$(echo "$metadata" | bin/yq '.version' -)"
+  chart_name="$(echo "$metadata" | "$YQ" '.name' -)"
+  chart_version="$(echo "$metadata" | "$YQ" '.version' -)"
 
   "$HELM" show chart "oci://${registry}/${chart_name}" --version "$chart_version" >/dev/null 2>&1
 }


### PR DESCRIPTION
## Summary
- Installs/uses a repo-local `yq` binary in chart publish scripts when chart metadata needs to be read
- Fixes manual v2 publish retries failing in TeamCity after Helm is installed but `bin/yq` is missing
- Tightens the legacy chart version check to quote the version and avoid leaking search output
