### PR TITLE
release: advance to v26.2.4

### DIFF
--- a/cockroachdb-parent/Chart.lock
+++ b/cockroachdb-parent/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.0-rc.3
 - name: cockroachdb-chart
   repository: file://charts/cockroachdb
-  version: 26.2.2
-digest: sha256:b185285858884f4be749ae733da39ab75ee3efe4cbf78ad39cab24cfdf7bff1f
-generated: "2026-07-20T15:55:54.661275+05:30"
+  version: 26.2.3
+digest: sha256:2e13debcabc3b2b526dae3352230b9a5b5b3b067c61df3432dbdfce7caa7f3a7
+generated: "2026-07-23T12:00:33.763166-04:00"

--- a/cockroachdb-parent/Chart.yaml
+++ b/cockroachdb-parent/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: cockroachdb-parent
 description: A parent Helm chart for CockroachDB and its operator using helm-spray
 type: application
-version: 26.2.2
-appVersion: 26.2.2
+version: 26.2.4
+appVersion: 26.2.4
 dependencies:
   - name: cockroachdb-operator-chart
     alias: operator
@@ -13,6 +13,6 @@ dependencies:
     repository: "file://charts/operator"
   - name: cockroachdb-chart
     alias: cockroachdb
-    version: 26.2.2
+    version: 26.2.3
     condition: cockroachdb.enabled
     repository: "file://charts/cockroachdb"

--- a/cockroachdb-parent/charts/cockroachdb/Chart.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 name: cockroachdb-chart
 home: https://www.cockroachlabs.com
-version: 26.2.2
-appVersion: 26.2.2
+version: 26.2.3
+appVersion: 26.2.4
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png
 sources:

--- a/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -164,7 +164,7 @@ cockroachdb:
     # image captures the container image settings for CockroachDB nodes.
     image:
       # name defines the CockroachDB container image.
-      name: cockroachdb/cockroach:v26.2.2
+      name: cockroachdb/cockroach:v26.2.4
       # pullPolicy defines the image pull policy for CockroachDB.
       pullPolicy: IfNotPresent
       # registry defines the container registry host (e.g., gcr.io, docker.io).
@@ -530,7 +530,7 @@ cockroachdb:
             #     fieldRef:
             #       fieldPath: metadata.name
             resources: {}
-            # image: cockroachdb/cockroach:v26.2.2
+            # image: cockroachdb/cockroach:v26.2.4
             # - name: cert-reloader
             #   image: docker.io/cockroachdb/cockroachdb-cert-reloader:v1.0.0-rc.3
 

--- a/cockroachdb-parent/values.yaml
+++ b/cockroachdb-parent/values.yaml
@@ -27,7 +27,7 @@
 #      namespace: test-cockroach
 #
 #  image:
-#    name: cockroachdb/cockroach:v26.2.2
+#    name: cockroachdb/cockroach:v26.2.4
 #    pullPolicy: IfNotPresent
 #
 #  nameOverride: ""

--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 21.0.2
-appVersion: 26.2.2
+version: 21.0.3
+appVersion: 26.2.4
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png
 sources:

--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -270,10 +270,10 @@ my-release-cockroachdb-init-nwjkh   0/1       ContainerCreating   0          6s
 $ kubectl get pods \
 -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[0].image}{"\n"}'
 
-my-release-cockroachdb-0    cockroachdb/cockroach:v26.2.2
-my-release-cockroachdb-1    cockroachdb/cockroach:v26.2.2
-my-release-cockroachdb-2    cockroachdb/cockroach:v26.2.2
-my-release-cockroachdb-3    cockroachdb/cockroach:v26.2.2
+my-release-cockroachdb-0    cockroachdb/cockroach:v26.2.4
+my-release-cockroachdb-1    cockroachdb/cockroach:v26.2.4
+my-release-cockroachdb-2    cockroachdb/cockroach:v26.2.4
+my-release-cockroachdb-3    cockroachdb/cockroach:v26.2.4
 ```
 
 Resume normal operations. Once you are comfortable that the stability and performance of the cluster is what you'd expect post-upgrade, finalize the upgrade:
@@ -358,7 +358,7 @@ For details see the [`values.yaml`](values.yaml) file.
 | `conf.store.attrs`                                        | CockroachDB storage attributes                                                                                                                                                                                                                                                                                                           | `""`                                                   |
 | `conf.wal-failover`                                       | CockroachDB WAL Failover configuration                                                                                                                                                                                                                                                                                                   | `{}`                                                   |
 | `image.repository`                                        | Container image name                                                                                                                                                                                                                                                                                                                     | `cockroachdb/cockroach`                                |
-| `image.tag`                                               | Container image tag                                                                                                                                                                                                                                                                                                                      | `v26.2.2`                                   |
+| `image.tag`                                               | Container image tag                                                                                                                                                                                                                                                                                                                      | `v26.2.4`                                   |
 | `image.pullPolicy`                                        | Container pull policy                                                                                                                                                                                                                                                                                                                    | `IfNotPresent`                                         |
 | `image.credentials`                                       | `registry`, `user` and `pass` credentials to pull private image                                                                                                                                                                                                                                                                          | `{}`                                                   |
 | `statefulset.replicas`                                    | StatefulSet replicas number                                                                                                                                                                                                                                                                                                              | `3`                                                    |

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -11,7 +11,7 @@ timestamp: "2021-10-18T00:00:00Z"
 
 image:
   repository: cockroachdb/cockroach
-  tag: v26.2.2
+  tag: v26.2.4
   pullPolicy: IfNotPresent
   credentials: {}
     # registry: docker.io


### PR DESCRIPTION
Advances the CockroachDB Helm charts to v26.2.4.

The automated post-release version-update step did not open this PR when 26.2.4 was published, so it is being created manually. Generated with `make bump/26.2.4`.

Epic: none