### PR TITLE
feat(charts): expose spec.postInitSQL on CrdbCluster (v1beta1)

### DIFF
--- a/build/templates/cockroachdb-parent/charts/cockroachdb/README.md
+++ b/build/templates/cockroachdb-parent/charts/cockroachdb/README.md
@@ -131,6 +131,32 @@ Alternatively, a YAML file that specifies custom values for the parameters can b
 $ helm install $CRDBCLUSTER ./cockroachdb-parent/charts/cockroachdb -f my-values.yaml -n $NAMESPACE
 ```
 
+### Post-Init SQL
+
+`cockroachdb.crdbCluster.postInitSQL` sets `spec.postInitSQL` on the `CrdbCluster`
+resource. The operator runs these SQL sources once after cluster initialization.
+TLS must be enabled, and the `CrdbCluster` reconciliation mode must be empty/default or
+`MutableOnly`.
+
+```yaml
+cockroachdb:
+  crdbCluster:
+    postInitSQL:
+      secretRef:
+        name: license-sql
+        key: license.sql
+      configMapRef:
+        name: bootstrap-sql
+        key: init.sql
+      inline:
+        - "CREATE DATABASE IF NOT EXISTS myapp"
+        - "CREATE USER IF NOT EXISTS app_user"
+```
+
+`secretRef`, `configMapRef`, and `inline` are optional and run in that order.
+Failures are reported on the `PostInitSQLApplied` condition. Keep statements idempotent
+because a retry starts from the first statement.
+
 ### Multi Region Deployments
 
 For multi-region cluster deployments, ensure the required networking is setup which allows for service discovery across regions. Also, ensure that the same CA cert is used across all the regions.

--- a/build/templates/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/build/templates/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -179,6 +179,19 @@ cockroachdb:
     # clusterSettings captures the map of cluster settings to apply to the CockroachDB cluster.
     # https://www.cockroachlabs.com/docs/stable/cluster-settings.html
     clusterSettings: ~
+    # postInitSQL runs SQL statements once after the cluster is initialized.
+    # See README.md#post-init-sql for requirements and examples.
+    postInitSQL: ~
+      # inline:
+      #   - "CREATE DATABASE IF NOT EXISTS myapp"
+      #   - "CREATE USER IF NOT EXISTS app_user"
+      #   - "GRANT ALL ON DATABASE myapp TO app_user"
+      # configMapRef:
+      #   name: bootstrap-sql
+      #   key: init.sql
+      # secretRef:
+      #   name: license-sql
+      #   key: license.sql
     # timestamp captures the annotation timestamp used for rolling restarts.
     timestamp: "2021-10-18T00:00:00Z"
     # dataStore captures the disk configuration for CockroachDB storage.

--- a/build/templates/cockroachdb-parent/values.yaml
+++ b/build/templates/cockroachdb-parent/values.yaml
@@ -36,6 +36,10 @@
 #  # See https://www.cockroachlabs.com/docs/stable/cluster-settings.html
 #  clusterSettings: ~
 #
+#  # SQL statements to run once after cluster initialization.
+#  # See charts/cockroachdb/README.md#post-init-sql for requirements and examples.
+#  postInitSQL: ~
+#
 #  # loggingConf is the logging configuration used by cockroach.
 #  # More details: https://www.cockroachlabs.com/docs/stable/logging-overview.html
 #  # Use log.config below to define inline logging configuration instead.

--- a/cockroachdb-parent/Chart.lock
+++ b/cockroachdb-parent/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.0-rc.2
 - name: cockroachdb-chart
   repository: file://charts/cockroachdb
-  version: 26.2.1
-digest: sha256:2a15ea22b30e4d8d3a2d6e65664bad007a9e5c3aec79b8531af9e9761f4106fe
-generated: "2026-05-27T16:48:55.251652198Z"
+  version: 26.2.2
+digest: sha256:91e561155803175bbc1a73f4007efbc32dd3d04a88c51b9bbf28122a244e10f3
+generated: "2026-07-09T16:06:46.372359+05:30"

--- a/cockroachdb-parent/Chart.yaml
+++ b/cockroachdb-parent/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: cockroachdb-parent
 description: A parent Helm chart for CockroachDB and its operator using helm-spray
 type: application
-version: 26.2.1
-appVersion: 26.2.1
+version: 26.2.2
+appVersion: 26.2.2
 dependencies:
   - name: cockroachdb-operator-chart
     alias: operator
@@ -13,6 +13,6 @@ dependencies:
     repository: "file://charts/operator"
   - name: cockroachdb-chart
     alias: cockroachdb
-    version: 26.2.1
+    version: 26.2.2
     condition: cockroachdb.enabled
     repository: "file://charts/cockroachdb"

--- a/cockroachdb-parent/charts/cockroachdb/CHANGELOG.md
+++ b/cockroachdb-parent/charts/cockroachdb/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CockroachDB Chart — CHANGELOG
 
+## [Unreleased]
+### Added
+- Added `cockroachdb.crdbCluster.postInitSQL` for post-initialization SQL; see
+  [Post-Init SQL](README.md#post-init-sql).
+
+### Changed
+- Updated the default CockroachDB image version from `v26.2.1` to `v26.2.2`.
+
 ## [26.2.1] — 2026-06-11
 ### Changed
 - Updated the default CockroachDB image version from `v26.2.0` to `v26.2.1`.

--- a/cockroachdb-parent/charts/cockroachdb/Chart.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 name: cockroachdb-chart
 home: https://www.cockroachlabs.com
-version: 26.2.1
-appVersion: 26.2.1
+version: 26.2.2
+appVersion: 26.2.2
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png
 sources:

--- a/cockroachdb-parent/charts/cockroachdb/README.md
+++ b/cockroachdb-parent/charts/cockroachdb/README.md
@@ -132,6 +132,32 @@ Alternatively, a YAML file that specifies custom values for the parameters can b
 $ helm install $CRDBCLUSTER ./cockroachdb-parent/charts/cockroachdb -f my-values.yaml -n $NAMESPACE
 ```
 
