### PR TITLE
e2e/operator: Refactor encryption provider interface and fix single-cluster setup

### DIFF
--- a/tests/e2e/operator/encryption/types.go
+++ b/tests/e2e/operator/encryption/types.go
@@ -1,0 +1,172 @@
+package encryption
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/stretchr/testify/require"
+)
+
+// PlatformConfig holds provider-specific encryption configuration defaults
+type PlatformConfig struct {
+	// Platform is the KMS platform type: "AWS_KMS", "GCP_CLOUD_KMS", or "UNKNOWN_KEY_TYPE"
+	Platform string
+
+	// RequiresCredentialsSecret indicates if cmekCredentialsSecretName is required
+	// True for AWS_KMS and GCP_KMS, false for UNKNOWN_KEY_TYPE (file-based)
+	RequiresCredentialsSecret bool
+
+	// DefaultCredentialsSecretName is the default name for the credentials secret
+	// Used when RequiresCredentialsSecret is true
+	DefaultCredentialsSecretName string
+}
+
+// Provider defines the encryption-related methods that cloud providers must implement
+// for encryption-at-rest testing. Providers return configuration, not implementation.
+type Provider interface {
+	// SetupEncryptionInfrastructure creates cloud KMS resources (keys, roles, policies)
+	// Returns a cleanup function that should be deferred to ensure proper resource cleanup
+	// Called once during test setup, before any encryption secrets are created
+	SetupEncryptionInfrastructure(t *testing.T) (cleanup func(), err error)
+
+	// GetEncryptionPlatformConfig returns provider-specific encryption platform configuration
+	GetEncryptionPlatformConfig() *PlatformConfig
+
+	// ─── CMEK Encryption Methods ─────────────────────────────────────────────────
+	// The following methods are only called for cloud KMS providers (AWS_KMS, GCP_CLOUD_KMS).
+	// File-based providers (UNKNOWN_KEY_TYPE) should return errors indicating lack of support.
+
+	// EncryptKey encrypts a plaintext key using the provider's KMS
+	// Takes raw key bytes, returns base64-encoded encrypted data
+	EncryptKey(plaintextKey []byte, clusterRegion string) (encryptedKeyBase64 string, err error)
+
+	// CreateKeySecret creates the Kubernetes secret with encrypted key data and provider metadata
+	// (AuthPrincipal, URI, Region, Type, ExternalID, etc.)
+	CreateKeySecret(kubectlOptions *k8s.KubectlOptions, secretName string, encryptedKeyData string, clusterRegion string) error
+
+	// CreateCredentialsSecret creates the Kubernetes secret with cloud credentials
+	// Returns the secret name and any error
+	CreateCredentialsSecret(kubectlOptions *k8s.KubectlOptions) (string, error)
+}
+
+// GenerateAndEncodeEncryptionKey generates a 256-bit AES encryption key and returns both
+// the raw bytes and base64-encoded string. This is a utility function for providers using
+// UNKNOWN_KEY_TYPE (file-based encryption) to generate and encode keys consistently.
+func GenerateAndEncodeEncryptionKey(t *testing.T) (rawKey []byte, base64Key string) {
+	tempDir := t.TempDir()
+	keyPath := filepath.Join(tempDir, "store.key")
+
+	// Generate 256-bit AES key using cockroach gen encryption-key
+	cmd := shell.Command{
+		Command:    "cockroach",
+		Args:       []string{"gen", "encryption-key", "--size", "256", "store.key"},
+		WorkingDir: tempDir,
+	}
+
+	_, err := shell.RunCommandAndGetOutputE(t, cmd)
+	require.NoError(t, err, "Failed to generate encryption key")
+
+	// Read the generated key file
+	keyBytes, err := os.ReadFile(keyPath)
+	require.NoError(t, err, "Failed to read encryption key file")
+
+	// Base64 encode the key (removing any newlines)
+	base64Encoded := base64.StdEncoding.EncodeToString(keyBytes)
+	base64Encoded = strings.ReplaceAll(base64Encoded, "\n", "")
+
+	return keyBytes, base64Encoded
+}
+
+// SetupEncryptionSecrets is the generic function that sets up encryption secrets using the provider's configuration.
+// It determines whether to use CMEK or file-based encryption by checking the platform type.
+func SetupEncryptionSecrets(t *testing.T, provider Provider, kubectlOptions *k8s.KubectlOptions, clusterRegion string) error {
+	platformConfig := provider.GetEncryptionPlatformConfig()
+
+	if platformConfig.Platform == "UNKNOWN_KEY_TYPE" {
+		// File-based encryption (local providers)
+		return SetupFileBasedEncryptionSecrets(t, kubectlOptions, platformConfig.Platform)
+	}
+
+	// CMEK-based encryption (AWS_KMS, GCP_CLOUD_KMS)
+	return setupCMEKEncryptionSecrets(t, provider, kubectlOptions, clusterRegion)
+}
+
+// setupCMEKEncryptionSecrets is a helper for cloud KMS envelope encryption.
+// It implements the common pattern: generate key → encrypt with KMS → create secrets.
+// Used internally by SetupEncryptionSecrets for CMEK providers.
+func setupCMEKEncryptionSecrets(
+	t *testing.T,
+	provider Provider,
+	kubectlOptions *k8s.KubectlOptions,
+	clusterRegion string,
+) error {
+	platformConfig := provider.GetEncryptionPlatformConfig()
+	t.Logf("Setting up KMS envelope encryption for cluster %s (platform: %s)", clusterRegion, platformConfig.Platform)
+
+	// 1. Generate plaintext data encryption key (DEK)
+	plaintextKey, _ := GenerateAndEncodeEncryptionKey(t)
+
+	// 2. Encrypt the DEK using cloud KMS
+	encryptedKey, err := provider.EncryptKey(plaintextKey, clusterRegion)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt store key with KMS: %w", err)
+	}
+
+	// 3. Create encryption secret with KMS-encrypted key and metadata
+	secretName := "cmek-key-secret"
+	if err := provider.CreateKeySecret(kubectlOptions, secretName, encryptedKey, clusterRegion); err != nil {
+		return fmt.Errorf("failed to create encryption key secret: %w", err)
+	}
+
+	// 4. Create credentials secret for cloud authentication
+	credentialsSecretName, err := provider.CreateCredentialsSecret(kubectlOptions)
+	if err != nil {
+		return fmt.Errorf("failed to create credentials secret: %w", err)
+	}
+	t.Logf("Created credentials secret %s for KMS authentication", credentialsSecretName)
+
+	return nil
+}
+
+// SetupFileBasedEncryptionSecrets is a utility function for providers using UNKNOWN_KEY_TYPE
+// (file-based encryption). It generates a key, creates the Kubernetes secret, and verifies it.
+// This is the common implementation for Local and GCP providers (when not using cloud KMS).
+func SetupFileBasedEncryptionSecrets(t *testing.T, kubectlOptions *k8s.KubectlOptions, providerName string) error {
+	t.Logf("%s provider: Setting up file-based encryption secrets", providerName)
+
+	// Generate and encode encryption key
+	_, base64Key := GenerateAndEncodeEncryptionKey(t)
+	t.Logf("Generated encryption key (base64 length: %d)", len(base64Key))
+
+	// Create Kubernetes secret with base64-encoded key
+	// Use default secret name for file-based encryption
+	secretName := "cmek-key-secret"
+
+	err := k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", secretName,
+		fmt.Sprintf("--from-literal=StoreKeyData=%s", base64Key))
+	if err != nil {
+		return fmt.Errorf("failed to create encryption key secret: %w", err)
+	}
+
+	// Verify secret was created with data
+	secretSize, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"get", "secret", secretName,
+		"-o", "jsonpath={.data.StoreKeyData}")
+	if err != nil {
+		return fmt.Errorf("failed to verify encryption secret: %w", err)
+	}
+	if len(secretSize) == 0 {
+		return fmt.Errorf("encryption secret StoreKeyData is empty")
+	}
+
+	t.Logf("Created encryption secret %s with key data (%d bytes)", secretName, len(secretSize))
+
+	// No credentials secret needed for file-based encryption (UNKNOWN_KEY_TYPE)
+	return nil
+}

