### PR TITLE
docs(charts): fix release changelog dates

### DIFF
--- a/cockroachdb-parent/charts/cockroachdb/CHANGELOG.md
+++ b/cockroachdb-parent/charts/cockroachdb/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CockroachDB Chart — CHANGELOG
 
-## [Unreleased]
+## [26.2.2] — 2026-07-23
 ### Added
 - Added `cockroachdb.crdbCluster.postInitSQL` for post-initialization SQL; see
   [Post-Init SQL](README.md#post-init-sql).

--- a/cockroachdb-parent/charts/operator/CHANGELOG.md
+++ b/cockroachdb-parent/charts/operator/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CockroachDB Operator Chart — CHANGELOG
 
-## [1.0.0-rc.3] — 2026-07-20
+## [1.0.0-rc.3] — 2026-07-23
 ### Added
 - Added support for `spec.postInitSQL` on `CrdbCluster` to run raw SQL once after cluster
   initialization. The CockroachDB chart exposes it through


### PR DESCRIPTION
## Summary

- Update the operator chart changelog date for `1.0.0-rc.3` to `2026-07-23`.
- Mark the CockroachDB chart changelog section as released `26.2.2` instead of `Unreleased`.

## Test plan

- [x] `git diff --check`