+### Post-Init SQL
+
+`cockroachdb.crdbCluster.postInitSQL` sets `spec.postInitSQL` on the `CrdbCluster`
+resource. The operator runs these SQL sources once after cluster initialization.
+TLS must be enabled, and the `CrdbCluster` reconciliation mode must be empty/default or
+`MutableOnly`.
+
+```yaml
+cockroachdb:
+  crdbCluster:
+    postInitSQL:
+      secretRef:
+        name: license-sql
+        key: license.sql
+      configMapRef:
+        name: bootstrap-sql
+        key: init.sql
+      inline:
+        - "CREATE DATABASE IF NOT EXISTS myapp"
+        - "CREATE USER IF NOT EXISTS app_user"
+```
+
+`secretRef`, `configMapRef`, and `inline` are optional and run in that order.
+Failures are reported on the `PostInitSQLApplied` condition. Keep statements idempotent
+because a retry starts from the first statement.
+
 ### Multi Region Deployments
 
 For multi-region cluster deployments, ensure the required networking is setup which allows for service discovery across regions. Also, ensure that the same CA cert is used across all the regions.

--- a/cockroachdb-parent/charts/cockroachdb/templates/_helpers.tpl
+++ b/cockroachdb-parent/charts/cockroachdb/templates/_helpers.tpl
@@ -252,6 +252,19 @@ and none when TLS is off.
 {{- end -}}
 
 
