### PR TITLE
e2e/kind: remove unused containerdConfigPatches registry mirror config

### DIFF
--- a/tests/kind/dev-multi-cluster.sh
+++ b/tests/kind/dev-multi-cluster.sh
@@ -146,14 +146,6 @@ EOF
       # Use a single shared Docker network for all clusters to enable cross-cluster L2 reachability
       cluster_network="${network_name}"
 
-      # Add containerdConfigPatches for proper runtime configuration
-      cat >> "/tmp/kind-config-${i}.yaml" << EOF
-containerdConfigPatches:
-- |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${REGISTRY}"]
-    endpoint = ["http://${network_name}-registry:5000"]
-EOF
-
       # Add nodes configuration with unique API server port (start from 7443 to avoid conflicts)
       api_server_port=$((7443 + i))
       cat >> "/tmp/kind-config-${i}.yaml" << EOF


### PR DESCRIPTION
Removes an unused containerdConfigPatches block in dev-multi-cluster.sh that referenced an undefined REGISTRY variable, causing the kind cluster creation to fail under set -euo pipefail.
This fixes the kind e2e test failures for both single-region and multi-region.