### PR TITLE
CC-36481: Add Helm operator troubleshooting and escalation skills

### DIFF
--- a/skills/cockroachdb-observability-and-diagnostics/collecting-cockroachdb-operator-escalation-packet/SKILL.md
+++ b/skills/cockroachdb-observability-and-diagnostics/collecting-cockroachdb-operator-escalation-packet/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: collecting-cockroachdb-operator-escalation-packet
+description: Collects a complete CockroachDB Operator escalation packet for TSC/TSE or operator-team handoff, including Helm state, Kubernetes resources, logs, operation-specific evidence, pprof goroutine dumps, metrics, and a customer action timeline. Use when general diagnosis cannot resolve an operator-managed CockroachDB Helm issue or before restarting a stuck operator.
+compatibility: CockroachDB Helm v2 charts and operator-managed crdb.cockroachlabs.com/v1beta1 resources. Requires Kubernetes read access to the operator namespace and CockroachDB namespace; pprof and metrics collection require port-forward access to the operator Deployment.
+metadata:
+  author: cockroachdb
+  version: "1.0"
+---
+
+# Collecting CockroachDB Operator Escalation Packet
+
+Collects the artifacts needed for TSC/TSE or operator-team escalation. Use this after basic diagnosis identifies an unresolved operator, Kubernetes, migration, upgrade, scale, DNS, PVC, or certificate issue. Keep collection read-only unless the customer explicitly approves a mitigation.
+
+## When to Use This Skill
+
+- A customer needs to escalate an operator-managed CockroachDB Helm issue to TSC
+- The operator is running but not reconciling and logs/status do not explain why
+- A rollout, upgrade, migration, or scale operation is stuck
+- Operator logs do not explain the failure
+- TSC needs consistent artifacts before advising restart, rollback, manual decommission, or status repair
+
+## Safety Considerations
+
+- Collect this packet before restarting, scaling, or deleting the operator during active operations.
+- Do not delete `CrdbNode`, PVC, Secret, service, version checker job, or StatefulSet resources while collecting data.
+- Do not print private key contents. Collect only Secret names, keys, certificate metadata, expiry, issuer, subject, and SANs.
+- Do not manually edit `CrdbCluster.status`.
+- Do not run `cockroach init` on an existing cluster.
+- If the operator is paused or disabled, record that state before changing anything.
+
+## Execution Discipline
+
+- Execute one step at a time and inspect the output before moving on. Do not run the packet collection in parallel; earlier results determine which operation-specific sections are relevant.
+- Keep collection read-only unless the user explicitly approves a mutating action for the target cluster.
+- Do not run interactive `kubectl exec` shells, `kubectl debug`, port-forwards, pprof/metrics collection, or commands that use external images in production unless the user approves them. If impact or policy is unclear, involve TSE or the operator team first.
+- Do not patch, annotate, delete, restart, scale, drain, decommission, or run `helm upgrade` as part of packet collection.
+
+## Required Inputs
+
+- Operator namespace and Helm release
+- CockroachDB namespace and Helm release
+- Kubernetes context and cluster/provider
+- Current operation: install, upgrade, scale up/down, cert rotation, migration, routine maintenance, or recovery
+- Current and target CockroachDB image, if an upgrade is involved
+- Customer timeline: what changed, what commands were run, and what was already tried
+
+## Packet Layout
+
+Ask the customer to gather outputs into a single directory:
+
+```bash
+mkdir -p crdb-operator-escalation
+```
+
+Use clear filenames, for example `operator-logs.txt`, `crdbcluster.yaml`, `events.txt`, `goroutine_dump.txt`, and `metrics_dump.txt`.
+
+## Step 1: Context and Version Inventory
+
+```bash
+kubectl config current-context > crdb-operator-escalation/kube-context.txt
+kubectl version --short > crdb-operator-escalation/kubernetes-version.txt
+
+helm -n <operator-namespace> status <operator-release> > crdb-operator-escalation/operator-helm-status.txt 2>&1 || true
+helm -n <operator-namespace> history <operator-release> > crdb-operator-escalation/operator-helm-history.txt 2>&1 || true
+helm -n <cockroachdb-namespace> status <cockroachdb-release> > crdb-operator-escalation/crdb-helm-status.txt 2>&1 || true
+helm -n <cockroachdb-namespace> history <cockroachdb-release> > crdb-operator-escalation/crdb-helm-history.txt 2>&1 || true
+
+kubectl -n <operator-namespace> get deploy cockroach-operator -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}' > crdb-operator-escalation/operator-image.txt
+kubectl get crd crdbclusters.crdb.cockroachlabs.com crdbnodes.crdb.cockroachlabs.com -o wide > crdb-operator-escalation/crds.txt
+kubectl get crd crdbclusters.crdb.cockroachlabs.com -o yaml > crdb-operator-escalation/crdbclusters-crd.yaml
+kubectl get crd crdbnodes.crdb.cockroachlabs.com -o yaml > crdb-operator-escalation/crdbnodes-crd.yaml
+```
+
+Get the CockroachDB version from a Ready pod:
+
+```bash
+kubectl -n <cockroachdb-namespace> exec <ready-crdb-pod> -c cockroachdb -- \
+  /cockroach/cockroach version > crdb-operator-escalation/crdb-version.txt 2>&1
+```
+
+## Step 2: Resource Specifications and Status
+
+```bash
+kubectl -n <operator-namespace> get deploy,pod,svc,endpoints -o wide > crdb-operator-escalation/operator-resources.txt
+kubectl -n <operator-namespace> describe deploy cockroach-operator > crdb-operator-escalation/operator-deploy-describe.txt
+kubectl -n <operator-namespace> describe pods -l app=cockroach-operator > crdb-operator-escalation/operator-pods-describe.txt
+kubectl -n <operator-namespace> get deploy cockroach-operator -o yaml > crdb-operator-escalation/operator-deploy.yaml
+
+kubectl -n <cockroachdb-namespace> get crdbcluster <cockroachdb-release> -o yaml > crdb-operator-escalation/crdbcluster.yaml
+kubectl -n <cockroachdb-namespace> describe crdbcluster <cockroachdb-release> > crdb-operator-escalation/crdbcluster-describe.txt
+kubectl -n <cockroachdb-namespace> get crdbnodes -o yaml > crdb-operator-escalation/crdbnodes.yaml
+kubectl -n <cockroachdb-namespace> describe crdbnodes > crdb-operator-escalation/crdbnodes-describe.txt
+kubectl -n <cockroachdb-namespace> get pod,svc,endpoints,pvc,pdb -o wide > crdb-operator-escalation/crdb-resources-wide.txt
+kubectl -n <cockroachdb-namespace> describe pods -l app.kubernetes.io/name=cockroachdb > crdb-operator-escalation/crdb-pods-describe.txt
+kubectl -n <cockroachdb-namespace> describe pvc > crdb-operator-escalation/pvc-describe.txt
+kubectl -n <cockroachdb-namespace> describe pdb > crdb-operator-escalation/pdb-describe.txt
+kubectl -n <cockroachdb-namespace> get events --sort-by=.lastTimestamp > crdb-operator-escalation/events.txt
+```
+
+Summarize key cluster status:
+
+```bash
+kubectl -n <cockroachdb-namespace> get crdbcluster <cockroachdb-release> -o json | jq '{
+  mode: .spec.mode,
+  nodes: [.spec.regions[]?.nodes],
+  regions: .spec.regions,
+  image: .spec.image,
+  generation: .metadata.generation,
+  observedGeneration: .status.observedGeneration,
+  statusImage: .status.image,
+  actions: .status.actions,
+  conditions: .status.conditions,
+  labels: .metadata.labels,
+  annotations: .metadata.annotations
+}' > crdb-operator-escalation/crdbcluster-summary.json
+
+kubectl -n <cockroachdb-namespace> get crdbnodes \
+  -o custom-columns=NAME:.metadata.name,GENERATION:.metadata.generation,OBSERVED:.status.observedGeneration,PHASE:.status.phase,HASH:.metadata.annotations["crdb.cockroachlabs.com/hash-revision"],NODE_ID:.status.nodeID \
+  > crdb-operator-escalation/crdbnodes-summary.txt
+```
+
+## Step 3: Logs
+
+Collect full recent logs, not filtered snippets:
+
+```bash
+kubectl -n <operator-namespace> logs -l app=cockroach-operator --tail=500 > crdb-operator-escalation/operator-logs.txt 2>&1
+kubectl -n <operator-namespace> logs -l app=cockroach-operator --previous --tail=500 > crdb-operator-escalation/operator-previous-logs.txt 2>&1 || true
+```
+
+For each CockroachDB pod:
+
+```bash
+kubectl -n <cockroachdb-namespace> logs <crdb-pod> -c cockroachdb --tail=500 > crdb-operator-escalation/<crdb-pod>-cockroachdb.log 2>&1
+kubectl -n <cockroachdb-namespace> logs <crdb-pod> -c cockroachdb --previous --tail=500 > crdb-operator-escalation/<crdb-pod>-cockroachdb-previous.log 2>&1 || true
+kubectl -n <cockroachdb-namespace> logs <crdb-pod> -c cert-reloader --tail=100 > crdb-operator-escalation/<crdb-pod>-cert-reloader.log 2>&1 || true
+```
+
+## Step 4: Operation-Specific Evidence
+
+### Upgrade
+
+```bash
+kubectl -n <cockroachdb-namespace> get crdbcluster <cockroachdb-release> -o json | jq '{
+  specImage: .spec.image,
+  statusImage: .status.image,
+  actions: .status.actions,
+  annotations: .metadata.annotations,
+  conditions: [.status.conditions[]? | select(.type | test("Upgrade|Version|Validate"))]
+}' > crdb-operator-escalation/upgrade-status.json
+
+kubectl -n <cockroachdb-namespace> get jobs -o wide > crdb-operator-escalation/jobs.txt
+kubectl -n <cockroachdb-namespace> get pods -o custom-columns=NAME:.metadata.name,IMAGE:.spec.containers[0].image,PHASE:.status.phase > crdb-operator-escalation/pod-images.txt
+kubectl -n <cockroachdb-namespace> describe job <version-checker-job> > crdb-operator-escalation/version-checker-job.txt 2>&1 || true
+kubectl -n <cockroachdb-namespace> logs -l job-name=<version-checker-job> > crdb-operator-escalation/version-checker-logs.txt 2>&1 || true
+```
+
+Include current and target CRDB image and whether any version checker job or pod was deleted.
+
+### Scale Down or Decommission
+
+```bash
+kubectl -n <cockroachdb-namespace> exec <ready-crdb-pod> -c cockroachdb -- \
+  /cockroach/cockroach node status --decommission > crdb-operator-escalation/node-decommission-status.txt 2>&1
+
+kubectl -n <cockroachdb-namespace> get crdbnodes -o json | jq '[.items[] | select(.status.phase=="Decommissioning")] | {count: length, nodes: [.[].metadata.name]}' \
+  > crdb-operator-escalation/decommissioning-crdbnodes.json
+```
+
+Include original and target node count, whether multiple nodes changed at once, and whether manual drain/decommission was attempted.
+
+### Scale Up
+
+Capture whether machines, Kubernetes nodes, disks, storage classes, topology spread constraints, or node labels changed:
+
+```bash
+kubectl get nodes -L topology.kubernetes.io/region,topology.kubernetes.io/zone > crdb-operator-escalation/nodes-locality.txt
+kubectl get storageclass > crdb-operator-escalation/storageclasses.txt
+kubectl -n <cockroachdb-namespace> get pvc -o wide > crdb-operator-escalation/pvc-wide.txt
+```
+
+### Certificate Rotation
+
+```bash
+kubectl -n <cockroachdb-namespace> get secret,configmap | grep -E 'ca|node|client|tls|cert' > crdb-operator-escalation/cert-resources.txt || true
+kubectl -n <cockroachdb-namespace> get certificate,issuer,clusterissuer -o wide > crdb-operator-escalation/cert-manager-resources.txt 2>&1 || true
+
+kubectl -n <cockroachdb-namespace> get secret <node-tls-secret> -o jsonpath='{.data.tls\.crt}' | base64 -d | \
+  openssl x509 -noout -dates -subject -issuer -ext subjectAltName > crdb-operator-escalation/node-cert-metadata.txt
+```
+
+Do not collect private key values.
+
+### Migration
+
+Use [debugging-cockroachdb-operator-migrations](../../cockroachdb-onboarding-and-migrations/debugging-cockroachdb-operator-migrations/SKILL.md) and attach its migration state output. Include source StatefulSet or v1alpha1 `CrdbCluster`, migration labels, migration phase, source ownerReferences, and migration controller logs.
+
+## Step 5: Operator pprof and Metrics
+
+Collect these when the operator is running but not reconciling, logs/status do not explain why, or a worker may be blocked. In production or restricted environments, confirm with the customer, TSE, or the operator team before opening port-forwards.
+
+In one terminal:
+
+```bash
+kubectl -n <operator-namespace> port-forward deployment/cockroach-operator 7080:7080
+```
+
+In another terminal:
+
+```bash
+curl -s 'http://localhost:7080/debug/pprof/goroutine?debug=2' > crdb-operator-escalation/goroutine_dump.txt
+curl -s 'http://localhost:7080/debug/pprof/goroutine?debug=1' > crdb-operator-escalation/goroutine_summary.txt
+curl -s 'http://localhost:7080/debug/pprof/heap' > crdb-operator-escalation/heap.prof
+curl -s 'http://localhost:7080/debug/pprof/profile?seconds=30' > crdb-operator-escalation/cpu.prof
+curl -s 'http://localhost:7080/debug/pprof/mutex' > crdb-operator-escalation/mutex.prof
+```
+
+Metrics:
+
+```bash
+kubectl -n <operator-namespace> port-forward deployment/cockroach-operator 8080:8080
+curl -s http://localhost:8080/metrics > crdb-operator-escalation/metrics_dump.txt
+grep 'controller_runtime_reconcile_total' crdb-operator-escalation/metrics_dump.txt > crdb-operator-escalation/reconcile-total.txt || true
+grep 'controller_runtime_reconcile_errors_total' crdb-operator-escalation/metrics_dump.txt > crdb-operator-escalation/reconcile-errors.txt || true
+grep 'workqueue_depth' crdb-operator-escalation/metrics_dump.txt > crdb-operator-escalation/workqueue-depth.txt || true
+grep 'workqueue_longest_running_processor_seconds' crdb-operator-escalation/metrics_dump.txt > crdb-operator-escalation/workqueue-longest-running.txt || true
+grep 'workqueue_unfinished_work_seconds' crdb-operator-escalation/metrics_dump.txt > crdb-operator-escalation/workqueue-unfinished.txt || true
+```
+
+What TSC should inspect:
+
+- `processNextWorkItem` followed by `Reconcile` and a long-running call in `goroutine_dump.txt`
+- `kube.(*Ctl).Exec`, `cockroach init`, HTTP calls, or mutex waits with long durations
+- increasing `workqueue_longest_running_processor_seconds`
+- growing `workqueue_depth`
+- no reconcile count movement for a controller that should be active
+
+## Step 6: Timeline
+
+Create `crdb-operator-escalation/timeline.md` with:
+
+- When the issue started
+- What operation was in progress
+- What docs or runbooks were followed
+- Whether VMs, Kubernetes nodes, disks, storage classes, certs, network policies, or Helm values changed
+- Every manual delete, patch, edit, restart, drain, decommission, or Helm command, in order
+- What is currently serving traffic and what is unavailable
+- Customer restrictions, such as no cluster-admin, no debug containers, no external images, or private registry only
+
+## Step 7: Escalation Summary
+
+Return a concise summary with:
+
+1. Operation type and current impact
+2. Current operator and CockroachDB versions
+3. Current `CrdbCluster` mode, generation, observedGeneration, status image, and actions
+4. Stuck resource or symptom
+5. Any unsafe operations already performed
+6. Missing artifacts, if any
+7. Whether pprof/metrics suggest a blocked worker
+
+## References
+
+- [diagnosing-cockroachdb-helm-deployments](../diagnosing-cockroachdb-helm-deployments/SKILL.md)
+- [debugging-cockroachdb-operator-migrations](../../cockroachdb-onboarding-and-migrations/debugging-cockroachdb-operator-migrations/SKILL.md)
+- [CockroachDB Helm Chart Changelog](../../../CHANGELOG.md)