--- a/tests/e2e/operator/infra/gcp.go
+++ b/tests/e2e/operator/infra/gcp.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
 	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/encryption"
 )
 
 // ─── GCP CONSTANTS ───────────────────────────────────────────────────────────────
@@ -316,6 +317,55 @@ func (r *GcpRegion) ScaleNodePool(t *testing.T, location string, nodeCount, inde
 
 func (r *GcpRegion) CanScale() bool {
 	return false
+}
+
+// ─── Encryption At Rest Methods ─────────────────────────────────────────────────
+
+// GetEncryptionProvider returns the GCP provider itself as it implements encryption.Provider
+func (r *GcpRegion) GetEncryptionProvider() encryption.Provider {
+	return r
+}
+
+// SetupEncryptionInfrastructure is simplified for GCP (uses file-based encryption for now)
+// TODO: Implement full GCP Cloud KMS support similar to AWS
+// Returns a no-op cleanup function
+func (r *GcpRegion) SetupEncryptionInfrastructure(t *testing.T) (func(), error) {
+	t.Log("GCP provider: Using file-based encryption (UNKNOWN_KEY_TYPE)")
+	t.Log("TODO: Implement full GCP Cloud KMS support for production use")
+	// Return no-op cleanup function
+	return func() {
+		t.Log("GCP provider: No KMS infrastructure to clean up")
+	}, nil
+}
+
+// GetEncryptionPlatformConfig returns GCP-specific encryption platform configuration
+// Currently uses UNKNOWN_KEY_TYPE (file-based) - can be extended to GCP_CLOUD_KMS
+func (r *GcpRegion) GetEncryptionPlatformConfig() *encryption.PlatformConfig {
+	// TODO: Switch to GCP_CLOUD_KMS and implement full KMS support
+	return &encryption.PlatformConfig{
+		Platform:                     "UNKNOWN_KEY_TYPE",
+		RequiresCredentialsSecret:    false,
+		DefaultCredentialsSecretName: "",
+	}
+}
+
+// ─── CMEK Methods (Not Yet Implemented for GCP) ────────────────────────────────
+// These methods are part of the encryption.Provider interface but not yet implemented for GCP
+// TODO: Implement full GCP Cloud KMS support for these methods
+
+// EncryptKey is not yet implemented for GCP (currently uses file-based encryption)
+func (r *GcpRegion) EncryptKey(plaintextKey []byte, clusterRegion string) (string, error) {
+	return "", fmt.Errorf("EncryptKey not yet implemented for GCP - currently using file-based encryption (UNKNOWN_KEY_TYPE)")
+}
+
+// CreateKeySecret is not yet implemented for GCP (currently uses file-based encryption)
+func (r *GcpRegion) CreateKeySecret(kubectlOptions *k8s.KubectlOptions, secretName string, encryptedKeyData string, clusterRegion string) error {
+	return fmt.Errorf("CreateKeySecret not yet implemented for GCP - currently using file-based encryption (UNKNOWN_KEY_TYPE)")
+}
+
+// CreateCredentialsSecret is not yet implemented for GCP (currently uses file-based encryption)
+func (r *GcpRegion) CreateCredentialsSecret(kubectlOptions *k8s.KubectlOptions) (string, error) {
+	return "", fmt.Errorf("CreateCredentialsSecret not yet implemented for GCP - currently using file-based encryption (UNKNOWN_KEY_TYPE)")
 }
 
 // createGKEClusters handles the complex logic of creating GKE clusters in parallel.

--- a/tests/e2e/operator/infra/local.go
+++ b/tests/e2e/operator/infra/local.go
@@ -9,10 +9,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/helm-charts/tests/e2e/calico"
-	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
-	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
-	"github.com/cockroachdb/helm-charts/tests/testutil"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/shell"
@@ -23,6 +19,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/calico"
+	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/encryption"
+	"github.com/cockroachdb/helm-charts/tests/testutil"
 )
 
 // LocalRegion implements CloudProvider for local Kubernetes providers (K3d and Kind)
@@ -32,9 +34,10 @@ type LocalRegion struct {
 	ProviderType string
 }
 
-// SetUpInfra Creates local k3d and kind clusters, deploy CNI, deploy coredns in each cluster.
+// SetUpInfra Creates local k3d and kind clusters, deploy CNI, and optionally deploy coredns for multi-cluster.
 //
-// Multi-region networking approach:
+// Single-cluster: Uses cluster's default DNS, no MetalLB, no custom CoreDNS.
+// Multi-cluster networking approach:
 //   - K3D: Calico CNI with BGP for cross-cluster pod routing, built-in ServiceLB for LBs.
 //   - Kind: default kindnet for in-cluster, Calico objects + BGP peering to advertise
 //     pod/service CIDRs between clusters. MetalLB for CoreDNS LBs.
@@ -84,96 +87,104 @@ func (r *LocalRegion) SetUpInfra(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		// For Kind, install MetalLB before creating LoadBalancer services
-		// Calico+BGP provides pod routing; MetalLB provides external LB IPs when needed
-		if r.ProviderType == ProviderKind {
+		// For Kind multi-cluster, install MetalLB before creating LoadBalancer services
+		// Calico+BGP provides pod routing; MetalLB provides external LB IPs for cross-cluster communication
+		// Single-cluster setups don't need MetalLB as there's no cross-cluster networking
+		if r.ProviderType == ProviderKind && len(r.Clusters) > 1 {
 			// Install MetalLB with Docker network IPs
 			err = r.installMetalLBWithDockerIPs(t, kubectlOptions, i)
 			require.NoError(t, err)
 		}
 
-		// Create or update CoreDNS deployment.
-		deployment := coredns.CoreDNSDeployment(coreDNSReplicas)
-		// Apply deployment.
-		deploymentYaml := coredns.ToYAML(t, deployment)
-		err = k8s.KubectlApplyFromStringE(t, kubectlOptions, deploymentYaml)
-		require.NoError(t, err)
+		// CoreDNS is only needed for multi-cluster setups to enable cross-cluster DNS resolution
+		// Single-cluster deployments use the cluster's default DNS (CoreDNS or kube-dns)
+		if len(r.Clusters) > 1 {
+			// Create or update CoreDNS deployment.
+			deployment := coredns.CoreDNSDeployment(coreDNSReplicas)
+			// Apply deployment.
+			deploymentYaml := coredns.ToYAML(t, deployment)
+			err = k8s.KubectlApplyFromStringE(t, kubectlOptions, deploymentYaml)
+			require.NoError(t, err)
 
-		// Wait for deployment to be ready.
-		_, err = retry.DoWithRetryE(t, "waiting for coredns deployment",
-			defaultRetries, defaultRetryInterval,
-			func() (string, error) {
-				return k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
-					"wait", "--for=condition=Available", fmt.Sprintf("deployment/%s", coreDNSDeploymentName))
-			})
-		require.NoError(t, err)
+			// Wait for deployment to be ready.
+			_, err = retry.DoWithRetryE(t, "waiting for coredns deployment",
+				defaultRetries, defaultRetryInterval,
+				func() (string, error) {
+					return k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+						"wait", "--for=condition=Available", fmt.Sprintf("deployment/%s", coreDNSDeploymentName))
+				})
+			require.NoError(t, err)
 
-		// Create a CoreDNS service.
-		service := coredns.CoreDNSService(nil, GetLoadBalancerAnnotations(r.ProviderType))
-		serviceYaml := coredns.ToYAML(t, service)
-		// Apply service.
-		err = k8s.KubectlApplyFromStringE(t, kubectlOptions, serviceYaml)
-		require.NoError(t, err)
+			// Create a CoreDNS service.
+			service := coredns.CoreDNSService(nil, GetLoadBalancerAnnotations(r.ProviderType))
+			serviceYaml := coredns.ToYAML(t, service)
+			// Apply service.
+			err = k8s.KubectlApplyFromStringE(t, kubectlOptions, serviceYaml)
+			require.NoError(t, err)
 
-		// Now get the DNS IPs.
-		ips, err := WaitForCoreDNSServiceIPs(t, kubectlOptions)
-		require.NoError(t, err)
+			// Now get the DNS IPs.
+			ips, err := WaitForCoreDNSServiceIPs(t, kubectlOptions)
+			require.NoError(t, err)
 
-		r.CorednsClusterOptions[operator.CustomDomains[i]] = coredns.CoreDNSClusterOption{
-			IPs:       ips,
-			Namespace: r.Namespace[cluster],
-			Domain:    operator.CustomDomains[i],
-		}
-		if !r.IsMultiRegion {
-			break
+			r.CorednsClusterOptions[operator.CustomDomains[i]] = coredns.CoreDNSClusterOption{
+				IPs:       ips,
+				Namespace: r.Namespace[cluster],
+				Domain:    operator.CustomDomains[i],
+			}
+		} else {
+			t.Logf("[%s] Skipping CoreDNS setup for single-cluster deployment", r.ProviderType)
 		}
 	}
 
