### PR TITLE
[CRDB-51639] Rename v2 chart artifacts

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -272,7 +272,7 @@ update_gcs_index_digest() {
 # push_oci_dockerhub pushes chart packages as OCI artifacts to DockerHub.
 # This is best-effort so missing DockerHub repos do not block GAR/GCS publishing.
 push_oci_dockerhub() {
-  local dockerhub_registry="${OCI_DOCKERHUB_REGISTRY:-registry-1.docker.io/cockroachdb-charts}"
+  local dockerhub_registry="${OCI_DOCKERHUB_REGISTRY:-registry-1.docker.io/cockroachdb}"
   local failed=false
 
   if [ -z "${DOCKERHUB_USERNAME:-}" ] || [ -z "${DOCKERHUB_TOKEN:-}" ]; then

--- a/build/templates/cockroachdb-parent/Chart.yaml
+++ b/build/templates/cockroachdb-parent/Chart.yaml
@@ -5,12 +5,13 @@ type: application
 version: {{ .Version }}
 appVersion: {{ .AppVersion }}
 dependencies:
-  - name: cockroachdb-operator
+  - name: cockroachdb-operator-chart
     alias: operator
     version: {{ .OperatorVersion }}
     condition: operator.enabled
     repository: "file://charts/operator"
-  - name: cockroachdb
+  - name: cockroachdb-chart
+    alias: cockroachdb
     version: {{ .CockroachDBVersion }}
     condition: cockroachdb.enabled
     repository: "file://charts/cockroachdb"

--- a/build/templates/cockroachdb-parent/charts/cockroachdb/Chart.yaml
+++ b/build/templates/cockroachdb-parent/charts/cockroachdb/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: cockroachdb
+name: cockroachdb-chart
 home: https://www.cockroachlabs.com
 version: {{ .Version }}
 appVersion: {{ .AppVersion }}

--- a/build/templates/cockroachdb-parent/charts/operator/Chart.yaml
+++ b/build/templates/cockroachdb-parent/charts/operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: cockroachdb-operator
+name: cockroachdb-operator-chart
 description: A Helm chart for managing the CockroachDB operator.
 type: application
 appVersion: {{ .AppVersion }}

--- a/cockroachdb-parent/Chart.lock
+++ b/cockroachdb-parent/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: cockroachdb-operator
+- name: cockroachdb-operator-chart
   repository: file://charts/operator
   version: 1.0.0-rc.1
-- name: cockroachdb
+- name: cockroachdb-chart
   repository: file://charts/cockroachdb
   version: 26.1.3
-digest: sha256:191176fa3adbfb2ddd5466ee8921e52d62e5d41145b7a8145917dcda020c43bb
-generated: "2026-04-27T23:43:51.149883+05:30"
+digest: sha256:75ef3ede72745294a6460e292bc21786fc05e9ef6b01ea5ec3910c6c898396db
+generated: "2026-05-06T12:57:20.379188+05:30"

--- a/cockroachdb-parent/Chart.yaml
+++ b/cockroachdb-parent/Chart.yaml
@@ -6,12 +6,13 @@ type: application
 version: 26.1.3
 appVersion: 26.1.3
 dependencies:
-  - name: cockroachdb-operator
+  - name: cockroachdb-operator-chart
     alias: operator
     version: 1.0.0-rc.1
     condition: operator.enabled
     repository: "file://charts/operator"
-  - name: cockroachdb
+  - name: cockroachdb-chart
+    alias: cockroachdb
     version: 26.1.3
     condition: cockroachdb.enabled
     repository: "file://charts/cockroachdb"

--- a/cockroachdb-parent/charts/cockroachdb/CHANGELOG.md
+++ b/cockroachdb-parent/charts/cockroachdb/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CockroachDB Chart — CHANGELOG
 
-## [26.1.3] — 2026-05-04
+## [26.1.3] — 2026-05-06
 ### Added
 - Support for additional Subject Alternative Names (SANs) in self-signer node certificates via
   `cockroachdb.selfSigner.additionalSANs`. This enables SSL verification when connecting through
@@ -14,13 +14,16 @@
 - **Per-chart versioning**: The CockroachDB chart's major.minor now tracks the CockroachDB database
   series (e.g., chart 26.1.x is for CockroachDB 26.1). The patch version increments independently.
   Check `appVersion` in Chart.yaml for the exact CockroachDB version bundled.
+- **Chart name**: The chart name is `cockroachdb-chart` for published Helm and OCI artifacts.
+  Rendered Kubernetes names remain based on `cockroachdb`.
 - Hook images (`bitnami/kubectl`, `dtzar/helm-kubectl`) are now configurable via
   `hooks.kubectlImage.{registry,repository,tag,pullPolicy}` for air-gapped deployments.
 - Self-signer image tag updated from `1.9` to `1.10` to include additional SANs support.
 
 ### Upgrade Notes
 - Users must be on the latest preview version (`26.1.3-preview+1`) before upgrading.
-- `helm upgrade <release> cockroachdb/cockroachdb --version 26.1.3`
+- `helm upgrade <release> cockroachdb-v2/cockroachdb-chart --version 26.1.3`
+- See [VERSIONING.md](../../docs/VERSIONING.md) for upstream Helm repository and OCI locations.
 
 ### Previous releases
 For changes prior to per-chart versioning, see the [root CHANGELOG](../../../CHANGELOG.md).

--- a/cockroachdb-parent/charts/cockroachdb/Chart.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/Chart.yaml
@@ -1,6 +1,6 @@
 # Generated file, DO NOT EDIT. Source: build/templates/cockroachdb-parent/charts/cockroachdb/Chart.yaml
 apiVersion: v1
-name: cockroachdb
+name: cockroachdb-chart
 home: https://www.cockroachlabs.com
 version: 26.1.3
 appVersion: 26.1.3

--- a/cockroachdb-parent/charts/cockroachdb/templates/_helpers.tpl
+++ b/cockroachdb-parent/charts/cockroachdb/templates/_helpers.tpl
@@ -1,8 +1,17 @@
 {{/*
+Name to use for Kubernetes resources. The published chart name may include
+"-chart" to disambiguate OCI artifacts from container images, but existing
+resource names should not gain that suffix on upgrade.
+*/}}
+{{- define "cockroachdb.chartName" -}}
+{{- .Chart.Name | trimSuffix "-chart" -}}
+{{- end -}}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "cockroachdb.name" -}}
-{{- default .Chart.Name .Values.k8s.nameOverride | trunc 56 | trimSuffix "-" -}}
+{{- default (include "cockroachdb.chartName" .) .Values.k8s.nameOverride | trunc 56 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -14,7 +23,7 @@ If release name contains chart name it will be used as a full name.
 {{- if .Values.k8s.fullnameOverride -}}
     {{- .Values.k8s.fullnameOverride | trunc 56 | trimSuffix "-" -}}
 {{- else -}}
-    {{- $name := default .Chart.Name .Values.k8s.nameOverride -}}
+    {{- $name := default (include "cockroachdb.chartName" .) .Values.k8s.nameOverride -}}
     {{- if contains $name .Release.Name -}}
         {{- .Release.Name | trunc 56 | trimSuffix "-" -}}
     {{- else -}}
@@ -32,7 +41,7 @@ If release name contains chart name it will be used as a full name with release 
 {{- if .Values.k8s.fullnameOverride -}}
     {{- printf "%s-%s" .Values.k8s.fullnameOverride .Release.Namespace | trunc 56 | trimSuffix "-" -}}
 {{- else -}}
-    {{- $name := default .Chart.Name .Values.k8s.nameOverride -}}
+    {{- $name := default (include "cockroachdb.chartName" .) .Values.k8s.nameOverride -}}
     {{- if contains $name .Release.Name -}}
         {{- printf "%s-%s" .Release.Name .Release.Namespace | trunc 56 | trimSuffix "-" -}}
     {{- else -}}
@@ -45,7 +54,7 @@ If release name contains chart name it will be used as a full name with release 
 Create chart name and version as used by the chart label.
 */}}
 {{- define "cockroachdb.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 56 | trimSuffix "-" -}}
+{{- printf "%s-%s" (include "cockroachdb.chartName" .) .Chart.Version | replace "+" "_" | trunc 56 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/cockroachdb-parent/charts/operator/CHANGELOG.md
+++ b/cockroachdb-parent/charts/operator/CHANGELOG.md
@@ -1,10 +1,11 @@
 # CockroachDB Operator Chart — CHANGELOG
 
-## [1.0.0-rc.1] — 2026-05-04
+## [1.0.0-rc.1] — 2026-05-06
 ### Changed
 - **Per-chart versioning**: The operator chart now uses independent semantic versioning, starting
   at 1.0.0-rc.1. A single operator version supports multiple CockroachDB versions.
-- **Chart renamed** from `operator` to `cockroachdb-operator`.
+- **Chart name**: The chart name is `cockroachdb-operator-chart` for published Helm and OCI
+  artifacts. Rendered Kubernetes names remain based on `cockroachdb-operator`.
 - **Image tags**: The operator image now uses semantic version tags (`v1.0.0-rc.1`) instead of
   SHA digests.
 - **Image registry**: The operator image now defaults to DockerHub (`docker.io/cockroachdb`)
@@ -12,7 +13,8 @@
 
 ### Upgrade Notes
 - Users must be on the latest preview version (`26.1.3-preview+1`) before upgrading.
-- `helm upgrade <release> cockroachdb/cockroachdb-operator --version 1.0.0-rc.1`
+- `helm upgrade <release> cockroachdb-v2/cockroachdb-operator-chart --version 1.0.0-rc.1`
+- See [VERSIONING.md](../../docs/VERSIONING.md) for upstream Helm repository and OCI locations.
 
 ### Previous releases
 For changes prior to per-chart versioning, see the [root CHANGELOG](../../../CHANGELOG.md).

--- a/cockroachdb-parent/charts/operator/Chart.yaml
+++ b/cockroachdb-parent/charts/operator/Chart.yaml
@@ -1,6 +1,6 @@
 # Generated file, DO NOT EDIT. Source: build/templates/cockroachdb-parent/charts/operator/Chart.yaml
 apiVersion: v2
-name: cockroachdb-operator
+name: cockroachdb-operator-chart
 description: A Helm chart for managing the CockroachDB operator.
 type: application
 appVersion: 1.0.0-rc.1

--- a/cockroachdb-parent/charts/operator/templates/clusterrole-hooks.yaml
+++ b/cockroachdb-parent/charts/operator/templates/clusterrole-hooks.yaml
@@ -6,7 +6,7 @@ kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}-hooks
   labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name | trimSuffix "-chart" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   annotations:
     "helm.sh/hook": pre-upgrade
@@ -26,7 +26,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Name }}-hooks
   labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name | trimSuffix "-chart" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   annotations:
     "helm.sh/hook": pre-upgrade

--- a/cockroachdb-parent/charts/operator/templates/pre-upgrade-validation.yaml
+++ b/cockroachdb-parent/charts/operator/templates/pre-upgrade-validation.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "{{ .Release.Name }}-operator-pre-upgrade-validation"
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/name: {{ .Chart.Name | trimSuffix "-chart" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   annotations:
     "helm.sh/hook": pre-upgrade

--- a/cockroachdb-parent/docs/VERSIONING.md
+++ b/cockroachdb-parent/docs/VERSIONING.md
@@ -62,10 +62,10 @@ Always upgrade the operator chart before the cockroachdb chart.
 
 ```bash
 # Step 1: Upgrade operator
-helm upgrade <operator-release> cockroachdb-v2/cockroachdb-operator --version <new-version>
+helm upgrade <operator-release> cockroachdb-v2/cockroachdb-operator-chart --version <new-version>
 
 # Step 2: Upgrade cockroachdb
-helm upgrade <cockroachdb-release> cockroachdb-v2/cockroachdb --version <new-version>
+helm upgrade <cockroachdb-release> cockroachdb-v2/cockroachdb-chart --version <new-version>
 ```
 
 The cockroachdb chart includes a pre-upgrade hook that validates the operator is in the expected
@@ -79,7 +79,7 @@ a clear error message.
 Only the cockroachdb chart changes. The operator chart stays the same.
 
 ```bash
-helm upgrade <cockroachdb-release> cockroachdb-v2/cockroachdb --version <new-chart-version>
+helm upgrade <cockroachdb-release> cockroachdb-v2/cockroachdb-chart --version <new-chart-version>
 ```
 
 No operator upgrade needed. No downtime.
@@ -89,7 +89,7 @@ No operator upgrade needed. No downtime.
 Only the operator chart changes. The cockroachdb chart stays the same.
 
 ```bash
-helm upgrade <operator-release> cockroachdb-v2/cockroachdb-operator --version <new-version>
+helm upgrade <operator-release> cockroachdb-v2/cockroachdb-operator-chart --version <new-version>
 ```
 
 The operator rolls out a new deployment. CockroachDB pods are not affected.
@@ -101,8 +101,8 @@ whether the new CockroachDB version requires operator changes.
 
 ```bash
 # Check the chart's compatibility notes for minimum operator version
-helm upgrade <operator-release> cockroachdb-v2/cockroachdb-operator --version <required-version>
-helm upgrade <cockroachdb-release> cockroachdb-v2/cockroachdb --version 26.2.0
+helm upgrade <operator-release> cockroachdb-v2/cockroachdb-operator-chart --version <required-version>
+helm upgrade <cockroachdb-release> cockroachdb-v2/cockroachdb-chart --version 26.2.0
 ```
 
 ### Breaking operator change (major version bump)
@@ -130,7 +130,7 @@ If any check fails, the upgrade is blocked with a message explaining what to do.
 To run a different CockroachDB version than the chart default, override the image name:
 
 ```bash
-helm upgrade <release> cockroachdb-v2/cockroachdb \
+helm upgrade <release> cockroachdb-v2/cockroachdb-chart \
   --set cockroachdb.crdbCluster.image.name=cockroachdb/cockroach:v26.1.5
 ```
 
@@ -143,10 +143,14 @@ The v2 release publishes two independent charts:
 
 | Chart | Package name | Purpose |
 |---|---|---|
-| `cockroachdb-operator` | `cockroachdb-operator-<version>.tgz` | Installs and upgrades the CockroachDB operator |
-| `cockroachdb` | `cockroachdb-<version>.tgz` | Installs and upgrades CockroachDB clusters managed by the operator |
+| `cockroachdb-operator-chart` | `cockroachdb-operator-chart-<version>.tgz` | Installs and upgrades the CockroachDB operator |
+| `cockroachdb-chart` | `cockroachdb-chart-<version>.tgz` | Installs and upgrades CockroachDB clusters managed by the operator |
 
 The parent chart is local-only and is not published.
+
+For existing preview or locally installed releases, keep the same Helm release name when upgrading
+to the published charts. The chart artifact name changes to `cockroachdb-chart` or
+`cockroachdb-operator-chart`, but rendered Kubernetes resource names remain stable.
 
 ### Helm repository
 
@@ -157,13 +161,13 @@ helm repo add cockroachdb-v2 https://charts.cockroachdb.com/v2 --force-update
 helm repo update cockroachdb-v2
 helm search repo cockroachdb-v2 --devel
 
-helm install crdb-operator cockroachdb-v2/cockroachdb-operator --version 1.0.0-rc.1
-helm install crdb cockroachdb-v2/cockroachdb --version 26.1.3
+helm install crdb-operator cockroachdb-v2/cockroachdb-operator-chart --version 1.0.0-rc.1
+helm install crdb cockroachdb-v2/cockroachdb-chart --version 26.1.3
 ```
 
 `cockroachdb-v2` is a local Helm repository alias. You can choose a different alias, but the chart
-references must use the same alias, for example `<alias>/cockroachdb-operator` and
-`<alias>/cockroachdb`.
+references must use the same alias, for example `<alias>/cockroachdb-operator-chart` and
+`<alias>/cockroachdb-chart`.
 
 `--force-update` only updates the local Helm repo entry if it already exists. It does not force an
 upgrade of any installed release.
@@ -177,15 +181,15 @@ Charts are also published as OCI artifacts.
 Google Artifact Registry:
 
 ```bash
-helm pull oci://us-docker.pkg.dev/releases-prod/self-hosted/charts/cockroachdb-operator --version 1.0.0-rc.1
-helm pull oci://us-docker.pkg.dev/releases-prod/self-hosted/charts/cockroachdb --version 26.1.3
+helm pull oci://us-docker.pkg.dev/releases-prod/self-hosted/charts/cockroachdb-operator-chart --version 1.0.0-rc.1
+helm pull oci://us-docker.pkg.dev/releases-prod/self-hosted/charts/cockroachdb-chart --version 26.1.3
 ```
 
 DockerHub:
 
 ```bash
-helm pull oci://registry-1.docker.io/cockroachdb-charts/cockroachdb-operator --version 1.0.0-rc.1
-helm pull oci://registry-1.docker.io/cockroachdb-charts/cockroachdb --version 26.1.3
+helm pull oci://registry-1.docker.io/cockroachdb/cockroachdb-operator-chart --version 1.0.0-rc.1
+helm pull oci://registry-1.docker.io/cockroachdb/cockroachdb-chart --version 26.1.3
 ```
 
 The DockerHub repositories must exist before charts appear there unless DockerHub auto-create is


### PR DESCRIPTION
## Summary
- Rename the v2 chart artifacts to cockroachdb-chart and cockroachdb-operator-chart.
- Keep rendered Kubernetes names and labels stable by trimming the chart artifact suffix in templates.
- Publish DockerHub OCI chart artifacts under the existing cockroachdb org.