+{{- define "cockroachdb.postInitSQL.validation" -}}
+{{- with .Values.cockroachdb.crdbCluster.postInitSQL }}
+{{- if not $.Values.cockroachdb.tls.enabled }}
+    {{ fail "postInitSQL requires cockroachdb.tls.enabled=true" }}
+{{- end }}
+{{- $mode := $.Values.cockroachdb.crdbCluster.mode | default "MutableOnly" }}
+{{- if ne $mode "MutableOnly" }}
+    {{ fail "postInitSQL requires cockroachdb.crdbCluster.mode to be empty or MutableOnly" }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+
 {{- define "cockroachdb.tls.certs.selfSigner.validation" -}}
 {{ include "cockroachdb.tls.certs.selfSigner.caProvidedValidation" . }}
 {{ include "cockroachdb.tls.certs.selfSigner.caCertValidation" . }}

--- a/cockroachdb-parent/charts/cockroachdb/templates/crdb.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/templates/crdb.yaml
@@ -1,5 +1,6 @@
 {{ template "cockroachdb.tlsValidation" . }}
 {{ template "cockroachdb.log.validation" . }}
+{{ template "cockroachdb.postInitSQL.validation" . }}
 {{- if .Release.IsUpgrade -}}
 {{ template "cockroachdb.isUpgradeAllowed" . }}
 {{- end -}}
@@ -23,6 +24,9 @@ spec:
   {{- end }}
   {{- with .Values.cockroachdb.crdbCluster.clusterSettings }}
   clusterSettings: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.cockroachdb.crdbCluster.postInitSQL }}
+  postInitSQL: {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.cockroachdb.crdbCluster.regions }}
   regions: {{- toYaml . | nindent 4 }}

--- a/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -164,7 +164,7 @@ cockroachdb:
     # image captures the container image settings for CockroachDB nodes.
     image:
       # name defines the CockroachDB container image.
-      name: cockroachdb/cockroach:v26.2.1
+      name: cockroachdb/cockroach:v26.2.2
       # pullPolicy defines the image pull policy for CockroachDB.
       pullPolicy: IfNotPresent
       # registry defines the container registry host (e.g., gcr.io, docker.io).
@@ -180,6 +180,19 @@ cockroachdb:
     # clusterSettings captures the map of cluster settings to apply to the CockroachDB cluster.
     # https://www.cockroachlabs.com/docs/stable/cluster-settings.html
     clusterSettings: ~
+    # postInitSQL runs SQL statements once after the cluster is initialized.
+    # See README.md#post-init-sql for requirements and examples.
+    postInitSQL: ~
+      # inline:
+      #   - "CREATE DATABASE IF NOT EXISTS myapp"
+      #   - "CREATE USER IF NOT EXISTS app_user"
+      #   - "GRANT ALL ON DATABASE myapp TO app_user"
+      # configMapRef:
+      #   name: bootstrap-sql
+      #   key: init.sql
+      # secretRef:
+      #   name: license-sql
+      #   key: license.sql
     # timestamp captures the annotation timestamp used for rolling restarts.
     timestamp: "2021-10-18T00:00:00Z"
     # dataStore captures the disk configuration for CockroachDB storage.
@@ -513,7 +526,7 @@ cockroachdb:
             #     fieldRef:
             #       fieldPath: metadata.name
             resources: {}
-            # image: cockroachdb/cockroach:v26.2.1
+            # image: cockroachdb/cockroach:v26.2.2
             # - name: cert-reloader
             #   image: docker.io/cockroachdb/cockroachdb-cert-reloader:v1.0.0-rc.2
 

--- a/cockroachdb-parent/values.yaml
+++ b/cockroachdb-parent/values.yaml
@@ -27,7 +27,7 @@
 #      namespace: test-cockroach
 #
 #  image:
-#    name: cockroachdb/cockroach:v26.2.1
+#    name: cockroachdb/cockroach:v26.2.2
 #    pullPolicy: IfNotPresent
 #
 #  nameOverride: ""
@@ -36,6 +36,10 @@
 #  # A map of CRDB cluster settings.
 #  # See https://www.cockroachlabs.com/docs/stable/cluster-settings.html
 #  clusterSettings: ~