-	// Update Coredns config.
-	for i, cluster := range r.Clusters {
-		// Create or update CoreDNS configmap.
-		kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, coreDNSNamespace)
-		cm := coredns.CoreDNSConfigMap(operator.CustomDomains[i], r.CorednsClusterOptions)
+	// Update Coredns config (only for multi-cluster).
+	if len(r.Clusters) > 1 {
+		for i, cluster := range r.Clusters {
+			// Create or update CoreDNS configmap.
+			kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, coreDNSNamespace)
+			cm := coredns.CoreDNSConfigMap(operator.CustomDomains[i], r.CorednsClusterOptions)
 
-		// Apply the updated ConfigMap to Kubernetes.
-		cmYaml := coredns.ToYAML(t, cm)
-		err := k8s.KubectlApplyFromStringE(t, kubectlOptions, cmYaml)
-		require.NoError(t, err)
+			// Apply the updated ConfigMap to Kubernetes.
+			cmYaml := coredns.ToYAML(t, cm)
+			err := k8s.KubectlApplyFromStringE(t, kubectlOptions, cmYaml)
+			require.NoError(t, err)
 
-		// restart coredns pods.
-		err = k8s.RunKubectlE(t, kubectlOptions, "rollout", "restart", "deployment", coreDNSDeploymentName)
-		require.NoError(t, err)
-		if !r.IsMultiRegion {
-			r.Clients = clients
-			r.ReusingInfra = true
-			return
+			// restart coredns pods.
+			err = k8s.RunKubectlE(t, kubectlOptions, "rollout", "restart", "deployment", coreDNSDeploymentName)
+			require.NoError(t, err)
 		}
 	}
 	r.Clients = clients
 	r.ReusingInfra = true
 
