### PR TITLE
ci: declare workflow-level `contents: read` on 3 workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: read
+
 jobs:
 
   needs-build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
 
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,9 @@ jobs:
   detect-self-signer-change:
     name: is-self-signer-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       certUtility: ${{ steps.filter.outputs.certUtility }}
     steps:

--- a/.github/workflows/k8s-compatibility-tests.yaml
+++ b/.github/workflows/k8s-compatibility-tests.yaml
@@ -6,6 +6,9 @@ on:
     - cron: "0 0 * * 1"
   workflow_dispatch: # allow manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   cockroachdb-operator-single-region-e2e:
     name: CockroachDB Operator Single Region Test (k8s ${{ matrix.k8s-version }})


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.