+#
+#  # SQL statements to run once after cluster initialization.
+#  # See charts/cockroachdb/README.md#post-init-sql for requirements and examples.
+#  postInitSQL: ~
 #
 #  # loggingConf is the logging configuration used by cockroach.
 #  # More details: https://www.cockroachlabs.com/docs/stable/logging-overview.html

--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 21.0.1
-appVersion: 26.2.1
+version: 21.0.2
+appVersion: 26.2.2
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png
 sources:

--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -270,10 +270,10 @@ my-release-cockroachdb-init-nwjkh   0/1       ContainerCreating   0          6s
 $ kubectl get pods \
 -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[0].image}{"\n"}'
 
-my-release-cockroachdb-0    cockroachdb/cockroach:v26.2.1
-my-release-cockroachdb-1    cockroachdb/cockroach:v26.2.1
-my-release-cockroachdb-2    cockroachdb/cockroach:v26.2.1
-my-release-cockroachdb-3    cockroachdb/cockroach:v26.2.1
+my-release-cockroachdb-0    cockroachdb/cockroach:v26.2.2
+my-release-cockroachdb-1    cockroachdb/cockroach:v26.2.2
+my-release-cockroachdb-2    cockroachdb/cockroach:v26.2.2
+my-release-cockroachdb-3    cockroachdb/cockroach:v26.2.2
 ```
 
 Resume normal operations. Once you are comfortable that the stability and performance of the cluster is what you'd expect post-upgrade, finalize the upgrade:
@@ -358,7 +358,7 @@ For details see the [`values.yaml`](values.yaml) file.
 | `conf.store.attrs`                                        | CockroachDB storage attributes                                                                                                                                                                                                                                                                                                           | `""`                                                   |
 | `conf.wal-failover`                                       | CockroachDB WAL Failover configuration                                                                                                                                                                                                                                                                                                   | `{}`                                                   |
 | `image.repository`                                        | Container image name                                                                                                                                                                                                                                                                                                                     | `cockroachdb/cockroach`                                |
-| `image.tag`                                               | Container image tag                                                                                                                                                                                                                                                                                                                      | `v26.2.1`                                   |
+| `image.tag`                                               | Container image tag                                                                                                                                                                                                                                                                                                                      | `v26.2.2`                                   |
 | `image.pullPolicy`                                        | Container pull policy                                                                                                                                                                                                                                                                                                                    | `IfNotPresent`                                         |
 | `image.credentials`                                       | `registry`, `user` and `pass` credentials to pull private image                                                                                                                                                                                                                                                                          | `{}`                                                   |
 | `statefulset.replicas`                                    | StatefulSet replicas number                                                                                                                                                                                                                                                                                                              | `3`                                                    |

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -11,7 +11,7 @@ timestamp: "2021-10-18T00:00:00Z"
 
 image:
   repository: cockroachdb/cockroach
-  tag: v26.2.1
+  tag: v26.2.2
   pullPolicy: IfNotPresent
   credentials: {}
     # registry: docker.io

--- a/pkg/migrate/build-manifests_test.go
+++ b/pkg/migrate/build-manifests_test.go
@@ -215,6 +215,20 @@ func TestExportValuesFromV1beta1(t *testing.T) {
 					Nodes:         3,
 				},
 			},
+			PostInitSQL: &v1beta1.PostInitSQL{
+				Inline: []string{
+					"CREATE DATABASE IF NOT EXISTS smoke",
+					"CREATE USER IF NOT EXISTS app_user",
+				},
+				ConfigMapRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "bootstrap-sql"},
+					Key:                  "init.sql",
+				},
+				SecretRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "license-sql"},
+					Key:                  "license.sql",
+				},
+			},
 			Template: v1beta1.CrdbNodeTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"template-scope": "ignore-me"},
@@ -340,6 +354,20 @@ func TestExportValuesFromV1beta1(t *testing.T) {
 	crdbClusterValues, ok := cockroachdbValues["crdbCluster"].(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "logging-config", crdbClusterValues["loggingConfigMapName"])
+	postInitSQL, ok := crdbClusterValues["postInitSQL"].(map[string]interface{})
+	require.True(t, ok, "postInitSQL should be present in generated values.yaml")
+	assert.Equal(t, []interface{}{
+		"CREATE DATABASE IF NOT EXISTS smoke",
+		"CREATE USER IF NOT EXISTS app_user",
+	}, postInitSQL["inline"])
+	configMapRef, ok := postInitSQL["configMapRef"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "bootstrap-sql", configMapRef["name"])
+	assert.Equal(t, "init.sql", configMapRef["key"])
+	secretRef, ok := postInitSQL["secretRef"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "license-sql", secretRef["name"])
+	assert.Equal(t, "license.sql", secretRef["key"])
 	rbacValues, ok := crdbClusterValues["rbac"].(map[string]interface{})
 	require.True(t, ok)
 	serviceAccountValues, ok := rbacValues["serviceAccount"].(map[string]interface{})

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -454,6 +454,9 @@ func buildHelmValuesFromV1beta1(
 	if len(cluster.Spec.ClusterSettings) > 0 {
 		crdbCluster["clusterSettings"] = cluster.Spec.ClusterSettings
 	}
+	if cluster.Spec.PostInitSQL != nil {
+		crdbCluster["postInitSQL"] = cluster.Spec.PostInitSQL
+	}
 	if cluster.Spec.RollingRestartDelay != nil {
 		crdbCluster["rollingRestartDelay"] = cluster.Spec.RollingRestartDelay
 	}

--- a/pkg/upstream/cockroach-operator/api/v1beta1/crdbcluster_types.go
+++ b/pkg/upstream/cockroach-operator/api/v1beta1/crdbcluster_types.go
@@ -51,6 +51,24 @@ type CrdbNodeTemplate struct {
 	Spec CrdbNodeSpec `json:"spec,omitempty"`
 }
 
+// PostInitSQL specifies SQL statements to execute once after the cluster has
+// been initialized. Statements run in the order: secretRef contents, then
+// configMapRef contents, then inline. Any failure flips the
+// PostInitSQLApplied condition to False with the error in Reason/Message.
+// Users are responsible for writing idempotent SQL (IF NOT EXISTS,
+// ON CONFLICT DO NOTHING) because all statements replay from the beginning
+// after a fix.
+type PostInitSQL struct {
+	// Inline is an ordered list of SQL statements to execute.
+	Inline []string `json:"inline,omitempty"`
+
+	// ConfigMapRef references a ConfigMap key whose value is a SQL script.
+	ConfigMapRef *corev1.ConfigMapKeySelector `json:"configMapRef,omitempty"`
+
+	// SecretRef references a Secret key whose value is a SQL script.
+	SecretRef *corev1.SecretKeySelector `json:"secretRef,omitempty"`
+}
+
 // CrdbClusterSpec defines the desired state of CrdbCluster.
 // NOTE: Run "make" to regenerate code after modifying this file.
 // TODO(chrisseto): Add backward compatibility for all betaclusterctrl fields
@@ -79,6 +97,10 @@ type CrdbClusterSpec struct {
 	// therefore optional.
 	// +kubebuilder:validation:Optional
 	ClusterSettings map[string]string `json:"clusterSettings,omitempty"`
+
+	// PostInitSQL specifies SQL statements to run once after cluster
+	// initialization. See PostInitSQL for execution semantics.
+	PostInitSQL *PostInitSQL `json:"postInitSQL,omitempty"`
 
 	// Regions specifies the regions in which this cluster is deployed, along
 	// with information about how each region is configured.

--- a/tests/e2e/operator/compatibility/chart_compatibility_e2e_test.go
+++ b/tests/e2e/operator/compatibility/chart_compatibility_e2e_test.go
@@ -14,9 +14,11 @@ import (
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -101,12 +103,16 @@ func TestChartCompatibilityUpgrade(t *testing.T) {
 	requireOperatorMigrationFlag(t, kubectlOptions, false)
 
 	t.Log("Upgrading CockroachDB chart from the local checkout")
-	upgradeCockroachDBChart(t, kubectlOptions, helmChartPath)
+	postInitSQLDatabase := "compat_post_init"
+	upgradeCockroachDBChart(t, kubectlOptions, helmChartPath, map[string]string{
+		"cockroachdb.crdbCluster.postInitSQL.inline[0]": fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", postInitSQLDatabase),
+	})
 
 	testutil.RequireCRDBClusterToBeReadyEventuallyTimeout(t, kubectlOptions, testutil.CockroachCluster{
 		DesiredNodes: r.NodeCount,
 	}, 600*time.Second)
 	r.ValidateCRDB(t, cluster)
+	requirePostInitSQLDatabase(t, kubectlOptions, postInitSQLDatabase)
 
 	t.Log("Exercising release-specific migration and split-chart node-reader settings")
 	nodeReaderName := fmt.Sprintf("compat-node-reader-%s", r.Namespace[cluster])
@@ -317,6 +323,38 @@ func requireNodeReaderDelegatedToOperatorChart(
 	require.NoError(t, err)
 	lines := strings.Split(strings.TrimSpace(canReadNodes), "\n")
 	require.Equal(t, "yes", strings.TrimSpace(lines[len(lines)-1]))
+}
+
+func requirePostInitSQLDatabase(t *testing.T, kubectlOptions *k8s.KubectlOptions, databaseName string) {
+	t.Helper()
+
+	_, err := retry.DoWithRetryE(t, fmt.Sprintf("waiting for postInitSQL database %s", databaseName), 60, 10*time.Second, func() (string, error) {
+		pods, err := k8s.ListPodsE(t, kubectlOptions, metav1.ListOptions{
+			LabelSelector: operator.LabelSelector,
+		})
+		if err != nil {
+			return "", err
+		}
+		if len(pods) == 0 {
+			return "", fmt.Errorf("no pods found with label %s", operator.LabelSelector)
+		}
+
+		output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+			"exec", pods[0].Name, "-c", operator.CockroachContainerName, "--",
+			"/cockroach/cockroach", "sql",
+			"--certs-dir=/cockroach/cockroach-certs",
+			"--host=localhost:26257",
+			"-e", fmt.Sprintf("SELECT database_name FROM [SHOW DATABASES] WHERE database_name = '%s'", databaseName),
+		)
+		if err != nil {
+			return output, err
+		}
+		if !strings.Contains(output, databaseName) {
+			return output, fmt.Errorf("database %s not found", databaseName)
+		}
+		return output, nil
+	})
+	require.NoError(t, err)
 }
 
 func cockroachDBCompatibilityValues() map[string]string {

--- a/tests/template/cockroachdb_helm_template_test.go
+++ b/tests/template/cockroachdb_helm_template_test.go
@@ -2760,6 +2760,192 @@ func TestHelmOperatorClusterSettings(t *testing.T) {
 	}
 }
 
+// TestHelmOperatorPostInitSQL exercises rendering of spec.postInitSQL on the
+// CrdbCluster CR. Mirrors TestHelmOperatorClusterSettings.
+func TestHelmOperatorPostInitSQL(t *testing.T) {
+	t.Parallel()
+
+	type expect struct {
+		hasPostInitSQL bool
+		inline         []string
+		configMapName  string
+		configMapKey   string
+		secretName     string
+		secretKey      string
+	}
+
+	testCases := []struct {
+		name   string
+		values map[string]string
+		expect
+	}{
+		{
+			"Unset",
+			map[string]string{},
+			expect{hasPostInitSQL: false},
+		},
+		{
+			"Inline only",
+			map[string]string{
+				"cockroachdb.crdbCluster.postInitSQL.inline[0]": "CREATE DATABASE IF NOT EXISTS smoke",
+				"cockroachdb.crdbCluster.postInitSQL.inline[1]": "CREATE USER IF NOT EXISTS app_user",
+			},
+			expect{
+				hasPostInitSQL: true,
+				inline: []string{
+					"CREATE DATABASE IF NOT EXISTS smoke",
+					"CREATE USER IF NOT EXISTS app_user",
+				},
+			},
+		},
+		{
+			"ConfigMapRef only",
+			map[string]string{
+				"cockroachdb.crdbCluster.postInitSQL.configMapRef.name": "bootstrap-sql",
+				"cockroachdb.crdbCluster.postInitSQL.configMapRef.key":  "init.sql",
+			},
+			expect{
+				hasPostInitSQL: true,
+				configMapName:  "bootstrap-sql",
+				configMapKey:   "init.sql",
+			},
+		},
+		{
+			"SecretRef only",
+			map[string]string{
+				"cockroachdb.crdbCluster.postInitSQL.secretRef.name": "license-sql",
+				"cockroachdb.crdbCluster.postInitSQL.secretRef.key":  "license.sql",
+			},
+			expect{
+				hasPostInitSQL: true,
+				secretName:     "license-sql",
+				secretKey:      "license.sql",
+			},
+		},
+		{
+			"All three sources",
+			map[string]string{
+				"cockroachdb.crdbCluster.postInitSQL.inline[0]":         "CREATE DATABASE IF NOT EXISTS smoke",
+				"cockroachdb.crdbCluster.postInitSQL.configMapRef.name": "bootstrap-sql",
+				"cockroachdb.crdbCluster.postInitSQL.configMapRef.key":  "init.sql",
+				"cockroachdb.crdbCluster.postInitSQL.secretRef.name":    "license-sql",
+				"cockroachdb.crdbCluster.postInitSQL.secretRef.key":     "license.sql",
+			},
+			expect{
+				hasPostInitSQL: true,
+				inline:         []string{"CREATE DATABASE IF NOT EXISTS smoke"},
+				configMapName:  "bootstrap-sql",
+				configMapKey:   "init.sql",
+				secretName:     "license-sql",
+				secretKey:      "license.sql",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(subT *testing.T) {
+			subT.Parallel()
+
+			options := &helm.Options{
+				KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+				SetValues:      testCase.values,
+			}
+
+			chartPath := filepath.Join("../../cockroachdb-parent/charts/cockroachdb")
+
+			output, err := helm.RenderTemplateE(
+				subT, options, chartPath, releaseName, []string{"templates/crdb.yaml"},
+			)
+			require.NoError(subT, err)
+
+			var crdbCluster crdbv1beta1.CrdbCluster
+			helm.UnmarshalK8SYaml(t, output, &crdbCluster)
+
+			require.Equal(subT, "CrdbCluster", crdbCluster.Kind)
+			require.Equal(subT, "crdb.cockroachlabs.com/v1beta1", crdbCluster.APIVersion)
+
+			spec := crdbCluster.Spec
+
+			if !testCase.expect.hasPostInitSQL {
+				require.Nil(subT, spec.PostInitSQL)
+				return
+			}
+
+			require.NotNil(subT, spec.PostInitSQL, "Expected postInitSQL field to exist")
+			require.Equal(subT, testCase.expect.inline, spec.PostInitSQL.Inline)
+
+			if testCase.expect.configMapName != "" {
+				require.NotNil(subT, spec.PostInitSQL.ConfigMapRef)
+				require.Equal(subT, testCase.expect.configMapName, spec.PostInitSQL.ConfigMapRef.Name)
+				require.Equal(subT, testCase.expect.configMapKey, spec.PostInitSQL.ConfigMapRef.Key)
+			} else {
+				require.Nil(subT, spec.PostInitSQL.ConfigMapRef)
+			}
+
+			if testCase.expect.secretName != "" {
+				require.NotNil(subT, spec.PostInitSQL.SecretRef)
+				require.Equal(subT, testCase.expect.secretName, spec.PostInitSQL.SecretRef.Name)
+				require.Equal(subT, testCase.expect.secretKey, spec.PostInitSQL.SecretRef.Key)
+			} else {
+				require.Nil(subT, spec.PostInitSQL.SecretRef)
+			}
+		})
+	}
+}
+
+func TestHelmOperatorPostInitSQLValidation(t *testing.T) {
+	t.Parallel()
+
+	chartPath := filepath.Join("../../cockroachdb-parent/charts/cockroachdb")
+
+	testCases := []struct {
+		name       string
+		values     map[string]string
+		wantErrMsg string
+	}{
+		{
+			name: "CreateOnly mode",
+			values: map[string]string{
+				"cockroachdb.crdbCluster.mode":                  "CreateOnly",
+				"cockroachdb.crdbCluster.postInitSQL.inline[0]": "CREATE DATABASE IF NOT EXISTS smoke",
+			},
+			wantErrMsg: "postInitSQL requires cockroachdb.crdbCluster.mode to be empty or MutableOnly",
+		},
+		{
+			name: "Disabled mode",
+			values: map[string]string{
+				"cockroachdb.crdbCluster.mode":                  "Disabled",
+				"cockroachdb.crdbCluster.postInitSQL.inline[0]": "CREATE DATABASE IF NOT EXISTS smoke",
+			},
+			wantErrMsg: "postInitSQL requires cockroachdb.crdbCluster.mode to be empty or MutableOnly",
+		},
+		{
+			name: "TLS disabled",
+			values: map[string]string{
+				"cockroachdb.tls.enabled":                       "false",
+				"cockroachdb.tls.selfSigner.enabled":            "false",
+				"cockroachdb.tls.certManager.enabled":           "false",
+				"cockroachdb.tls.externalCertificates.enabled":  "false",
+				"cockroachdb.crdbCluster.postInitSQL.inline[0]": "CREATE DATABASE IF NOT EXISTS smoke",
+			},
+			wantErrMsg: "postInitSQL requires cockroachdb.tls.enabled=true",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(subT *testing.T) {
+			subT.Parallel()
+
+			options := &helm.Options{SetValues: testCase.values}
+			_, err := helm.RenderTemplateE(subT, options, chartPath, releaseName, []string{"templates/crdb.yaml"})
+			require.Error(subT, err)
+			require.Contains(subT, err.Error(), testCase.wantErrMsg)
+		})
+	}
+}
+
 // TestHelmClusterTLSConfiguration covers tests for CockroachDB TLS configuration
 // for both secure and insecure modes.
 func TestHelmClusterTLSConfiguration(t *testing.T) {


### PR DESCRIPTION
## Summary

Expose `cockroachdb.crdbCluster.postInitSQL` on the v2 CockroachDB chart so Helm can set `spec.postInitSQL` on the `CrdbCluster` resource. See [Post-Init SQL](https://github.com/cockroachdb/helm-charts/blob/vijaisha/postgres/cockroachdb-parent/charts/cockroachdb/README.md#post-init-sql) for usage details.

Also adds render-time validation for TLS and default/`MutableOnly` mode, preserves `postInitSQL` in v1beta1 `export-values` round trips, bumps the default CockroachDB image to `v26.2.2`, and covers enabling `postInitSQL` in the chart upgrade compatibility test.

Pairs with [cockroach-enterprise-operator#239](https://github.com/cockroachlabs/cockroach-enterprise-operator/pull/239).

## Test plan

- [x] `go run build/build.go generate`
- [x] `git diff --check`
- [x] `go test ./tests/template ./pkg/migrate -count=1`
- [x] `go test ./tests/e2e/operator/compatibility -run TestChartCompatibilityUpgrade -count=1`
- [x] Local k3d verification with an operator image built from `shcm-main`.

## Compatibility

Backwards compatible: the field is optional and additive; unset values render no changes to the CR.