-	netConfig := calico.K3dCalicoBGPPeeringOptions{
-		ClusterConfig: map[string]calico.K3dClusterBGPConfig{},
-	}
-
-	// Update network config for each region.
-	for i, region := range r.RegionCodes {
-		rawConfig.CurrentContext = r.Clusters[i]
-		kubectlOptions := k8s.NewKubectlOptions(r.Clusters[i], kubeConfig, coreDNSNamespace)
-		err := r.setupNetworking(t, context.TODO(), region, netConfig, kubectlOptions, i)
-		if err != nil {
-			t.Logf("[%s] Failed to setup networking for region %s: %v", r.ProviderType, region, err)
+	// Setup cross-cluster networking only for multi-region deployments
+	// Single-region deployments don't need BGP peering between clusters
+	if len(r.Clusters) > 1 {
+		netConfig := calico.K3dCalicoBGPPeeringOptions{
+			ClusterConfig: map[string]calico.K3dClusterBGPConfig{},
 		}
-	}
 
-	objectsByRegion := calico.K3dCalicoBGPPeeringObjects(netConfig)
-	// Apply all the objects for each region on to the cluster.
-	for i, region := range r.RegionCodes {
-		ctl := clients[r.Clusters[i]]
-		for _, obj := range objectsByRegion[region] {
-			err := ctl.Create(context.Background(), obj)
-			require.NoError(t, err)
+		// Update network config for each region.
+		for i, region := range r.RegionCodes {
+			rawConfig.CurrentContext = r.Clusters[i]
+			kubectlOptions := k8s.NewKubectlOptions(r.Clusters[i], kubeConfig, coreDNSNamespace)
+			err := r.setupNetworking(t, context.TODO(), region, netConfig, kubectlOptions, i)
+			if err != nil {
+				t.Logf("[%s] Failed to setup networking for region %s: %v", r.ProviderType, region, err)
+			}
 		}
+
+		objectsByRegion := calico.K3dCalicoBGPPeeringObjects(netConfig)
+		// Apply all the objects for each region on to the cluster.
+		for i, region := range r.RegionCodes {
+			ctl := clients[r.Clusters[i]]
+			for _, obj := range objectsByRegion[region] {
+				err := ctl.Create(context.Background(), obj)
+				require.NoError(t, err)
+			}
+		}
+		t.Logf("[%s] Multi-region networking setup complete for %d clusters", r.ProviderType, len(r.Clusters))
+	} else {
+		t.Logf("[%s] Single-region setup - skipping cross-cluster networking", r.ProviderType)
 	}
 }
 
@@ -221,6 +232,50 @@ func (r *LocalRegion) ScaleNodePool(t *testing.T, location string, nodeCount, in
 
 func (r *LocalRegion) CanScale() bool {
 	return false
+}
+
+// ─── Encryption At Rest Methods ─────────────────────────────────────────────────
+
+// GetEncryptionProvider returns the local provider itself as it implements encryption.Provider
+func (r *LocalRegion) GetEncryptionProvider() encryption.Provider {
+	return r
+}
+
+// SetupEncryptionInfrastructure is a no-op for local providers (file-based encryption)
+// Returns a no-op cleanup function
+func (r *LocalRegion) SetupEncryptionInfrastructure(t *testing.T) (func(), error) {
+	t.Log("Local provider: No KMS infrastructure needed for file-based encryption (UNKNOWN_KEY_TYPE)")
+	// Return no-op cleanup function
+	return func() {
+		t.Log("Local provider: No KMS infrastructure to clean up")
+	}, nil
+}
+
+// GetEncryptionPlatformConfig returns file-based encryption platform configuration for local providers
+func (r *LocalRegion) GetEncryptionPlatformConfig() *encryption.PlatformConfig {
+	return &encryption.PlatformConfig{
+		Platform:                     "UNKNOWN_KEY_TYPE",
+		RequiresCredentialsSecret:    false,
+		DefaultCredentialsSecretName: "", // Not needed for file-based encryption
+	}
+}
+
+// ─── CMEK Methods (Not Used for File-Based Encryption) ─────────────────────────
+// These methods are part of the encryption.Provider interface but not used for UNKNOWN_KEY_TYPE
+
+// EncryptKey is not used for local providers (file-based encryption)
+func (r *LocalRegion) EncryptKey(plaintextKey []byte, clusterRegion string) (string, error) {
+	return "", fmt.Errorf("EncryptKey not supported for file-based encryption (UNKNOWN_KEY_TYPE)")
+}
+
+// CreateKeySecret is not used for local providers (file-based encryption)
+func (r *LocalRegion) CreateKeySecret(kubectlOptions *k8s.KubectlOptions, secretName string, encryptedKeyData string, clusterRegion string) error {
+	return fmt.Errorf("CreateKeySecret not supported for file-based encryption (UNKNOWN_KEY_TYPE)")
+}
+
+// CreateCredentialsSecret is not used for local providers (file-based encryption)
+func (r *LocalRegion) CreateCredentialsSecret(kubectlOptions *k8s.KubectlOptions) (string, error) {
+	return "", fmt.Errorf("CreateCredentialsSecret not supported for file-based encryption (UNKNOWN_KEY_TYPE)")
 }
 
 // setupNetworking ensures there is cross-cluster network connectivity and

--- a/tests/e2e/operator/infra/provider.go
+++ b/tests/e2e/operator/infra/provider.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/encryption"
 )
 
 // CloudProvider defines the interface that all cloud providers must implement
@@ -22,24 +23,38 @@ type CloudProvider interface {
 
 	// CanScale checks if the provider supports scaling.
 	CanScale() bool
+
+	// GetEncryptionProvider returns an encryption.Provider implementation for this cloud provider.
+	// The provider can return itself since CloudProvider implementations also implement encryption.Provider.
+	// All encryption-related operations are accessed through the returned encryption.Provider interface.
+	GetEncryptionProvider() encryption.Provider
 }
 
 // ProviderFactory creates a CloudProvider instance for the given provider type.
+// It also automatically sets the encryption provider on the region so it's available for advanced installs.
 func ProviderFactory(providerType string, region *operator.Region) CloudProvider {
+	var cloudProvider CloudProvider
+
 	switch providerType {
 	case ProviderK3D:
 		provider := LocalRegion{Region: region, ProviderType: ProviderK3D}
 		provider.RegionCodes = GetRegionCodes(providerType)
-		return &provider
+		cloudProvider = &provider
 	case ProviderKind:
 		provider := LocalRegion{Region: region, ProviderType: ProviderKind}
 		provider.RegionCodes = GetRegionCodes(providerType)
-		return &provider
+		cloudProvider = &provider
 	case ProviderGCP:
 		provider := GcpRegion{Region: region}
 		provider.RegionCodes = GetRegionCodes(providerType)
-		return &provider
+		cloudProvider = &provider
 	default:
 		return nil
 	}
+
+	// Automatically set the encryption provider on the region
+	// This makes it available for encryption-enabled advanced installs
+	region.SetEncryptionProvider(cloudProvider.GetEncryptionProvider())
+
+	return cloudProvider
 }

--- a/tests/e2e/operator/multiRegion/cockroachdb_multi_region_advanced_features_test.go
+++ b/tests/e2e/operator/multiRegion/cockroachdb_multi_region_advanced_features_test.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
 )
 
 // TestWALFailoverMultiRegion tests WAL failover with different paths in each region
@@ -75,42 +76,26 @@ func (r *multiRegion) TestWALFailoverMultiRegion(t *testing.T) {
 	t.Logf("WAL failover multi-region test completed successfully")
 }
 
-// TestEncryptionAtRestMultiRegion tests encryption at rest with different secrets per region
-// Region 0: Encryption enabled with secret "cmek-key-secret-region-0"
+// TestEncryptionAtRestMultiRegion tests encryption at rest with different configurations per region
+// Region 0: Encryption enabled with the default secret "cmek-key-secret"
 // Region 1: Encryption disabled (no encryption)
+// Each region has its own namespace, so using the same secret name is safe.
 func (r *multiRegion) TestEncryptionAtRestMultiRegion(t *testing.T) {
 	// Setup namespaces and CA for each region
 	cleanup := r.SetupMultiClusterWithCA(t)
 	defer cleanup()
 
-	// Generate encryption key for region 0
-	encryptionKeyB64 := r.GenerateEncryptionKey(t)
-	t.Logf("Generated encryption key for region 0 (base64 length: %d)", len(encryptionKeyB64))
-
 	// Region 0: Install with encryption at rest enabled
 	cluster0 := r.Clusters[0]
-	secretName0 := "cmek-key-secret-region-0"
 
-	encryptionRegions0 := []map[string]interface{}{
-		{
-			"code":          r.RegionCodes[0],
-			"cloudProvider": r.Provider,
-			"nodes":         r.NodeCount,
-			"namespace":     r.Namespace[cluster0],
-			"domain":        operator.CustomDomains[0],
-			"encryptionAtRest": map[string]interface{}{
-				"platform":      "UNKNOWN_KEY_TYPE",
-				"keySecretName": secretName0,
-			},
-		},
-	}
+	// Use BuildEncryptionRegions to ensure consistency with single-region tests
+	// This uses the default secret name "cmek-key-secret" and gets platform config from provider
+	encryptionRegions0 := r.BuildEncryptionRegions(cluster0, 0, nil)
 
 	t.Logf("Installing region 0 (%s) with encryption at rest enabled", cluster0)
 	config0 := operator.AdvancedInstallConfig{
-		EncryptionEnabled:       true,
-		EncryptionKeySecret:     encryptionKeyB64,
-		EncryptionKeySecretName: secretName0,
-		CustomRegions:           encryptionRegions0,
+		EncryptionEnabled: true,
+		CustomRegions:     encryptionRegions0,
 	}
 	r.InstallChartsWithAdvancedConfig(t, cluster0, 0, config0)
 
@@ -129,12 +114,9 @@ func (r *multiRegion) TestEncryptionAtRestMultiRegion(t *testing.T) {
 	r.ValidateMultiRegionSetup(t)
 
 	// Validate encryption in region 0
-	t.Log("Validating encryption at rest in region 0")
-	r.ValidateEncryptionAtRest(t, cluster0, &operator.AdvancedValidationConfig{
-		EncryptionAtRest: operator.EncryptionAtRestValidation{
-			SecretName: secretName0,
-		},
-	})
+	// Use nil config to rely on default secret name "cmek-key-secret"
+	t.Log("Validating encryption at rest in region 0...")
+	r.ValidateEncryptionAtRest(t, cluster0, nil)
 
 	// Validate NO encryption in region 1
 	t.Log("Validating NO encryption at rest in region 1")

--- a/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
+++ b/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
@@ -7,20 +7,21 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
-	"github.com/cockroachdb/helm-charts/tests/e2e/operator/infra"
-	"github.com/cockroachdb/helm-charts/tests/testutil"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/infra"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/utils"
+	"github.com/cockroachdb/helm-charts/tests/testutil"
 )
 
 // Region codes for each provider are now centralized in infra.RegionCodes
 type multiRegion struct {
-	operator.OperatorUseCases
 	operator.Region
 }
 
@@ -28,44 +29,50 @@ func newMultiRegion() *multiRegion {
 	return &multiRegion{}
 }
 
+// mapProviderToInfra maps utils package provider constants to infra package constants.
+// This avoids import cycles while allowing centralized provider parsing.
+func mapProviderToInfra(provider string) string {
+	switch provider {
+	case utils.ProviderK3D:
+		return infra.ProviderK3D
+	case utils.ProviderKind:
+		return infra.ProviderKind
+	case utils.ProviderGCP:
+		return infra.ProviderGCP
+	default:
+		return provider
+	}
+}
+
 // TestOperatorInMultiRegion tests CockroachDB operator functionality across multiple regions
 func TestOperatorInMultiRegion(t *testing.T) {
-	// Fetch provider from env
-	var provider string
-	if p := strings.TrimSpace(strings.ToLower(os.Getenv("PROVIDER"))); p != "" {
-		switch p {
-		case "kind":
-			provider = infra.ProviderKind
-		case "gcp":
-			provider = infra.ProviderGCP
-		default:
-			t.Fatalf("Unsupported provider override: %s", p)
-		}
-	} else {
-		provider = infra.ProviderK3D
+	// Fetch provider from env using centralized utility
+	provider, err := utils.GetProviderFromEnv()
+	if err != nil {
+		t.Fatalf("Failed to get provider: %v", err)
 	}
 
-	t.Run(provider, func(t *testing.T) {
+	// Map utils provider constants to infra provider constants
+	infraProvider := mapProviderToInfra(provider)
+
+	t.Run(infraProvider, func(t *testing.T) {
 		t.Parallel()
 
 		// Create a provider-specific instance to avoid race conditions.
 		providerRegion := newMultiRegion()
 		providerRegion.Region = operator.Region{
-			IsMultiRegion: true,
-			NodeCount:     3,
-			ReusingInfra:  false,
+			NodeCount:    3,
+			ReusingInfra: false,
 		}
 		providerRegion.Clients = make(map[string]client.Client)
 		providerRegion.Namespace = make(map[string]string)
 
-		providerRegion.Provider = provider
-		for _, cluster := range operator.Clusters {
-			clusterName := fmt.Sprintf("%s-%s", providerRegion.Provider, cluster)
-			if providerRegion.Provider != infra.ProviderK3D && provider != infra.ProviderKind {
-				clusterName = fmt.Sprintf("%s-%s", clusterName, strings.ToLower(random.UniqueId()))
-			}
-			providerRegion.Clusters = append(providerRegion.Clusters, clusterName)
-		}
+		providerRegion.Provider = infraProvider
+
+		// Generate cluster names with better context (PR number or username)
+		// Multi-region needs 2 clusters
+		clusterNames := utils.GenerateClusterNames(provider, len(operator.Clusters))
+		providerRegion.Clusters = clusterNames
 
 		// Create and reuse the same provider instance for both setup and teardown.
 		cloudProvider := infra.ProviderFactory(providerRegion.Provider, &providerRegion.Region)

--- a/tests/e2e/operator/region.go
+++ b/tests/e2e/operator/region.go
@@ -1,7 +1,6 @@
 package operator
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -10,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
-	"github.com/cockroachdb/helm-charts/tests/testutil"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
@@ -23,6 +20,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/encryption"
+	"github.com/cockroachdb/helm-charts/tests/testutil"
 )
 
 const (
@@ -56,21 +57,9 @@ var (
 	}
 )
 
-// OperatorUseCases defines use cases for the CockroachDB cluster.
-type OperatorUseCases interface {
-	TestHelmInstall(t *testing.T)
-	TestHelmUpgrade(t *testing.T)
-	TestClusterScaleUp(t *testing.T)
-	TestClusterRollingRestart(t *testing.T)
-	TestKillingCockroachNode(t *testing.T)
-	TestInstallWithCertManager(t *testing.T)
-}
-
 type Region struct {
 	// IsCertManager is true if the cockroachdb cluster is using cert-manager.
 	IsCertManager bool
-	// IsMultiRegion is true if the region is multi-region.
-	IsMultiRegion bool
 	// NodeCount is the desired CockroachDB nodes in the region.
 	NodeCount int
 	// Namespace stores mapping between cluster name and namespace.
@@ -90,6 +79,27 @@ type Region struct {
 	// OperatorNamespace tracks the namespace in which the operator was installed,
 	// keyed by cluster name.
 	OperatorNamespace map[string]string
+
+	// Encryption infrastructure tracking
+	encryptionProvider       encryption.Provider
+	encryptionInfraSetup     bool
+	encryptionCleanupFunc    func()
+	encryptionPlatformConfig *encryption.PlatformConfig
+	encryptionCredSecretName string
+}
+
+// SetEncryptionProvider sets the encryption provider for this region.
+// This should be called by the infrastructure setup code with the provider's GetEncryptionProvider() result.
+func (r *Region) SetEncryptionProvider(provider encryption.Provider) {
+	r.encryptionProvider = provider
+}
+
+// CleanupEncryptionInfra calls the stored encryption cleanup function
+// Call this in test cleanup/defer to clean up KMS resources
+func (r *Region) CleanupEncryptionInfra() {
+	if r.encryptionCleanupFunc != nil {
+		r.encryptionCleanupFunc()
+	}
 }
 
 // InstallCharts Installs both Operator and CockroachDB charts by providing custom CA secret
@@ -138,7 +148,7 @@ func (r *Region) InstallCharts(t *testing.T, cluster string, index int) {
 
 	if r.IsCertManager {
 		crdbOp = PatchHelmValues(map[string]string{
-			"cockroachdb.clusterDomain":               CustomDomains[index],
+			"cockroachdb.clusterDomain":               r.GetClusterDomain(index),
 			"cockroachdb.tls.enabled":                 "true",
 			"cockroachdb.tls.selfSigner.enabled":      "false",
 			"cockroachdb.tls.certManager.enabled":     "true",
@@ -147,7 +157,7 @@ func (r *Region) InstallCharts(t *testing.T, cluster string, index int) {
 		})
 	} else {
 		crdbOp = PatchHelmValues(map[string]string{
-			"cockroachdb.clusterDomain":             CustomDomains[index],
+			"cockroachdb.clusterDomain":             r.GetClusterDomain(index),
 			"cockroachdb.tls.enabled":               "true",
 			"cockroachdb.tls.selfSigner.caProvided": "true",
 			"cockroachdb.tls.selfSigner.caSecret":   customCASecret,
@@ -357,6 +367,10 @@ func (r *Region) ValidateCRDBContainerResources(t *testing.T, kubectlOptions *k8
 
 // CreateCACertificate creates CA cert and key at the same path.
 func (r *Region) CreateCACertificate(t *testing.T) error {
+	// Clean up any existing CA files first to ensure a fresh start
+	// This handles cases where previous test runs were interrupted or failed cleanup
+	r.CleanUpCACertificate(t)
+
 	// Create CA secret in all regions.
 	cmd := shell.Command{
 		Command:    "cockroach",
@@ -464,7 +478,7 @@ func (r *Region) CleanupResources(t *testing.T) {
 // OperatorRegions returns the regions config based on the index
 // which is referring to cluster index.
 func (r *Region) OperatorRegions(index int, nodes int) []map[string]interface{} {
-	return r.createOperatorRegions(index, nodes, CustomDomains)
+	return r.createOperatorRegions(index, nodes)
 }
 
 func HelmChartPaths() (helmChartPath string, operatorChartPath string) {
@@ -479,18 +493,14 @@ func HelmChartPaths() (helmChartPath string, operatorChartPath string) {
 // required while installing CockroachDb charts.
 // Other clusters' regions are listed first so their join addresses are tried
 // before the current cluster's, allowing it to join the existing cluster immediately.
-func (r *Region) createOperatorRegions(index int, nodes int, customDomains map[int]string) []map[string]interface{} {
+func (r *Region) createOperatorRegions(index int, nodes int) []map[string]interface{} {
 	buildRegion := func(i int) map[string]interface{} {
 		region := map[string]interface{}{
 			"code":          r.RegionCodes[i],
 			"cloudProvider": r.Provider,
 			"nodes":         nodes,
 			"namespace":     r.Namespace[r.Clusters[i]],
-		}
-		if len(r.Clusters) > i && r.Clusters[i] != "" {
-			if domain, ok := customDomains[i]; ok {
-				region["domain"] = domain
-			}
+			"domain":        r.GetClusterDomain(i),
 		}
 		return region
 	}
@@ -774,6 +784,21 @@ func (r *Region) SetupMultiClusterWithCA(t *testing.T) func() {
 	}
 }
 
+// GetClusterDomain returns the appropriate cluster domain for the given index.
+// For single-cluster setups, returns "cluster.local" (default Kubernetes domain).
+// For multi-cluster setups, returns CustomDomains[index] (e.g., "cluster1.local", "cluster2.local").
+func (r *Region) GetClusterDomain(index int) string {
+	// For single-cluster setups, use the default Kubernetes cluster domain.
+	// CustomDomains (cluster1.local, cluster2.local) are only for multi-cluster with custom CoreDNS.
+	if len(r.Clusters) == 1 {
+		return "cluster.local"
+	}
+	if domain, ok := CustomDomains[index]; ok {
+		return domain
+	}
+	return "cluster.local" // fallback to default
+}
+
 // BaseRegionConfig returns a baseline region configuration map for the provided cluster and index.
 func (r *Region) BaseRegionConfig(cluster string, index int) map[string]interface{} {
 	code := fmt.Sprintf("region-%d", index)
@@ -785,9 +810,7 @@ func (r *Region) BaseRegionConfig(cluster string, index int) map[string]interfac
 		"cloudProvider": r.Provider,
 		"nodes":         r.NodeCount,
 		"namespace":     r.Namespace[cluster],
-	}
-	if domain, ok := CustomDomains[index]; ok {
-		region["domain"] = domain
+		"domain":        r.GetClusterDomain(index),
 	}
 	return region
 }
@@ -800,10 +823,30 @@ func (r *Region) EncryptionAtRestConfig(secretName string, overrides map[string]
 	if secretName == "" {
 		secretName = DefaultEncryptionSecret
 	}
+
+	// Get platform configuration from the encryption provider if available
+	platform := "UNKNOWN_KEY_TYPE"
+	var cmekCredentialsSecretName string
+	if r.encryptionProvider != nil {
+		platformConfig := r.encryptionProvider.GetEncryptionPlatformConfig()
+		if platformConfig != nil {
+			platform = platformConfig.Platform
+			if platformConfig.RequiresCredentialsSecret && platformConfig.DefaultCredentialsSecretName != "" {
+				cmekCredentialsSecretName = platformConfig.DefaultCredentialsSecretName
+			}
+		}
+	}
+
 	config := map[string]interface{}{
-		"platform":      "UNKNOWN_KEY_TYPE",
+		"platform":      platform,
 		"keySecretName": secretName,
 	}
+
+	// Add cmekCredentialsSecretName if required by the platform
+	if cmekCredentialsSecretName != "" {
+		config["cmekCredentialsSecretName"] = cmekCredentialsSecretName
+	}
+
 	for k, v := range overrides {
 		if v == nil || v == "" {
 			// Delete the key so it is omitted from JSON (nil pointer in operator = "plain").
@@ -829,9 +872,8 @@ type AdvancedInstallConfig struct {
 	WALFailoverSize    string
 
 	// Encryption at Rest configuration
-	EncryptionEnabled      bool
-	EncryptionKeySecret    string
-	EncryptionKeySecretName string // defaults to "cmek-key-secret" if empty
+	// Note: The encryption provider is automatically obtained from the CloudProvider via Region.SetEncryptionProvider()
+	EncryptionEnabled bool
 
 	// Virtual Cluster configuration (for PCR)
 	VirtualClusterMode string // "primary", "standby", or ""
@@ -870,27 +912,29 @@ func (r *Region) InstallChartsWithAdvancedConfig(t *testing.T, cluster string, i
 		"--from-file=ca.key")
 	require.NoError(t, err)
 
-	// Create encryption key secret if encryption is enabled
-	if config.EncryptionEnabled && config.EncryptionKeySecret != "" {
-		encryptionSecretName := config.EncryptionKeySecretName
-		if encryptionSecretName == "" {
-			encryptionSecretName = DefaultEncryptionSecret
+	// Setup encryption if enabled and provider is available
+	if config.EncryptionEnabled && r.encryptionProvider != nil {
+		// Setup encryption infrastructure once (creates KMS keys, IAM roles, etc.)
+		// This is called once and the cleanup function is stored for later cleanup
+		if !r.encryptionInfraSetup {
+			t.Log("Setting up encryption infrastructure (KMS keys, IAM roles, etc.)")
+			cleanup, err := r.encryptionProvider.SetupEncryptionInfrastructure(t)
+			require.NoError(t, err, "Failed to setup encryption infrastructure")
+			r.encryptionCleanupFunc = cleanup
+			r.encryptionInfraSetup = true
+			t.Log("Encryption infrastructure setup complete")
 		}
 
-		// Use --from-literal with the base64-encoded key string. Kubernetes base64-encodes
-		// secret values for storage, so the pod receives the original base64 string when
-		// the secret is mounted — which the init container then decodes to get the raw key.
-		err = k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", encryptionSecretName,
-			fmt.Sprintf("--from-literal=StoreKeyData=%s", config.EncryptionKeySecret))
-		require.NoError(t, err)
+		// Get platform configuration from provider
+		r.encryptionPlatformConfig = r.encryptionProvider.GetEncryptionPlatformConfig()
+		t.Logf("Using encryption platform: %s (requires credentials: %v)",
+			r.encryptionPlatformConfig.Platform, r.encryptionPlatformConfig.RequiresCredentialsSecret)
 
-		// Verify secret was created with data
-		secretSize, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
-			"get", "secret", encryptionSecretName,
-			"-o", "jsonpath={.data.StoreKeyData}")
-		require.NoError(t, err)
-		require.True(t, len(secretSize) > 0, "Secret StoreKeyData should be >0")
-		t.Logf("Created encryption secret %s with size: %d bytes", encryptionSecretName, len(secretSize))
+		// Create all encryption secrets (key secret + credentials secret if needed)
+		// Use the generic function that calls either CMEK or file-based setup based on provider
+		err = encryption.SetupEncryptionSecrets(t, r.encryptionProvider, kubectlOptions, cluster)
+		require.NoError(t, err, "Failed to setup encryption secrets")
+		t.Logf("Successfully set up encryption secrets for cluster %s", cluster)
 	}
 
 	// Install the operator when it is not skipped and not already marked as installed.
@@ -911,7 +955,7 @@ func (r *Region) InstallChartsWithAdvancedConfig(t *testing.T, cluster string, i
 
 	// Build helm values
 	helmValues := PatchHelmValues(map[string]string{
-		"cockroachdb.clusterDomain":             CustomDomains[index],
+		"cockroachdb.clusterDomain":             r.GetClusterDomain(index),
 		"cockroachdb.tls.selfSigner.caProvided": "true",
 		"cockroachdb.tls.selfSigner.caSecret":   customCASecret,
 	})
@@ -1025,29 +1069,10 @@ func (r *Region) ValidateWALFailover(t *testing.T, cluster string, cfg *Advanced
 }
 
 // GenerateEncryptionKey generates a 256-bit AES encryption key and returns base64 encoded value
+// This is a convenience wrapper around encryption.GenerateAndEncodeEncryptionKey for backward compatibility
 func (r *Region) GenerateEncryptionKey(t *testing.T) string {
-	tempDir := t.TempDir()
-	keyPath := filepath.Join(tempDir, "store.key")
-
-	// Generate 256-bit AES key using cockroach gen encryption-key
-	cmd := shell.Command{
-		Command:    "cockroach",
-		Args:       []string{"gen", "encryption-key", "--size", "256", "store.key"},
-		WorkingDir: tempDir,
-	}
-
-	_, err := shell.RunCommandAndGetOutputE(t, cmd)
-	require.NoError(t, err)
-
-	// Read the generated key file
-	keyBytes, err := os.ReadFile(keyPath)
-	require.NoError(t, err)
-
-	// Base64 encode the key (removing any newlines)
-	storeKeyB64 := base64.StdEncoding.EncodeToString(keyBytes)
-	storeKeyB64 = strings.ReplaceAll(storeKeyB64, "\n", "")
-
-	return storeKeyB64
+	_, base64Key := encryption.GenerateAndEncodeEncryptionKey(t)
+	return base64Key
 }
 
 // ValidateEncryptionAtRest verifies that encryption at rest is properly configured by checking flags and encryption status.
@@ -1324,7 +1349,7 @@ func (r *Region) ValidatePCR(t *testing.T, cfg *AdvancedValidationConfig) {
 	// Step 4a: Generate external connection URI for replication
 	// Following: https://www.cockroachlabs.com/docs/stable/set-up-physical-cluster-replication#step-4-start-replication
 	t.Log("Generating connection URI for primary cluster using cockroach convert-url")
-	primaryHost := fmt.Sprintf("cockroachdb-public.%s.svc.%s:26257", primaryNamespace, CustomDomains[0])
+	primaryHost := fmt.Sprintf("cockroachdb-public.%s.svc.%s:26257", primaryNamespace, r.GetClusterDomain(0))
 	primaryConnString := fmt.Sprintf("postgresql://%s:%s@%s?options=-ccluster%%3Dsystem", pcrSourceUser, pcrSourcePassword, primaryHost)
 	t.Logf("Primary connection string format: postgresql://pcr_source:***@%s?options=-ccluster%%3Dsystem", primaryHost)
 

--- a/tests/e2e/operator/singleRegion/cockroachdb_single_region_advanced_features_test.go
+++ b/tests/e2e/operator/singleRegion/cockroachdb_single_region_advanced_features_test.go
@@ -5,12 +5,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
 )
 
 // TestWALFailover tests the WAL failover functionality by:
@@ -79,7 +80,7 @@ func (r *singleRegion) TestWALFailoverDisable(t *testing.T) {
 
 	// Upgrade with WAL failover disabled
 	disableConfig := operator.PatchHelmValues(map[string]string{
-		"cockroachdb.clusterDomain":                      operator.CustomDomains[0],
+		"cockroachdb.clusterDomain":                      r.GetClusterDomain(0),
 		"cockroachdb.tls.selfSigner.caProvided":          "true",
 		"cockroachdb.tls.selfSigner.caSecret":            "cockroachdb-ca-secret",
 		"cockroachdb.crdbCluster.walFailoverSpec.status": "disable",
@@ -141,19 +142,13 @@ func (r *singleRegion) TestEncryptionAtRestEnable(t *testing.T) {
 	cleanup := r.SetupSingleClusterWithCA(t, cluster)
 	defer cleanup()
 
-	// Generate proper 256-bit AES encryption key
-	t.Log("Generating 256-bit AES encryption key")
-	encryptionKeyB64 := r.GenerateEncryptionKey(t)
-	t.Logf("Generated encryption key (base64 length: %d)", len(encryptionKeyB64))
-
 	// Configure encryption at rest regions
 	encryptionRegions := r.BuildEncryptionRegions(cluster, 0, nil)
 
 	// Install CockroachDB with encryption at rest enabled using common method
 	config := operator.AdvancedInstallConfig{
-		EncryptionEnabled:   true,
-		EncryptionKeySecret: encryptionKeyB64,
-		CustomRegions:       encryptionRegions,
+		EncryptionEnabled: true,
+		CustomRegions:     encryptionRegions,
 	}
 	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
 
@@ -199,17 +194,14 @@ func (r *singleRegion) TestEncryptionAtRestDisable(t *testing.T) {
 	defer cleanup()
 
 	// Step 1: Install CockroachDB with encryption at rest enabled
-	t.Log("Installing CockroachDB with encryption at rest enabled")
-	encryptionKeyB64 := r.GenerateEncryptionKey(t)
-	t.Logf("Generated encryption key (base64 length: %d)", len(encryptionKeyB64))
+	t.Log("Installing CockroachDB with encryption at rest enabled...")
 
 	// Configure encryption at rest regions
 	encryptionRegions := r.BuildEncryptionRegions(cluster, 0, nil)
 
 	config := operator.AdvancedInstallConfig{
-		EncryptionEnabled:   true,
-		EncryptionKeySecret: encryptionKeyB64,
-		CustomRegions:       encryptionRegions,
+		EncryptionEnabled: true,
+		CustomRegions:     encryptionRegions,
 	}
 	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
 
@@ -306,17 +298,14 @@ func (r *singleRegion) TestEncryptionAtRestModifySecret(t *testing.T) {
 	defer cleanup()
 
 	// Step 1: Install CockroachDB with encryption at rest enabled
-	t.Log("Installing CockroachDB with encryption at rest enabled")
-	encryptionKeyB64 := r.GenerateEncryptionKey(t)
-	t.Logf("Generated initial encryption key (base64 length: %d)", len(encryptionKeyB64))
+	t.Log("Installing CockroachDB with encryption at rest enabled...")
 
 	// Configure encryption at rest regions
 	encryptionRegions := r.BuildEncryptionRegions(cluster, 0, nil)
 
 	config := operator.AdvancedInstallConfig{
-		EncryptionEnabled:   true,
-		EncryptionKeySecret: encryptionKeyB64,
-		CustomRegions:       encryptionRegions,
+		EncryptionEnabled: true,
+		CustomRegions:     encryptionRegions,
 	}
 	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
 
@@ -436,21 +425,15 @@ func (r *singleRegion) TestWALFailoverWithEncryption(t *testing.T) {
 	cleanup := r.SetupSingleClusterWithCA(t, cluster)
 	defer cleanup()
 
-	// Step 1: Generate encryption key
-	t.Log("Generating 256-bit AES encryption key")
-	encryptionKeyB64 := r.GenerateEncryptionKey(t)
-	t.Logf("Generated encryption key (base64 length: %d)", len(encryptionKeyB64))
-
 	// Configure encryption at rest regions
 	encryptionRegions := r.BuildEncryptionRegions(cluster, 0, nil)
 
 	// Install CockroachDB with both WAL failover and encryption enabled
 	config := operator.AdvancedInstallConfig{
-		WALFailoverEnabled:  true,
-		WALFailoverSize:     "5Gi",
-		EncryptionEnabled:   true,
-		EncryptionKeySecret: encryptionKeyB64,
-		CustomRegions:       encryptionRegions,
+		WALFailoverEnabled: true,
+		WALFailoverSize:    "5Gi",
+		EncryptionEnabled:  true,
+		CustomRegions:      encryptionRegions,
 	}
 	r.InstallChartsWithAdvancedConfig(t, cluster, 0, config)
 
@@ -588,4 +571,3 @@ func (r *singleRegion) TestPCR(t *testing.T) {
 
 	t.Logf("PCR (Physical Cluster Replication) test completed successfully")
 }
-

--- a/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
+++ b/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
@@ -7,61 +7,69 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
-	"github.com/cockroachdb/helm-charts/tests/e2e/operator/infra"
-	"github.com/cockroachdb/helm-charts/tests/testutil"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/infra"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/utils"
+	"github.com/cockroachdb/helm-charts/tests/testutil"
 )
 
 type singleRegion struct {
-	operator.OperatorUseCases
 	operator.Region
 }
 
 func newSingleRegion() *singleRegion {
 	return &singleRegion{}
 }
+
+// mapProviderToInfra maps utils package provider constants to infra package constants.
+// This avoids import cycles while allowing centralized provider parsing.
+func mapProviderToInfra(provider string) string {
+	switch provider {
+	case utils.ProviderK3D:
+		return infra.ProviderK3D
+	case utils.ProviderKind:
+		return infra.ProviderKind
+	case utils.ProviderGCP:
+		return infra.ProviderGCP
+	default:
+		return provider
+	}
+}
 func TestOperatorInSingleRegion(t *testing.T) {
-	// Fetch provider from env
-	var provider string
-	if p := strings.TrimSpace(strings.ToLower(os.Getenv("PROVIDER"))); p != "" {
-		switch p {
-		case "kind":
-			provider = infra.ProviderKind
-		case "gcp":
-			provider = infra.ProviderGCP
-		default:
-			t.Fatalf("Unsupported provider override: %s", p)
-		}
-	} else {
-		provider = infra.ProviderK3D
+	// Fetch provider from env using centralized utility
+	provider, err := utils.GetProviderFromEnv()
+	if err != nil {
+		t.Fatalf("Failed to get provider: %v", err)
 	}
 
-	t.Run(provider, func(t *testing.T) {
+	// Map utils provider constants to infra provider constants
+	infraProvider := mapProviderToInfra(provider)
+
+	t.Run(infraProvider, func(t *testing.T) {
 		// Run tests for different providers in parallel.
 		t.Parallel()
 
 		// Create a provider-specific instance to avoid race conditions.
 		providerRegion := newSingleRegion()
 		providerRegion.Region = operator.Region{
-			IsMultiRegion: false,
-			NodeCount:     3,
-			ReusingInfra:  false,
+			NodeCount:    3,
+			ReusingInfra: false,
 		}
 		providerRegion.Clients = make(map[string]client.Client)
 		providerRegion.Namespace = make(map[string]string)
 
-		providerRegion.Provider = provider
-		clusterName := fmt.Sprintf("%s-%s", providerRegion.Provider, operator.Clusters[0])
-		if provider != infra.ProviderK3D && provider != infra.ProviderKind {
-			clusterName = fmt.Sprintf("%s-%s", clusterName, strings.ToLower(random.UniqueId()))
-		}
-		providerRegion.Clusters = append(providerRegion.Clusters, clusterName)
+		providerRegion.Provider = infraProvider
+
+		// Generate cluster names with better context (PR number or username)
+		clusterNames := utils.GenerateClusterNames(provider, 1)
+		providerRegion.Clusters = clusterNames
 
 		// Create and reuse the same provider instance for both setup and teardown.
 		cloudProvider := infra.ProviderFactory(providerRegion.Provider, &providerRegion.Region)

--- a/tests/e2e/operator/utils/cluster_naming.go
+++ b/tests/e2e/operator/utils/cluster_naming.go
@@ -1,0 +1,102 @@
+// Package utils provides common utilities for E2E tests to avoid duplication
+// between single-region and multi-region test suites.
+package utils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+const (
+	// Provider constants (duplicated from infra package to avoid import cycles)
+
+	ProviderK3D  = "k3d"
+	ProviderKind = "kind"
+	ProviderGCP  = "gcp"
+)
+
+// GetProviderFromEnv reads the PROVIDER environment variable and returns the provider string.
+// Returns ProviderK3D as default if no provider is specified.
+func GetProviderFromEnv() (string, error) {
+	p := strings.TrimSpace(strings.ToLower(os.Getenv("PROVIDER")))
+	if p == "" {
+		return ProviderK3D, nil
+	}
+
+	switch p {
+	case "k3d":
+		return ProviderK3D, nil
+	case "kind":
+		return ProviderKind, nil
+	case "gcp":
+		return ProviderGCP, nil
+	default:
+		return "", fmt.Errorf("unsupported provider: %s", p)
+	}
+}
+
+// GenerateClusterNames creates cluster names with context about who is running the test.
+// For GitHub CI: includes PR number (e.g., gcp-chart-testing-pr602-cluster-0-abc123)
+// For local runs: includes username (e.g., gcp-chart-testing-bhaskar-cluster-0-abc123)
+// For K3D/Kind: includes provider prefix to match kubeconfig context names
+//
+//	(e.g., k3d-chart-testing-cluster-0 matches the context created by k3d)
+//
+// Parameters:
+//   - provider: The cloud provider (gcp, k3d, kind)
+//   - clusterCount: Number of clusters to create names for
+//
+// Returns: Array of cluster names
+func GenerateClusterNames(provider string, clusterCount int) []string {
+	// Start with provider prefix for all providers
+	// For k3d/kind, this matches the kubeconfig context name (k3d adds "k3d-" prefix to contexts)
+	var clusterPrefix string
+	clusterPrefix = fmt.Sprintf("%s-%s", provider, "chart-testing")
+
+	// For cloud providers (GCP), add GitHub PR number or username for isolation
+	// For local providers (k3d, kind), keep simple names without PR/username
+	if provider != ProviderK3D && provider != ProviderKind {
+		// Add GitHub PR number if running in CI
+		if prNumber := os.Getenv("GITHUB_PR_NUMBER"); prNumber != "" {
+			clusterPrefix = fmt.Sprintf("%s-pr%s", clusterPrefix, prNumber)
+		} else if ghRef := os.Getenv("GITHUB_REF"); strings.Contains(ghRef, "/pull/") {
+			// Extract PR number from GITHUB_REF (e.g., refs/pull/123/merge)
+			parts := strings.Split(ghRef, "/")
+			if len(parts) >= 3 {
+				clusterPrefix = fmt.Sprintf("%s-pr%s", clusterPrefix, parts[2])
+			}
+		} else {
+			// For local runs, add username
+			if username := os.Getenv("USER"); username != "" {
+				// Sanitize username for Kubernetes naming (lowercase, alphanumeric and dash only)
+				username = strings.ToLower(username)
+				username = strings.Map(func(r rune) rune {
+					if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+						return r
+					}
+					return '-'
+				}, username)
+				// Truncate username to max 10 characters to avoid exceeding 63-char label limit
+				if len(username) > 10 {
+					username = username[:10]
+				}
+				clusterPrefix = fmt.Sprintf("%s-%s", clusterPrefix, username)
+			}
+		}
+	}
+
+	clusterNames := make([]string, 0, clusterCount)
+	for i := 0; i < clusterCount; i++ {
+		clusterName := fmt.Sprintf("%s-cluster-%d", clusterPrefix, i)
+		// Add random suffix for cloud providers (not for local K3D/Kind)
+		if provider != ProviderK3D && provider != ProviderKind {
+			clusterName = fmt.Sprintf("%s-%s", clusterName, strings.ToLower(random.UniqueId()))
+		}
+		clusterNames = append(clusterNames, clusterName)
+	}
+
+	return clusterNames
+}


### PR DESCRIPTION
Introduce clean interface-based architecture for encryption at rest testing:

**Core Changes:**
- Create encryption.Provider interface with platform-specific config
- Define encryption.PlatformConfig (Platform, RequiresCredentialsSecret, etc.)
- Add GetEncryptionProvider() to CloudProvider interface
- Auto-set encryption provider in ProviderFactory

**Fix: Cloud-Specific Config Flow**
- Problem: Platform/credentials hardcoded to "UNKNOWN_KEY_TYPE"
- Solution: EncryptionAtRestConfig() dynamically retrieves from provider
- Platform and cmekCredentialsSecretName now flow correctly to helm charts
- Enables AWS_KMS, GCP_CLOUD_KMS, UNKNOWN_KEY_TYPE support

**Additional Improvements:**
- Extract shared SetupFileBasedEncryptionSecrets() utility
- Remove unused IsMultiRegion field and OperatorUseCases interface
- Add utils.GetProviderFromEnv() and utils.GenerateClusterNames()
- Better cluster naming: PR numbers in CI, usernames locally

Fix Kind single-cluster deployments timing out during infrastructure setup:

**Problem:** CoreDNS LoadBalancer service waited for IP without MetalLB **Solution:** Skip MetalLB and CoreDNS for single-cluster (uses default DNS)

Single-cluster now completes setup in seconds instead of timing out.

- tests/e2e/operator/encryption/types.go: Provider interface
- tests/e2e/operator/infra/{provider,local,gcp}.go: Implementations
- tests/e2e/operator/region.go: Fix EncryptionAtRestConfig()
- tests/e2e/operator/utils/cluster_naming.go: New utilities
- tests/e2e/operator/*/test.go: Use new architecture