--- a/skills/cockroachdb-observability-and-diagnostics/diagnosing-cockroachdb-helm-deployments/SKILL.md
+++ b/skills/cockroachdb-observability-and-diagnostics/diagnosing-cockroachdb-helm-deployments/SKILL.md
@@ -1,0 +1,390 @@
+---
+name: diagnosing-cockroachdb-helm-deployments
+description: Diagnoses failed or unhealthy CockroachDB Helm chart deployments by checking Helm release state, operator health, CrdbCluster and CrdbNode status, pod readiness, RBAC, webhooks, TLS, upgrades, scaling, PVCs, DNS, and multi-region assumptions. Use when Helm install or upgrade fails, pods are not Ready, or the operator is not reconciling.
+compatibility: CockroachDB Helm v2 charts and operator-managed crdb.cockroachlabs.com/v1beta1 resources. Requires Kubernetes read access to the operator namespace and CockroachDB namespace; some remediation requires cluster-admin or platform-team action.
+metadata:
+  author: cockroachdb
+  version: "1.1"
+---
+
+# Diagnosing CockroachDB Helm Deployments
+
+Diagnoses CockroachDB Helm install, upgrade, and readiness failures for operator-managed clusters. Keep the flow customer-facing: collect read-only evidence, classify the failure, and propose the smallest safe remediation. If the issue needs TSC escalation or deep operator forensics, use [collecting-cockroachdb-operator-escalation-packet](../collecting-cockroachdb-operator-escalation-packet/SKILL.md).
+
+## When to Use This Skill
+
+- `helm install` or `helm upgrade` fails
+- `CrdbCluster.status.observedGeneration` is behind `metadata.generation`
+- `CrdbCluster.status.reconciled` is false or missing
+- CockroachDB pods are Pending, Init, CrashLoopBackOff, Running but not Ready, or stuck on an old image
+- The operator Deployment is unavailable, silent, or not reconciling
+- Errors mention RBAC, CRDs, TLS, certificates, webhooks, node locality, PVCs, DNS, upgrades, scale operations, decommissioning, or multi-region networking
+
+## Related Skills
+
+- Use [collecting-cockroachdb-operator-escalation-packet](../collecting-cockroachdb-operator-escalation-packet/SKILL.md) when the customer needs to escalate or when TSC asks for a complete data bundle.
+- Use [debugging-cockroachdb-operator-migrations](../../cockroachdb-onboarding-and-migrations/debugging-cockroachdb-operator-migrations/SKILL.md) for Helm StatefulSet or public operator migration problems.
+- Use [configuring-cockroachdb-helm-tls](../../cockroachdb-operations-and-lifecycle/configuring-cockroachdb-helm-tls/SKILL.md) for TLS provider selection and certificate validation.
+- Use [validating-cockroachdb-helm-multiregion](../../cockroachdb-onboarding-and-migrations/validating-cockroachdb-helm-multiregion/SKILL.md) for cross-region DNS, networking, and certificate checks.
+
+## Inputs
+
+- Exact failed command and stderr
+- Operator namespace, operator Helm release name, and operator chart version
+- CockroachDB namespace, CockroachDB Helm release name, and CockroachDB chart version
+- Values file or `--set` values used
+- Kubernetes context and Kubernetes version
+- CockroachDB image/version and operator image/version
+- Whether this is install, upgrade, scale up/down, certificate rotation, migration, maintenance, or recovery
+- What the customer already tried, in order
+
+## Safety Considerations
+
+- Collect evidence before retrying. Repeated Helm or kubectl attempts can obscure the original failure.
+- Do not delete PVCs, Secrets, `CrdbCluster`, or `CrdbNode` resources unless the user explicitly asks for teardown and understands data impact.
+- Do not manually edit `CrdbCluster.status`; the operator owns status.
+- Do not run `cockroach init` on an existing cluster.
+- Do not change service settings such as `publishNotReadyAddresses` without operator-team guidance.
+- Do not delete version checker jobs or pods during an upgrade until their status and logs are collected.
+- Do not restart or scale down the operator during an active rollout, decommission, or migration unless basic evidence has already been collected.
+- Do not uninstall the operator before checking whether it manages other namespaces or clusters.
+
+## Execution Discipline
+
+- Execute one step at a time and inspect the output before moving on. Do not run whole sections, unrelated command groups, or later diagnostic branches in parallel; earlier output determines which later checks are relevant.
+- Treat commands as templates. Substitute namespaces, release names, chart names, and pod names deliberately before running anything.
+- Do not run any mutating command unless the user explicitly approves it for the target cluster. This includes `kubectl patch`, `kubectl annotate`, `kubectl delete`, `kubectl scale`, `kubectl rollout restart`, `helm upgrade`, drain/decommission commands, and interactive `kubectl exec` or `kubectl debug` shells.
+- In production or whenever the impact is unclear, stop and escalate to TSE or the operator team before pprof/metrics collection, debug containers, timestamp-based rolling restarts, mode changes, operator restarts, scale changes, or decommission actions.
+
+## Step 1: Collect Baseline State
+
+```bash
+# Helm release state
+helm -n <operator-namespace> status <operator-release> || true
+helm -n <cockroachdb-namespace> status <cockroachdb-release> || true
+helm -n <operator-namespace> history <operator-release> || true
+helm -n <cockroachdb-namespace> history <cockroachdb-release> || true
+
+# Operator state
+kubectl -n <operator-namespace> get deploy,pod,svc -o wide | grep -E 'cockroach-operator|NAME'
+kubectl -n <operator-namespace> logs -l app=cockroach-operator --tail=200 || true
+
+# CRD and CockroachDB resources
+kubectl get crd crdbclusters.crdb.cockroachlabs.com crdbnodes.crdb.cockroachlabs.com
+kubectl -n <cockroachdb-namespace> get crdbcluster,crdbnode,pod,svc,endpoints,pvc,pdb -o wide
+kubectl -n <cockroachdb-namespace> describe crdbcluster <cockroachdb-release> || true
+kubectl -n <cockroachdb-namespace> get events --sort-by=.lastTimestamp | tail -50
+```
+
+For a stuck pod or node:
+
+```bash
+kubectl -n <cockroachdb-namespace> describe pod <crdb-pod>
+kubectl -n <cockroachdb-namespace> logs <crdb-pod> -c cockroachdb --tail=200
+kubectl -n <cockroachdb-namespace> logs <crdb-pod> -c cockroachdb --previous
+kubectl -n <cockroachdb-namespace> describe crdbnode <crdbnode-name>
+```
+
+## Step 2: Classify the Failure
+
+| Symptom | Likely Class | Next Check |
+|---|---|---|
+| `no matches for kind "CrdbCluster"` | CRDs/operator not installed or not ready | [CRD and operator readiness](#crd-and-operator-readiness) |
+| `attempt to grant extra privileges` | Helm RBAC restriction | [RBAC and node-reader failures](#rbac-and-node-reader-failures) |
+| TLS values validation error | TLS provider conflict | [TLS and certificate failures](#tls-and-certificate-failures) |
+| Operator pod CrashLoopBackOff or OOMKilled | Operator crash or resource limit | [Operator health](#operator-health) |
+| Operator running but no reconcile logs | Watch namespace mismatch or blocked worker | [Operator health](#operator-health) |
+| `observedGeneration` behind `generation` | Reconcile is stuck or skipped | [Reconciliation not progressing](#reconciliation-not-progressing) |
+| Pods Pending | Scheduling, storage, topology, image pull, or node labels | [Pod scheduling and storage failures](#pod-scheduling-and-storage-failures) |
+| Pods Running but not Ready | CRDB readiness, TLS, join, DNS, network, or recovery | [Pod readiness and CRDB issues](#pod-readiness-and-crdb-issues) |
+| Upgrade stuck with mixed pod images | Version validation, rejected image, rollout dependency, scheduling | [Upgrade and version validation](#upgrade-and-version-validation) |
+| Multi-region pods cannot join | DNS, network, region list, CA mismatch | [DNS, service, and network issues](#dns-service-and-network-issues) |
+| Scale-down stuck | Decommission/drain blocked or multiple nodes decommissioning | [Scale down and decommission](#scale-down-and-decommission) |
+| Migration labels/status stuck | Migration controller issue | [debugging-cockroachdb-operator-migrations](../../cockroachdb-onboarding-and-migrations/debugging-cockroachdb-operator-migrations/SKILL.md) |
+
+## CRD and Operator Readiness
+
+```bash
+kubectl -n <operator-namespace> rollout status deploy/cockroach-operator --timeout=5m
+kubectl get crd crdbclusters.crdb.cockroachlabs.com -o jsonpath='{.spec.versions[*].name}{"\n"}'
+kubectl get crd crdbnodes.crdb.cockroachlabs.com -o jsonpath='{.spec.versions[*].name}{"\n"}'
+kubectl -n <operator-namespace> get deploy cockroach-operator -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+```
+
+Remediation:
+
+- Install or upgrade the operator chart first.
+- Wait for the operator Deployment before installing the CockroachDB chart.
+- For split charts, upgrade the operator chart before the CockroachDB chart.
+- Check the Helm chart changelog for version-specific operator fixes before deep debugging older releases.
+
+## Operator Health
+
+```bash
+kubectl -n <operator-namespace> get pods -l app=cockroach-operator -o wide
+kubectl -n <operator-namespace> describe pod <operator-pod>
+kubectl -n <operator-namespace> logs -l app=cockroach-operator --tail=100
+kubectl -n <operator-namespace> get deploy cockroach-operator -o jsonpath='{.spec.template.spec.containers[0].env}{"\n"}'
+```
+
+Interpretation:
+
+- CrashLoopBackOff: collect previous logs and check for panics.
+- OOMKilled: inspect limits and consider increasing operator memory.
+- Empty or unset `WATCH_NAMESPACE`: global mode.
+- Non-empty `WATCH_NAMESPACE`: the operator watches only listed namespaces.
+- If the CockroachDB namespace is not watched, deploy an operator for it or add it to the watch scope.
+
+Check recent logs to see whether reconciliation is active:
+
+```bash
+kubectl -n <operator-namespace> logs -l app=cockroach-operator --tail=100 | grep -i reconcil || true
+```
+
+Do not add ad hoc annotations to trigger reconciliation. If a user-approved reconcile-triggering change is required, use the chart-supported timestamp path through `helm upgrade --reuse-values`; this updates `helm.sh/restartedAt` and may roll CockroachDB pods, so treat it as a mutating operation:
+
+```bash
+helm -n <cockroachdb-namespace> upgrade <cockroachdb-release> <cockroachdb-chart> \
+  --reuse-values \
+  --set-string cockroachdb.crdbCluster.timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+```
+
+If the operator is healthy but silent and no user-approved mutation is appropriate, use [collecting-cockroachdb-operator-escalation-packet](../collecting-cockroachdb-operator-escalation-packet/SKILL.md) to gather pprof and metrics before restarting it.
+
+## RBAC and Node-Reader Failures
+
+Common error:
+
+```text
+attempt to grant extra privileges
+```
+
+Cause:
+
+- The installing principal cannot create cluster-scoped RBAC.
+- CockroachDB pods need node read access to derive locality.
+
+Checks:
+
+```bash
+kubectl auth can-i create clusterroles.rbac.authorization.k8s.io
+kubectl auth can-i create clusterrolebindings.rbac.authorization.k8s.io
+kubectl auth can-i get nodes
+```
+
+Remediation options:
+
+- Platform team installs the operator chart with `nodeReader.enabled=true` and subjects matching the CockroachDB ServiceAccount.
+- Tenant chart sets `cockroachdb.crdbCluster.rbac.nodeReader.create=false` only after the platform-owned binding exists.
+- If the customer accepts cluster-admin install privileges, rerun the Helm operation with an identity that can create the required ClusterRole and ClusterRoleBinding.
+
+Do not set `nodeReader.create=false` before replacement RBAC exists.
+
+## Webhook Checks
+
+```bash
+kubectl -n <operator-namespace> get svc cockroach-webhook-service
+kubectl -n <operator-namespace> get endpoints cockroach-webhook-service
+kubectl get validatingwebhookconfigurations | grep cockroach
+```
+
+If webhook validation fails, verify the CA bundle:
+
+```bash
+kubectl get validatingwebhookconfiguration cockroach-webhook-config \
+  -o jsonpath='{.webhooks[0].clientConfig.caBundle}' | base64 -d | openssl x509 -noout -dates -subject -issuer
+```
+
+For scoped operators, webhook configurations may be namespace-suffixed, such as `cockroach-webhook-config-<namespace>`.
+
+## Reconciliation Not Progressing
+
+```bash
+kubectl -n <cockroachdb-namespace> get crdbcluster <cockroachdb-release> -o json | jq '{
+  mode: .spec.mode,
+  image: .spec.image,
+  generation: .metadata.generation,
+  observedGeneration: .status.observedGeneration,
+  statusImage: .status.image,
+  actions: .status.actions,
+  conditions: .status.conditions
+}'
+
+kubectl -n <cockroachdb-namespace> get crdbnodes \
+  -o custom-columns=NAME:.metadata.name,GENERATION:.metadata.generation,OBSERVED:.status.observedGeneration,PHASE:.status.phase,HASH:.metadata.annotations["crdb.cockroachlabs.com/hash-revision"],NODE_ID:.status.nodeID
+```
+
+Checklist:
+
+1. Confirm the operator is running and watching the CockroachDB namespace.
+2. Confirm `spec.mode` is not `Disabled`.
+3. Check whether initialization conditions look correct for an existing cluster.
+4. Check operator logs for reconcile start/end pairs and errors.
+5. If no progress is visible, collect the escalation packet before restarting the operator.
+
+## Pod Readiness and CRDB Issues
+
+```bash
+kubectl -n <cockroachdb-namespace> get pods -l app.kubernetes.io/name=cockroachdb -o wide
+kubectl -n <cockroachdb-namespace> describe pod <crdb-pod>
+kubectl -n <cockroachdb-namespace> logs <crdb-pod> -c cockroachdb --tail=200
+kubectl -n <cockroachdb-namespace> logs <crdb-pod> -c cockroachdb --previous
+kubectl -n <cockroachdb-namespace> get pod <crdb-pod> -o jsonpath='{.spec.containers[0].readinessProbe}{"\n"}'
+kubectl -n <cockroachdb-namespace> get pods -l app.kubernetes.io/name=cockroachdb \
+  -o custom-columns=NAME:.metadata.name,IMAGE:.spec.containers[0].image,PHASE:.status.phase,READY:.status.containerStatuses[0].ready,NODE:.spec.nodeName
+```
+
+Common pod issues:
+
+- Pending during upgrade: old pods may still carry pre-upgrade scheduling or affinity constraints.
+- CrashLoopBackOff: inspect storage errors, TLS errors, join address failures, and previous logs.
+- Running but not Ready: check the readiness probe, CRDB health endpoint, certificate trust, join service, and whether the node is recovering.
+
+## Upgrade and Version Validation
+
+```bash
+kubectl -n <cockroachdb-namespace> get crdbcluster <cockroachdb-release> -o json | jq '{
+  specImage: .spec.image,
+  statusImage: .status.image,
+  actions: .status.actions,
+  conditions: [.status.conditions[]? | select(.type | test("Upgrade|Version|Validate"))]
+}'
+
+kubectl -n <cockroachdb-namespace> get crdbcluster <cockroachdb-release> -o jsonpath='{.metadata.annotations}{"\n"}' | jq .
+kubectl -n <cockroachdb-namespace> get jobs
+kubectl -n <cockroachdb-namespace> describe job <version-checker-job>
+kubectl -n <cockroachdb-namespace> logs -l job-name=<version-checker-job>
+kubectl -n <cockroachdb-namespace> get pods -l app.kubernetes.io/name=cockroachdb \
+  -o custom-columns=NAME:.metadata.name,IMAGE:.spec.containers[0].image,REVISION:.metadata.annotations["crdb\.cockroachlabs\.com/hash-revision"],PHASE:.status.phase
+```
+
+Interpretation:
+
+- If `spec.image` differs from `status.image`, an upgrade is in progress or stuck.
+- If a rejected-image annotation exists, inspect its value; the operator rejected the target version.
+- If the version checker job exists but the pod is gone, use job status and operator logs for validation messages.
+- Do not delete version checker jobs or pods until their status and logs are captured.
+
+## DNS, Service, and Network Issues
+
+The operator creates separate service paths for pod DNS and join traffic. Do not change service settings without operator-team guidance.
+
+```bash
+kubectl -n <cockroachdb-namespace> get service <cockroachdb-release> -o yaml
+kubectl -n <cockroachdb-namespace> get service <cockroachdb-release>-join -o yaml
+kubectl -n <cockroachdb-namespace> get endpoints <cockroachdb-release>
+kubectl -n <cockroachdb-namespace> get endpoints <cockroachdb-release>-join
+
+kubectl -n <cockroachdb-namespace> exec <crdb-pod> -c cockroachdb -- \
+  nslookup <cockroachdb-release>.<cockroachdb-namespace>.svc.cluster.local 2>&1 || true
+
+kubectl -n <cockroachdb-namespace> exec <crdb-pod> -c cockroachdb -- \
+  nslookup <cockroachdb-release>-join.<cockroachdb-namespace>.svc.cluster.local 2>&1 || true
+```
+
+For multi-region checks, use [validating-cockroachdb-helm-multiregion](../../cockroachdb-onboarding-and-migrations/validating-cockroachdb-helm-multiregion/SKILL.md).
+
+## TLS and Certificate Failures
+
+Use [configuring-cockroachdb-helm-tls](../../cockroachdb-operations-and-lifecycle/configuring-cockroachdb-helm-tls/SKILL.md) for TLS mode selection and detailed certificate checks.
+
+Quick checks:
+
+```bash
+helm template <release> <chart> -n <namespace> -f values.yaml >/tmp/rendered.yaml
+kubectl -n <namespace> get secret,configmap | grep -E 'cockroach|crdb|cert|ca|tls'
+kubectl -n <namespace> get crdbcluster <release> -o yaml | grep -A20 certificates
+kubectl -n <namespace> get pod <crdb-pod> -o jsonpath='{.spec.containers[*].name}{"\n"}'
+kubectl -n <namespace> logs <crdb-pod> -c cert-reloader --tail=100
+```
+
+Remediation:
+
+- Ensure exactly one TLS provider is enabled.
+- Ensure self-signer `caProvided=true` has a valid `caSecret`.
+- Ensure cert-manager `Issuer` or `ClusterIssuer` exists and `Certificate` resources become Ready.
+- Ensure external certificate Secrets and CA ConfigMap have expected keys and share a trust root.
+- Collect expiry, subject, issuer, and SANs, but do not print private key contents.
+
+## Pod Scheduling and Storage Failures
+
+```bash
+kubectl -n <namespace> describe pod <pod-name>
+kubectl -n <namespace> get pvc -o wide
+kubectl get storageclass
+kubectl get nodes -L topology.kubernetes.io/region,topology.kubernetes.io/zone
+kubectl -n <namespace> exec <crdb-pod> -c cockroachdb -- df -h /cockroach/cockroach-data
+```
+
+Common causes:
+
+- PVCs cannot bind because no default StorageClass exists or `storageClassName` is wrong.
+- Topology spread constraints cannot be satisfied because node zone labels are missing or insufficient.
+- Node resources are too small for requested CPU/memory.
+- Image pull failures from registry policy or air-gapped environments.
+- Migrated PVCs may be missing ownerReferences; use the migration debugging skill before deleting anything.
+
+## Scale Down and Decommission
+
+```bash
+kubectl -n <cockroachdb-namespace> exec <ready-crdb-pod> -c cockroachdb -- \
+  /cockroach/cockroach node status --decommission
+
+kubectl -n <cockroachdb-namespace> get crdbnodes -o json | jq '[.items[] | select(.status.phase=="Decommissioning")] | {count: length, nodes: [.[].metadata.name]}'
+
+kubectl -n <operator-namespace> logs -l app=cockroach-operator --tail=300 | grep -Ei 'decommission|drain|scale|blocking_ranges' || true
+```
+
+Questions to answer:
+
+- What was the original and target node count?
+- Were multiple nodes scaled down at the same time?
+- Were manual decommission or drain commands issued?
+- Did any pods or PVCs get deleted manually?
+
+## Temporary Mitigations
+
+Only use these after collecting evidence and confirming the risk with the customer or operator team.
+
+Disable reconciliation for one cluster:
+
+```bash
+kubectl -n <cockroachdb-namespace> patch crdbcluster <cockroachdb-release> --type=merge -p '{"spec":{"mode":"Disabled"}}'
+
+# Resume reconciliation:
+kubectl -n <cockroachdb-namespace> patch crdbcluster <cockroachdb-release> --type=merge -p '{"spec":{"mode":"MutableOnly"}}'
+```
+
+Restart the operator after evidence is collected:
+
+```bash
+kubectl -n <operator-namespace> rollout restart deploy/cockroach-operator
+```
+
+User-approved timestamp rolling restart:
+
+```bash
+helm -n <cockroachdb-namespace> upgrade <cockroachdb-release> <cockroachdb-chart> \
+  --reuse-values \
+  --set-string cockroachdb.crdbCluster.timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+```
+
+## Output Format
+
+Return findings in this order:
+
+1. Failure class
+2. Evidence: exact command output or Kubernetes status field
+3. Root cause or most likely cause
+4. Minimal remediation
+5. Verification command
+6. Data/availability risk, if any
+7. Whether escalation packet collection is needed
+
+## References
+
+- [CockroachDB Helm Chart Versioning](../../../cockroachdb-parent/docs/VERSIONING.md)
+- [Operator Helm Chart README](../../../cockroachdb-parent/charts/operator/README.md)
+- [CockroachDB Helm Chart README](../../../cockroachdb-parent/charts/cockroachdb/README.md)
+- [v1alpha1 to v1beta1 Migration Guide](../../../cockroachdb-parent/MIGRATION_v1alpha1_to_v1beta1.md)
+- [CockroachDB Docs: Kubernetes troubleshooting](https://www.cockroachlabs.com/docs/stable/orchestrate-cockroachdb-with-kubernetes)

--- a/skills/cockroachdb-onboarding-and-migrations/debugging-cockroachdb-operator-migrations/SKILL.md
+++ b/skills/cockroachdb-onboarding-and-migrations/debugging-cockroachdb-operator-migrations/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: debugging-cockroachdb-operator-migrations
+description: Debugs CockroachDB Operator migration scenarios, including Helm StatefulSet to v1beta1 CrdbNode migration and public operator v1alpha1 to v1beta1 migration. Use when migration labels, migration phases, source StatefulSet ownership, converted CRDs, PVC ownership, or post-migration reconciliation are unclear or stuck.
+compatibility: CockroachDB Helm v2 charts and CockroachDB Operator resources, including crdb.cockroachlabs.com/v1alpha1 and v1beta1. Requires read access to the CockroachDB namespace and operator namespace; final source StatefulSet deletion must be explicitly approved by the customer.
+metadata:
+  author: cockroachdb
+  version: "1.0"
+---
+
+# Debugging CockroachDB Operator Migrations
+
+Debugs migration from Helm StatefulSet or public operator v1alpha1 workloads to CockroachDB Operator v1beta1 `CrdbNode` management. Use this after collecting the general baseline from [diagnosing-cockroachdb-helm-deployments](../../cockroachdb-observability-and-diagnostics/diagnosing-cockroachdb-helm-deployments/SKILL.md).
+
+## When to Use This Skill
+
+- A Helm StatefulSet to operator migration is stuck or unclear
+- A public operator v1alpha1 to v1beta1 migration has conversion or webhook issues
+- Migration labels remain `start` or `finalized`
+- `status.migration.phase` or `status.migration.message` reports an error
+- Source StatefulSet ownership, pod ownerReferences, or PVC ownerReferences are unclear
+- The operator stops reconciling after migration
+
+## Safety Considerations
+
+- Do not delete the source StatefulSet until the migration phase is `finalized` and the customer is ready to complete migration.
+- Do not modify the source StatefulSet spec during migration.
+- Do not remove the migration label `crdb.io/migrate` during an active migration.
+- Do not manually create `CrdbNode` resources during migration.
+- Do not delete migrated PVCs. They contain CockroachDB data.
+- If the operator stalls after migration, collect the escalation packet before restarting it.
+
+## Execution Discipline
+
+- Execute one step at a time and inspect the output before moving on. Migration phase, source workload state, and ownership determine which later checks are safe.
+- Do not delete the source StatefulSet, patch labels, patch mode, restart the operator, run Helm upgrades, or change ownerReferences unless the user explicitly approves the action for the target cluster.
+- Do not run interactive `kubectl exec` shells or debug containers unless the user approves them and the customer policy allows the image/source.
+- In production or when the migration phase is ambiguous, involve TSE or the operator team before changing source or target resources.
+
+## Required Inputs
+
+- Migration type: Helm StatefulSet to operator, or public operator v1alpha1 to v1beta1
+- Source resource name and namespace
+- Target `CrdbCluster` name and namespace
+- Operator namespace and version
+- Values file or migration command used
+- Current migration label and phase
+- Whether the source StatefulSet has already been deleted
+
+## Step 1: Confirm Migration Documentation and Versions
+
+```bash
+kubectl -n <operator-namespace> get deploy cockroach-operator -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
+kubectl get crd crdbclusters.crdb.cockroachlabs.com -o jsonpath='{.spec.versions[*].name}{"\n"}'
+helm -n <cockroachdb-namespace> history <cockroachdb-release> || true
+```
+
+Check the local migration guide and chart changelog for version-specific migration fixes:
+
+- [v1alpha1 to v1beta1 Migration Guide](../../../cockroachdb-parent/MIGRATION_v1alpha1_to_v1beta1.md)
+- [CockroachDB Helm Chart Changelog](../../../CHANGELOG.md)
+
+## Step 2: Inspect Migration State
+
+```bash
+kubectl -n <cockroachdb-namespace> get crdbcluster <cockroachdb-release> -o json | jq '{
+  mode: .spec.mode,
+  migrateLabel: .metadata.labels["crdb.io/migrate"],
+  migrationStatus: .metadata.labels["crdb.cockroachlabs.com/migration"],
+  migrationPhase: .status.migration.phase,
+  migrationMessage: .status.migration.message,
+  initialized: [.status.conditions[]? | select(.type=="Initialized" or .type=="ClusterInitialized")],
+  generation: .metadata.generation,
+  observedGeneration: .status.observedGeneration
+}'
+
+kubectl -n <operator-namespace> logs -l app=cockroach-operator --tail=300 | grep -Ei 'migrationctrl|migration|phase|cert' || true
+kubectl -n <cockroachdb-namespace> get crdbnodes -o wide
+kubectl -n <cockroachdb-namespace> get crdbnodes -o yaml
+```
+
+## Step 3: Inspect Source Workload
+
+For Helm StatefulSet migration:
+
+```bash
+kubectl -n <cockroachdb-namespace> get sts <source-statefulset> -o json | jq '{
+  replicas: .spec.replicas,
+  readyReplicas: .status.readyReplicas,
+  migrateLabel: .metadata.labels["crdb.io/migrate"],
+  ownerReferences: .metadata.ownerReferences
+}'
+
+kubectl -n <cockroachdb-namespace> get sts <source-statefulset> -o yaml
+kubectl -n <cockroachdb-namespace> get pods -l app.kubernetes.io/name=cockroachdb -o yaml | grep -E 'name:|ownerReferences:|kind:|uid:|controller:' -A8
+kubectl -n <cockroachdb-namespace> get pvc -o yaml | grep -E 'name:|ownerReferences:|kind:|uid:|controller:' -A8
+```
+
+For public operator v1alpha1 migration:
+
+```bash
+kubectl -n <cockroachdb-namespace> get crdbcluster.crdb.cockroachlabs.com <cluster-name> -o yaml
+kubectl -n <cockroachdb-namespace> get crdbcluster.v1beta1.crdb.cockroachlabs.com <cluster-name> -o yaml 2>&1 || true
+kubectl -n <operator-namespace> get svc cockroach-webhook-service
+kubectl -n <operator-namespace> get endpoints cockroach-webhook-service
+kubectl get validatingwebhookconfigurations | grep cockroach
+```
+
+The operator supports both v1alpha1 and v1beta1 through conversion webhooks. If conversion fails, check webhook service health and operator logs.
+
+## Step 4: Interpret Migration Phases
+
+| Phase | What Happens | What to Check |
+|---|---|---|
+| Init | Operator validates prerequisites and prepares migration | Migration label is `start`; check operator logs for validation errors |
+| CertMigration | Operator migrates or creates TLS certificate resources | Check certificate Secrets, CA resources, cert-manager resources, and cert metadata |
+| PodMigration | Operator creates `CrdbNode` resources to take over pods from the StatefulSet | Check `CrdbNode` creation and pod ownerReferences |
+| Finalization | Operator sets `mode=MutableOnly` and stops source migration work | `CrdbCluster` mode should be `MutableOnly`; migration label should be `finalized` |
+| Complete | Customer deletes the source StatefulSet and the delete event triggers final reconcile | StatefulSet must be manually deleted only after finalization; migration label should become `complete` |
+
+## Step 5: Debug Common Migration Stalls
+
+### Migration Not Progressing
+
+```bash
+kubectl -n <cockroachdb-namespace> get crdbcluster <cockroachdb-release> -o jsonpath='{.status.migration}{"\n"}'
+kubectl -n <operator-namespace> logs -l app=cockroach-operator --tail=300 | grep -Ei 'migration|phase|cert|error' || true
+kubectl -n <operator-namespace> get deploy cockroach-operator -o jsonpath='{.spec.template.spec.containers[0].args}{"\n"}'
+```
+
+Check:
+
+- The migration feature is enabled in operator args, if the deployed version uses a feature flag.
+- The source StatefulSet still exists when phase is before `finalized`.
+- The source StatefulSet spec has not been changed mid-migration.
+- Certificate prerequisites are present and trusted.
+- `CrdbNode` objects are being created and observed.
+
+### CertMigration Issues
+
+Use [configuring-cockroachdb-helm-tls](../../cockroachdb-operations-and-lifecycle/configuring-cockroachdb-helm-tls/SKILL.md). Confirm:
+
+- CA ConfigMap or Secret exists.
+- Node, HTTP, and root client certificate resources exist.
+- Certificate expiry, issuer, subject, and SANs match generated pod DNS names.
+- Cert-manager `Certificate` resources are Ready, when cert-manager is used.
+- Secret keys are present without printing private key values.
+
+### PodMigration Issues
+
+```bash
+kubectl -n <cockroachdb-namespace> get pods -l app.kubernetes.io/name=cockroachdb -o wide
+kubectl -n <cockroachdb-namespace> describe pods -l app.kubernetes.io/name=cockroachdb
+kubectl -n <cockroachdb-namespace> get crdbnodes -o custom-columns=NAME:.metadata.name,PHASE:.status.phase,NODE_ID:.status.nodeID,OBSERVED:.status.observedGeneration
+kubectl -n <cockroachdb-namespace> get pvc -o json | jq '.items[] | {name: .metadata.name, ownerReferences: .metadata.ownerReferences, storageClass: .spec.storageClassName, capacity: .status.capacity}'
+```
+
+Check:
+
+- `CrdbNode` resources are created for expected pods.
+- Pods and PVCs have expected ownership after the operator takes over.
+- PVCs are not orphaned before deleting source resources.
+
+### Finalization or Completion Stuck
+
+Check:
+
+- `mode` is `MutableOnly`, not `Disabled`.
+- migration label is `finalized` before deleting the source StatefulSet.
+- source StatefulSet deletion happened only after finalization.
+- migration label eventually becomes `complete`.
+- operator logs show a final reconcile after the source StatefulSet delete event.
+
+## Step 6: Post-Migration Operator Stall
+
+If the operator stops reconciling after migration completes:
+
+1. Check the initialization condition. If missing on an already-initialized cluster, the operator may try to initialize and block.
+2. Verify `mode` is `MutableOnly`.
+3. Verify the migration label is `complete`, not `start` or `finalized`.
+4. Use [collecting-cockroachdb-operator-escalation-packet](../../cockroachdb-observability-and-diagnostics/collecting-cockroachdb-operator-escalation-packet/SKILL.md) to collect pprof goroutine dump, metrics, and logs before restart.
+
+## Output Format
+
+Return findings in this order:
+
+1. Migration type and current phase
+2. Source workload state
+3. Target `CrdbCluster` mode, migration labels, and migration message
+4. `CrdbNode`, pod, and PVC ownership state
+5. Current blocker and likely cause
+6. Safe next action
+7. Whether escalation packet collection is required
+
+## References
+
+- [diagnosing-cockroachdb-helm-deployments](../../cockroachdb-observability-and-diagnostics/diagnosing-cockroachdb-helm-deployments/SKILL.md)
+- [collecting-cockroachdb-operator-escalation-packet](../../cockroachdb-observability-and-diagnostics/collecting-cockroachdb-operator-escalation-packet/SKILL.md)
+- [v1alpha1 to v1beta1 Migration Guide](../../../cockroachdb-parent/MIGRATION_v1alpha1_to_v1beta1.md)
+- [CockroachDB Helm Chart Changelog](../../../CHANGELOG.md)

--- a/skills/cockroachdb-onboarding-and-migrations/installing-cockroachdb-with-helm/SKILL.md
+++ b/skills/cockroachdb-onboarding-and-migrations/installing-cockroachdb-with-helm/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: installing-cockroachdb-with-helm
+description: Guides customer-facing installation of CockroachDB on Kubernetes using the CockroachDB split Helm charts and operator-managed v1beta1 resources. Use when installing CockroachDB with Helm, choosing between published and local split charts, verifying a new install, or helping an agent complete first-time Kubernetes onboarding.
+compatibility: CockroachDB Helm v2 charts with crdb.cockroachlabs.com/v1beta1 CrdbCluster resources. Requires Kubernetes 1.30+, Helm 3+, and cluster permissions to install CRDs and cluster-scoped RBAC unless pre-provisioned by a platform team.
+metadata:
+  author: cockroachdb
+  version: "1.1"
+---
+
+# Installing CockroachDB with Helm
+
+Guides an agent through a customer-facing CockroachDB install on Kubernetes using the CockroachDB split Helm charts. Prefer the published split charts for customers. Do not use the unsupported parent or umbrella chart path for customer installs.
+
+## When to Use This Skill
+
+- A customer asks to install CockroachDB on Kubernetes using Helm
+- An agent needs to decide whether to install the published split charts or local split charts
+- A first install needs structured preflight, chart values, and post-install verification
+- A deployment has partially completed and needs the next Helm step
+
+**Related skills:** Use [configuring-cockroachdb-helm-tls](../../cockroachdb-operations-and-lifecycle/configuring-cockroachdb-helm-tls/SKILL.md) for TLS decisions, [validating-cockroachdb-helm-multiregion](../validating-cockroachdb-helm-multiregion/SKILL.md) before multi-region installs, [debugging-cockroachdb-operator-migrations](../debugging-cockroachdb-operator-migrations/SKILL.md) for StatefulSet or v1alpha1 migrations, and [diagnosing-cockroachdb-helm-deployments](../../cockroachdb-observability-and-diagnostics/diagnosing-cockroachdb-helm-deployments/SKILL.md) when any step fails.
+
+## Inputs
+
+Collect these before changing the cluster:
+
+| Input | Example | Why It Matters |
+|---|---|---|
+| Kubernetes context and namespace | `prod-us-east1`, `cockroachdb` | Avoids installing into the wrong cluster or namespace |
+| Install path | Published split charts or local split charts | Determines Helm commands and dependency order |
+| Operator release and CockroachDB release names | `crdb-operator`, `crdb` | Resource names and generated services depend on release names |
+| Region and cloud provider | `us-east1`, `gcp` | `operator.cloudRegion` must match the region reconciled by this operator |
+| TLS mode | self-signer, cert-manager, external certificates, insecure non-prod | Determines chart values and required secrets |
+| Topology | single-region or multi-region | Multi-region requires complete `regions` entries and cross-region DNS/networking |
+
+## Safety Considerations
+
+- Confirm the target Kubernetes context with the user before running `helm install`, `helm upgrade`, or `kubectl apply`.
+- Do not toggle `cockroachdb.tls.enabled` on an existing cluster. The chart documents this as unsafe and unrecoverable for a running cluster.
+- Do not configure multiple operators with overlapping `watchNamespaces`; both can reconcile the same `CrdbCluster` resources.
+- If the customer cannot create ClusterRoles or ClusterRoleBindings, coordinate split-chart node-reader RBAC with the platform team before installing the CockroachDB chart.
+- Do not use unsupported parent or umbrella chart installs for customer-facing deployment guidance.
+
+## Execution Discipline
+
+- Execute one step at a time and inspect the output before moving on. Preflight output determines whether installation can continue.
+- Do not run `helm install`, `helm upgrade`, `kubectl apply`, or any mutating command unless the user explicitly approves it for the target Kubernetes context and namespace.
+- Stop before installing if cluster-scoped RBAC, node labels, storage class, TLS mode, registry access, or multi-region prerequisites are unclear.
+- In production or restricted environments, involve TSE, the platform team, or the operator team before changing RBAC, webhook, operator, certificate, storage, or network configuration.
+
+## Step 1: Preflight the Kubernetes Context
+
+Run read-only checks first:
+
+```bash
+kubectl config current-context
+kubectl version --short
+helm version --short
+kubectl auth can-i create customresourcedefinitions.apiextensions.k8s.io
+kubectl auth can-i create clusterroles.rbac.authorization.k8s.io
+kubectl auth can-i create clusterrolebindings.rbac.authorization.k8s.io
+kubectl get nodes -o wide
+kubectl get nodes --show-labels | grep -E 'topology.kubernetes.io/(region|zone)' || true
+```
+
+Interpretation:
+
+- Kubernetes must be 1.30 or newer for the current v2 chart line.
+- Helm must be v3.
+- Node labels `topology.kubernetes.io/region` and `topology.kubernetes.io/zone` should exist before relying on default locality behavior.
+- Missing cluster-scoped RBAC is not automatically fatal, but it changes the install path. Use operator-chart `nodeReader` values or have a platform team pre-create the required bindings.
+
+## Step 2: Choose the Install Path
+
+### Published Split Charts (Recommended for Customers)
+
+Use this path for normal customer installs.
+
+```bash
+helm repo add cockroachdb-v2 https://charts.cockroachdb.com/v2 --force-update
+helm repo update cockroachdb-v2
+helm search repo cockroachdb-v2 --devel
+```
+
+Install the operator first:
+
+```bash
+helm upgrade --install crdb-operator cockroachdb-v2/cockroachdb-operator-chart \
+  --namespace cockroach-operator-system \
+  --create-namespace \
+  --version <operator-chart-version> \
+  --set cloudRegion=<current-region>
+
+kubectl -n cockroach-operator-system rollout status deploy/cockroach-operator --timeout=5m
+kubectl get crd crdbclusters.crdb.cockroachlabs.com crdbnodes.crdb.cockroachlabs.com
+```
+
+Then install CockroachDB:
+
+```bash
+helm upgrade --install crdb cockroachdb-v2/cockroachdb-chart \
+  --namespace cockroachdb \
+  --create-namespace \
+  --version <cockroachdb-chart-version> \
+  -f values.yaml
+```
+
+### Local Split Charts
+
+Use this path when working from a checkout of this repository:
+
+```bash
+helm upgrade --install crdb-operator ./cockroachdb-parent/charts/operator \
+  --namespace cockroach-operator-system \
+  --create-namespace \
+  --set cloudRegion=<current-region>
+
+kubectl -n cockroach-operator-system rollout status deploy/cockroach-operator --timeout=5m
+
+helm upgrade --install crdb ./cockroachdb-parent/charts/cockroachdb \
+  --namespace cockroachdb \
+  --create-namespace \
+  -f values.yaml
+```
+
+## Step 3: Create a Minimal Values File
+
+For a single-region secure install using the chart self-signer:
+
+```yaml
+cockroachdb:
+  clusterDomain: cluster.local
+  tls:
+    enabled: true
+    selfSigner:
+      enabled: true
+    certManager:
+      enabled: false
+    externalCertificates:
+      enabled: false
+  crdbCluster:
+    regions:
+      - code: us-east1
+        nodes: 3
+        cloudProvider: gcp
+        namespace: cockroachdb
+    dataStore:
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 100Gi
+          volumeMode: Filesystem
+```
+
+Adjust `code`, `cloudProvider`, `namespace`, storage size, and storage class to the customer environment. The region `code` should match the Kubernetes node region label and the operator chart `cloudRegion`.
+
+## Step 4: Verify the Install
+
+Check Kubernetes resources:
+
+```bash
+kubectl -n cockroach-operator-system get deploy cockroach-operator
+kubectl -n cockroach-operator-system logs deploy/cockroach-operator --tail=100
+kubectl -n cockroachdb get crdbcluster,crdbnode,pods,svc
+kubectl -n cockroachdb get crdbcluster crdb -o jsonpath='{.status.readyNodes}{" ready, reconciled="}{.status.reconciled}{" version="}{.status.version}{"\n"}'
+kubectl -n cockroachdb get crdbnodes -o custom-columns=NAME:.metadata.name,NODE_ID:.status.nodeID,CONDITIONS:.status.conditions[*].type,TOPOLOGY:.status.topologyValues
+```
+
+Expected state:
+
+- `cockroach-operator` Deployment is available.
+- CRDs `crdbclusters.crdb.cockroachlabs.com` and `crdbnodes.crdb.cockroachlabs.com` exist.
+- `CrdbCluster.status.reconciled` is `true` and `readyNodes` equals the regional node count.
+- Each `CrdbNode` has a `nodeID` and Ready/Running conditions.
+- CockroachDB pods are Running and Ready.
+
+For SQL verification, connect with the certificate mode selected by [configuring-cockroachdb-helm-tls](../../cockroachdb-operations-and-lifecycle/configuring-cockroachdb-helm-tls/SKILL.md), then run:
+
+```sql
+SELECT version();
+SHOW REGIONS;
+SHOW JOBS;
+```
+
+## Outputs
+
+Return a concise install report:
+
+- Kubernetes context, namespace, and chart path used
+- Operator release, CockroachDB release, and chart versions
+- Values file path or inline values that were applied
+- CRD registration status
+- `CrdbCluster` ready/reconciled status and node count
+- SQL verification result or the exact blocker if SQL could not be verified
+
+## Troubleshooting Handoff
+
+If any command fails, stop the install flow and use [diagnosing-cockroachdb-helm-deployments](../../cockroachdb-observability-and-diagnostics/diagnosing-cockroachdb-helm-deployments/SKILL.md). Preserve the exact command, stderr, namespace, release names, and values file path. If the failure remains unresolved or the operator appears stuck, gather [the operator escalation packet](../../cockroachdb-observability-and-diagnostics/collecting-cockroachdb-operator-escalation-packet/SKILL.md) before restarting or changing operator state.
+
+## References
+
+- [CockroachDB Helm Chart Versioning](../../../cockroachdb-parent/docs/VERSIONING.md)
+- [Operator Helm Chart README](../../../cockroachdb-parent/charts/operator/README.md)
+- [CockroachDB Helm Chart README](../../../cockroachdb-parent/charts/cockroachdb/README.md)
+- [CockroachDB Docs: Deploy with Kubernetes](https://www.cockroachlabs.com/docs/stable/deploy-cockroachdb-with-kubernetes)
+- [Helm Docs: Role-based Access Control](https://helm.sh/docs/topics/rbac/)

--- a/skills/cockroachdb-onboarding-and-migrations/validating-cockroachdb-helm-multiregion/SKILL.md
+++ b/skills/cockroachdb-onboarding-and-migrations/validating-cockroachdb-helm-multiregion/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: validating-cockroachdb-helm-multiregion
+description: Validates CockroachDB Helm chart values and Kubernetes prerequisites for operator-managed multi-region deployments. Use before adding a region, deploying CockroachDB across multiple Kubernetes clusters, checking region DNS domains, or confirming that all regions share certificate and networking assumptions.
+compatibility: CockroachDB Helm v2 charts with crdb.cockroachlabs.com/v1beta1 CrdbCluster resources. Requires access to each Kubernetes context participating in the multi-region deployment.
+metadata:
+  author: cockroachdb
+  version: "1.1"
+---
+
+# Validating CockroachDB Helm Multi-Region
+
+Validates the high-risk prerequisites for multi-region CockroachDB deployments managed by the Helm v2 charts and operator. Run this before the first region install and before adding every additional region.
+
+## When to Use This Skill
+
+- A customer is deploying CockroachDB across multiple Kubernetes clusters or regions
+- A new region is being added to an existing Helm-managed CockroachDB cluster
+- An agent needs to validate `cockroachdb.crdbCluster.regions` before `helm install` or `helm upgrade`
+- Cross-region DNS, namespace, or certificate assumptions are unclear
+
+## Required Inputs
+
+| Input | Example | Why It Matters |
+|---|---|---|
+| Region list in deployment order | `us-central1`, `us-east1` | Each region values file must include current and previously deployed regions |
+| Kubernetes context per region | `gke-prod-us-central1` | Commands must run against the correct cluster |
+| Namespace per region | `cockroachdb` | Used in generated join addresses |
+| Cluster domain per region | `cluster.gke.gcp-us-east1` | Other regions connect through this domain |
+| CA/certificate mode | self-signer with shared CA, cert-manager, external | Multi-region requires compatible trust across regions |
+
+## Safety Considerations
+
+- Do not deploy a new region until cross-region service discovery and network paths are proven.
+- Do not use different CA trust roots across regions.
+- Do not omit previously deployed regions from a new region's values file. The operator uses the full list to compute join addresses.
+- Confirm `operator.cloudRegion` matches the region reconciled by that operator instance.
+- If an existing multi-region cluster cannot join or reconcile, use the deployment diagnostic skill first and collect the operator escalation packet before restarting the operator.
+
+## Execution Discipline
+
+- Execute one step at a time and inspect the output before moving on. Region inventory, DNS results, network results, and certificate state determine which later checks are relevant.
+- Do not create debug pods, run interactive shells, use external diagnostic images, or perform Helm upgrades unless the user explicitly approves them for each participating cluster.
+- In air-gapped or private-registry environments, use customer-approved diagnostic images mirrored into the customer's registry.
+- In production or when cross-region networking, certificate trust, or locality is unclear, involve TSE or the operator team before adding regions or changing chart values.
+
+## Step 1: Validate Node Locality Labels
+
+For each Kubernetes context:
+
+```bash
+kubectl --context <context> get nodes \
+  -L topology.kubernetes.io/region,topology.kubernetes.io/zone
+```
+
+Expected:
+
+- Every schedulable node has the correct `topology.kubernetes.io/region`.
+- Nodes are spread across expected zones where zone failure survival is expected.
+- `cockroachdb.crdbCluster.regions[].code` matches the node region label for that cluster.
+
+## Step 2: Validate Values File Completeness
+
+Each region's values file must include all already deployed regions plus the current region.
+
+Example for deploying `us-east1` after `us-central1`:
+
+```yaml
+cockroachdb:
+  clusterDomain: cluster.gke.gcp-us-east1
+  crdbCluster:
+    regions:
+      - code: us-central1
+        nodes: 3
+        cloudProvider: gcp
+        domain: cluster.gke.gcp-us-central1
+        namespace: cockroachdb
+      - code: us-east1
+        nodes: 3
+        cloudProvider: gcp
+        domain: cluster.gke.gcp-us-east1
+        namespace: cockroachdb
+```
+
+Checklist:
+
+- `cockroachdb.clusterDomain` equals the current region's domain.
+- Every previous region appears under `cockroachdb.crdbCluster.regions`.
+- Every non-local region has `domain` and `namespace` set.
+- `nodes` matches the intended node count in each region.
+- `cloudProvider` is one of `gcp`, `aws`, `azure`, `k3d`, or empty for other environments.
+
+## Step 3: Validate Cross-Region DNS and Network Paths
+
+From a temporary debugging pod in each region, verify that peer region service names resolve and connect. Replace names with the actual release and namespace.
+
+```bash
+kubectl --context <context> -n <namespace> run crdb-dns-check \
+  --rm -it --restart=Never --image=busybox:1.36 -- sh
+```
+
+Inside the pod:
+
+```sh
+nslookup <release-name>.<peer-namespace>.svc.<peer-domain>
+nc -vz <release-name>.<peer-namespace>.svc.<peer-domain> 26258
+```
+
+If `nc` is unavailable, use an approved network diagnostic image or cloud-native connectivity test. Do not proceed until DNS and TCP connectivity are proven in both directions.
+
+## Step 4: Validate Certificate Trust Across Regions
+
+Use [configuring-cockroachdb-helm-tls](../../cockroachdb-operations-and-lifecycle/configuring-cockroachdb-helm-tls/SKILL.md) for the selected TLS mode, then apply these multi-region checks:
+
+- Self-signer with generated CA is appropriate only if the same CA trust material is shared across regions.
+- Self-signer with customer-provided CA requires the same CA Secret in every region namespace.
+- Cert-manager requires issuer configuration that produces certificates trusted by the same CA ConfigMap in every region.
+- External certificate mode requires all node, HTTP, and root client certificates to chain to the same CA trust root.
+
+Check CA presence without printing contents:
+
+```bash
+kubectl --context <context> -n <namespace> get configmap <ca-configmap> -o jsonpath='{.data.ca\.crt}' >/dev/null
+kubectl --context <context> -n <namespace> get secret <ca-secret> >/dev/null
+```
+
+## Step 5: Render Before Applying
+
+Use `helm template` before installing or upgrading each region:
+
+```bash
+helm template <release-name> cockroachdb-v2/cockroachdb-chart \
+  --version <cockroachdb-chart-version> \
+  --namespace <namespace> \
+  -f values-<region>.yaml > rendered-<region>.yaml
+
+grep -n "regions:" -A30 rendered-<region>.yaml
+grep -n "clusterDomain:" -A3 values-<region>.yaml
+```
+
+Confirm the rendered `CrdbCluster` contains the expected region list and certificate references.
+
+## Outputs
+
+Return a preflight report:
+
+- Region inventory and deployment order
+- Per-context node labels and zone spread
+- Per-region `clusterDomain`, `namespace`, and `regions` completeness
+- Cross-region DNS/TCP results
+- Certificate trust validation result
+- A clear go/no-go recommendation before Helm install or upgrade
+
+## References
+
+- [CockroachDB Helm Chart README: Multi Region Deployments](../../../cockroachdb-parent/charts/cockroachdb/README.md)
+- [Multi-region values example](../../../examples/cockroachdb-operator/multi-region-values.yaml)
+- [Diagnosing CockroachDB Helm deployments](../../cockroachdb-observability-and-diagnostics/diagnosing-cockroachdb-helm-deployments/SKILL.md)
+- [Operator escalation packet collection](../../cockroachdb-observability-and-diagnostics/collecting-cockroachdb-operator-escalation-packet/SKILL.md)
+- [CockroachDB Docs: Multi-Region Capabilities](https://www.cockroachlabs.com/docs/stable/multiregion-overview.html)
+- [CockroachDB Docs: cockroach start locality](https://www.cockroachlabs.com/docs/stable/cockroach-start.html#locality)

--- a/skills/cockroachdb-operations-and-lifecycle/configuring-cockroachdb-helm-tls/SKILL.md
+++ b/skills/cockroachdb-operations-and-lifecycle/configuring-cockroachdb-helm-tls/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: configuring-cockroachdb-helm-tls
+description: Selects and validates TLS settings for CockroachDB Helm chart deployments, including self-signer, cert-manager, and external certificate modes. Use when a customer needs secure CockroachDB Helm values, certificate secret mapping, cert-manager integration, or TLS install troubleshooting before deploying the chart.
+compatibility: CockroachDB Helm v2 charts. Requires Kubernetes Secret or cert-manager access for externally managed certificates. TLS mode must be chosen before initial cluster creation.
+metadata:
+  author: cockroachdb
+  version: "1.1"
+---
+
+# Configuring CockroachDB Helm TLS
+
+Guides TLS configuration for operator-managed CockroachDB clusters installed with the Helm v2 charts. The operator API receives `externalCertificates`; the Helm chart is responsible for translating self-signer, cert-manager, or external certificate values into the `CrdbCluster` spec.
+
+## When to Use This Skill
+
+- A customer asks which TLS mode to use with CockroachDB Helm charts
+- A values file needs a secure `cockroachdb.tls` block
+- The install fails with chart TLS validation errors
+- The customer already has cert-manager or externally generated certificates
+- The customer needs to understand which Secrets and ConfigMaps the chart expects
+
+## Safety Considerations
+
+- Do not change `cockroachdb.tls.enabled` on a running cluster.
+- Enable exactly one of `selfSigner.enabled`, `certManager.enabled`, or `externalCertificates.enabled` when `cockroachdb.tls.enabled=true`.
+- Disable all three certificate providers when `cockroachdb.tls.enabled=false`.
+- For production, confirm the certificate rotation owner before install. Self-signer can rotate node/client certs, but a customer-provided CA remains the customer's responsibility.
+- Do not print private key contents. Only reference Secret names and required keys.
+- For certificate rotation or trust failures on a running operator-managed cluster, collect certificate metadata and cert-reloader logs before changing Secrets, ConfigMaps, or cert-manager resources.
+
+## Execution Discipline
+
+- Execute one step at a time and inspect the output before moving on. Certificate mode, Secret names, and issuer state determine which later checks are relevant.
+- Do not change TLS mode, replace Secrets, patch cert-manager resources, run debug containers, or perform Helm upgrades unless the user explicitly approves the action for the target cluster.
+- Never print private key data. Use metadata checks for expiry, issuer, subject, SANs, and required key presence.
+- In production or when certificate ownership is unclear, involve TSE or the operator team before rotation, regeneration, debug containers, or restart actions.
+
+## Step 1: Choose the TLS Mode
+
+| Mode | Use When | Required Inputs |
+|---|---|---|
+| Self-signer | Fastest secure install, dev/test, or customer accepts chart-managed cert generation | Optional CA Secret if customer provides CA |
+| Cert-manager | Customer already runs cert-manager and wants Kubernetes-native renewal | Issuer or ClusterIssuer, CA ConfigMap, node Secret, root client Secret |
+| External certificates | Customer PKI owns all certificates and rotation | CA ConfigMap, node Secret, HTTP Secret, root SQL client Secret |
+| Insecure | Non-production test only | Explicit user confirmation |
+
+If the user is unsure, default to self-signer for a first secure non-production deployment and recommend cert-manager or external certificates for production environments with existing PKI.
+
+## Self-Signer Values
+
+Chart-managed CA, node certs, and root client certs:
+
+```yaml
+cockroachdb:
+  tls:
+    enabled: true
+    selfSigner:
+      enabled: true
+      rotateCerts: true
+    certManager:
+      enabled: false
+    externalCertificates:
+      enabled: false
+```
+
+Customer-provided CA with chart-generated node and client certs:
+
+```yaml
+cockroachdb:
+  tls:
+    enabled: true
+    selfSigner:
+      enabled: true
+      caProvided: true
+      caSecret: custom-ca-secret
+      rotateCerts: true
+    certManager:
+      enabled: false
+    externalCertificates:
+      enabled: false
+```
+
+The CA Secret must contain `ca.crt` and `ca.key` in the CockroachDB namespace before install.
+
+Validate:
+
+```bash
+kubectl -n <namespace> get secret custom-ca-secret
+helm template crdb ./cockroachdb-parent/charts/cockroachdb -n <namespace> -f values.yaml >/tmp/crdb-rendered.yaml
+```
+
+## Cert-Manager Values
+
+Use cert-manager when an Issuer or ClusterIssuer can issue CockroachDB node and root client certificates.
+
+```yaml
+cockroachdb:
+  tls:
+    enabled: true
+    selfSigner:
+      enabled: false
+    certManager:
+      enabled: true
+      caConfigMap: cockroachdb-ca
+      nodeSecret: cockroachdb-node
+      clientRootSecret: cockroachdb-root
+      issuer:
+        group: cert-manager.io
+        kind: Issuer
+        name: cockroachdb
+    externalCertificates:
+      enabled: false
+```
+
+Preflight:
+
+```bash
+kubectl -n <namespace> get issuer cockroachdb
+kubectl -n <namespace> get configmap cockroachdb-ca || true
+kubectl -n <namespace> get secret cockroachdb-node cockroachdb-root || true
+kubectl get crd certificates.cert-manager.io issuers.cert-manager.io
+```
+
+If cert-manager stores CA material in a Secret but the chart needs a ConfigMap, configure trust-manager or another approved process to publish `ca.crt` into the namespace.
+
+## External Certificate Values
+
+Use external certificates when the customer has already generated Kubernetes resources with the names the operator expects:
+
+```yaml
+cockroachdb:
+  tls:
+    enabled: true
+    selfSigner:
+      enabled: false
+    certManager:
+      enabled: false
+    externalCertificates:
+      enabled: true
+      certificates:
+        caConfigMapName: cockroachdb-ca
+        nodeSecretName: cockroachdb-node
+        httpSecretName: cockroachdb-node
+        rootSqlClientSecretName: cockroachdb-root
+```
+
+Expected data keys:
+
+| Resource | Required Keys |
+|---|---|
+| CA ConfigMap | `ca.crt` |
+| Node TLS Secret | `tls.crt`, `tls.key` |
+| HTTP TLS Secret | `tls.crt`, `tls.key` |
+| Root SQL client Secret | `tls.crt`, `tls.key` or chart-compatible root client cert keys |
+
+Validate names and keys without printing secret values:
+
+```bash
+kubectl -n <namespace> get configmap cockroachdb-ca -o jsonpath='{.data.ca\.crt}' >/dev/null
+kubectl -n <namespace> get secret cockroachdb-node -o jsonpath='{.data.tls\.crt}' >/dev/null
+kubectl -n <namespace> get secret cockroachdb-node -o jsonpath='{.data.tls\.key}' >/dev/null
+kubectl -n <namespace> get secret cockroachdb-root -o jsonpath='{.data.tls\.crt}' >/dev/null
+kubectl -n <namespace> get secret cockroachdb-root -o jsonpath='{.data.tls\.key}' >/dev/null
+```
+
+## Insecure Non-Production Values
+
+Only use for local testing or temporary non-production validation:
+
+```yaml
+cockroachdb:
+  tls:
+    enabled: false
+    selfSigner:
+      enabled: false
+    certManager:
+      enabled: false
+    externalCertificates:
+      enabled: false
+```
+
+State clearly that insecure mode has no TLS or authentication protections and is not suitable for production.
+
+## Post-Install Verification
+
+```bash
+kubectl -n <namespace> get crdbcluster <release-name> -o yaml | grep -A12 certificates
+kubectl -n <namespace> get secret,configmap | grep -E 'cockroach|crdb'
+kubectl -n <namespace> get pods
+```
+
+For self-signer, confirm the self-signer job ran and the generated CA, node, and client resources exist. For cert-manager, confirm `Certificate` resources are Ready. For external certificates, confirm the `CrdbCluster` references the expected names.
+
+## Certificate Debugging and Rotation Evidence
+
+Use this section when pods report `x509` errors, certificate rotation is not reflected in pods, the `cert-reloader` sidecar fails, or TSC asks for certificate evidence. Collect metadata only; do not print private keys.
+
+```bash
+kubectl -n <namespace> get crdbcluster <release-name> -o yaml | grep -A20 certificates
+kubectl -n <namespace> get secret,configmap | grep -E 'ca|node|client|tls|cert|cockroach|crdb'
+kubectl -n <namespace> get pod <pod-name> -o jsonpath='{.spec.containers[*].name}{"\n"}'
+kubectl -n <namespace> logs <pod-name> -c cert-reloader --tail=100
+```
+
+Inspect the node certificate:
+
+```bash
+kubectl -n <namespace> get secret <node-tls-secret> -o jsonpath='{.data.tls\.crt}' | base64 -d | \
+  openssl x509 -noout -dates -subject -issuer -ext subjectAltName
+```
+
+Inspect cert-manager resources, if cert-manager is used:
+
+```bash
+kubectl -n <namespace> get certificate,issuer -o wide
+kubectl get clusterissuer -o wide 2>/dev/null || true
+kubectl -n <namespace> describe certificate <certificate-name>
+kubectl -n <namespace> describe issuer <issuer-name>
+```
+
+If the CockroachDB image does not include network or OpenSSL tooling, use an approved debug image according to the customer's policy. In air-gapped environments, mirror the approved image into the customer's registry and use that registry path instead of pulling a public image directly.
+
+```bash
+kubectl -n <namespace> debug <pod-name> --image=<approved-network-debug-image> --target=cockroachdb -it -- \
+  openssl s_client -connect <pod-ip>:26257 \
+    -CAfile /cockroach/cockroach-certs/ca.crt \
+    -cert /cockroach/cockroach-certs/node.crt \
+    -key /cockroach/cockroach-certs/node.key
+```
+
+For full in-pod certificate metadata:
+
+```bash
+kubectl -n <namespace> debug <pod-name> --image=<approved-network-debug-image> --target=cockroachdb -it -- bash -c '
+for DIR in /cockroach/cockroach-certs /certs /cockroach-certs; do
+  if [ -d "$DIR" ]; then
+    echo "=== Cert directory: $DIR ==="
+    ls -la "$DIR" 2>/dev/null
+    for CERT in "$DIR"/*.crt; do
+      if [ -f "$CERT" ]; then
+        echo "--- $CERT ---"
+        openssl x509 -in "$CERT" -noout -subject -issuer -dates -ext subjectAltName 2>&1
+      fi
+    done
+  fi
+done'
+```
+
+Escalate with [collecting-cockroachdb-operator-escalation-packet](../../cockroachdb-observability-and-diagnostics/collecting-cockroachdb-operator-escalation-packet/SKILL.md) if certificates look correct but pods still cannot join, rotate, or become Ready.
+
+## Common TLS Failures
+
+| Symptom | Likely Cause | Action |
+|---|---|---|
+| `Exactly one of selfSigner, certManager or externalCertificates must be enabled when TLS is on` | Multiple or zero providers enabled | Set exactly one provider true |
+| `selfSigner, certManager and externalCertificates must all be disabled when TLS is off` | Provider enabled while TLS disabled | Disable all providers or enable TLS |
+| `caProvided` with empty `caSecret` | Customer CA mode missing Secret name | Set `cockroachdb.tls.selfSigner.caSecret` |
+| Pods fail with certificate trust errors | CA and issued certs do not match | Verify CA ConfigMap/Secret and regenerate certs from the same CA |
+| Cert rotation does not take effect | cert-reloader sidecar issue, stale mounted Secret, or cert-manager failure | Check cert-reloader logs, cert-manager `Certificate` status, and node cert expiry/SAN metadata |
+| Pods fail after migration with TLS errors | Migrated cert resources or CA names do not match operator references | Use the migration debugging skill and verify the `CrdbCluster` certificate references |
+
+## References
+
+- [Self-signer certificate management](../../../docs/certificate-management/self-signer.md)
+- [cert-manager certificate management](../../../docs/certificate-management/cert-manager.md)
+- [CockroachDB Helm Chart README](../../../cockroachdb-parent/charts/cockroachdb/README.md)
+- [CockroachDB Docs: Authentication](https://www.cockroachlabs.com/docs/stable/authentication.html)
+- [Operator escalation packet collection](../../cockroachdb-observability-and-diagnostics/collecting-cockroachdb-operator-escalation-packet/SKILL.md)


### PR DESCRIPTION
## Summary
- Add customer-facing CockroachDB Helm skills for install, deployment diagnosis, TLS setup/debugging, and multi-region validation.
- Add a dedicated operator migration debugging skill for Helm StatefulSet and public operator v1alpha1 to v1beta1 migrations.
- Add a separate operator escalation packet collection skill so TSC/TSE artifact gathering does not clutter the normal diagnostic flow.

## Tracking
- Jira: [CC-36481](https://cockroachlabs.atlassian.net/browse/CC-36481)

## Reviewer Context
This split is based on the current TSC/SRE runbooks used with customers:

- https://cockroachlabs.atlassian.net/wiki/spaces/SRE/pages/5464883229/CockroachDB+Operator+Escalation+Debugging+Runbook
- https://cockroachlabs.atlassian.net/wiki/spaces/SRE/pages/5666537508/Operator+Migration+Debugging

The general diagnostic skill stays focused on customer self-service checks and safe next actions. Escalation-only artifacts, pprof/metrics collection, and handoff packaging live in the new escalation packet skill.

## Validation
- Verified the working tree only contained the intended skill files before commit.
- Checked the skill files for trailing whitespace.

