### PR TITLE
ci: run e2e and integration workflows on self-hosted runners

### DIFF
--- a/.github/workflows/advanced-features-tests.yaml
+++ b/.github/workflows/advanced-features-tests.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   advanced-features-single-region:
-    runs-on: ubuntu-latest-4-core
+    runs-on: [self-hosted, ubuntu_2404]
     strategy:
       fail-fast: false
       matrix:
@@ -63,7 +63,7 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   advanced-features-multi-region:
-    runs-on: ubuntu-latest-4-core
+    runs-on: [self-hosted, ubuntu_2404]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -219,7 +219,7 @@ jobs:
   # pre job to run helm e2e tests
   helm-install-e2e:
     name: Helm-E2E-Test
-    runs-on: ubuntu-latest-4-core
+    runs-on: [self-hosted, ubuntu_2404]
     needs: detect-heavy-e2e-change
     if: needs.detect-heavy-e2e-change.outputs.heavyE2E == 'true'
     steps:
@@ -247,7 +247,7 @@ jobs:
 
   helm-rotate-cert-e2e:
     name: Helm-rotate-cert-Test
-    runs-on: ubuntu-latest-4-core
+    runs-on: [self-hosted, ubuntu_2404]
     needs: detect-heavy-e2e-change
     if: needs.detect-heavy-e2e-change.outputs.heavyE2E == 'true'
     steps:
@@ -275,7 +275,7 @@ jobs:
 
   helm-single-region-e2e:
     name: Helm-single-region-Test
-    runs-on: ubuntu-latest-4-core
+    runs-on: [self-hosted, ubuntu_2404]
     needs: detect-heavy-e2e-change
     if: needs.detect-heavy-e2e-change.outputs.heavyE2E == 'true'
     steps:
@@ -305,7 +305,7 @@ jobs:
 
   chart-compatibility-e2e:
     name: Chart Compatibility E2E
-    runs-on: ubuntu-latest-4-core
+    runs-on: [self-hosted, ubuntu_2404]
     needs: detect-chart-version-change
     if: (needs.detect-chart-version-change.outputs.chartVersions == 'true')
     steps:
@@ -349,7 +349,7 @@ jobs:
 
   helm-multi-region-e2e:
     name: Helm-multi-region-Test
-    runs-on: ubuntu-latest-4-core
+    runs-on: [self-hosted, ubuntu_2404]
     needs: detect-heavy-e2e-change
     if: needs.detect-heavy-e2e-change.outputs.heavyE2E == 'true'
     steps:
@@ -376,7 +376,7 @@ jobs:
 
   controller-migration-e2e:
     name: controller-migration-e2e
-    runs-on: ubuntu-latest-4-core
+    runs-on: [self-hosted, ubuntu_2404]
     needs: detect-heavy-e2e-change
     if: needs.detect-heavy-e2e-change.outputs.heavyE2E == 'true'
     steps:
@@ -403,7 +403,7 @@ jobs:
 
   manual-migration-e2e:
     name: manual-migration-e2e
-    runs-on: ubuntu-latest-4-core
+    runs-on: [self-hosted, ubuntu_2404]
     needs: detect-heavy-e2e-change
     if: needs.detect-heavy-e2e-change.outputs.heavyE2E == 'true'
     steps:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   integration-tests-multi-region:
-    runs-on: ubuntu-latest-4-core
+    runs-on: [self-hosted, ubuntu_2404]
     strategy:
       fail-fast: false
       matrix:
@@ -59,7 +59,7 @@ jobs:
           test-name: "Multi-region e2e"
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
   integration-tests-single-region:
-    runs-on: ubuntu-latest-4-core
+    runs-on: [self-hosted, ubuntu_2404]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/k8s-compatibility-tests.yaml
+++ b/.github/workflows/k8s-compatibility-tests.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   cockroachdb-operator-single-region-e2e:
     name: CockroachDB Operator Single Region Test (k8s ${{ matrix.k8s-version }})
-    runs-on: ubuntu-latest-4-core
+    runs-on: [self-hosted, ubuntu_2404]
 
     strategy:
       fail-fast: false
@@ -59,7 +59,7 @@ jobs:
  
   cockroachdb-operator-multi-region-e2e:
     name: CockroachDB Operator Multi Region Test (k8s ${{ matrix.k8s-version }})
-    runs-on: ubuntu-latest-4-core
+    runs-on: [self-hosted, ubuntu_2404]
 
     strategy:
       fail-fast: false

--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,8 @@ test/cluster/bounce: bin/k3d test/cluster/down test/cluster/up ## restart a loca
 
 test/cluster/up: bin/k3d test/cluster/up/1
 
-test/cluster/up/%: bin/k3d
-	@bin/k3d cluster list | grep $(K3D_CLUSTER) || ./tests/k3d/dev-cluster.sh up --name "$(K3D_CLUSTER)" --nodes $*
+test/cluster/up/%: bin/k3d bin/kubectl
+	@bin/k3d cluster list | grep $(K3D_CLUSTER) || PATH="$(PWD)/bin:${PATH}" ./tests/k3d/dev-cluster.sh up --name "$(K3D_CLUSTER)" --nodes $*
 
 
 test/cluster/down: bin/k3d
@@ -155,8 +155,8 @@ test/e2e/manual-migrate: bin/cockroach bin/kubectl bin/helm bin/migration-helper
 	$(MAKE) test/cluster/down; \
 	exit $${EXIT_CODE:-0}
 
-test/single-cluster/up: bin/k3d
-	 ./tests/k3d/dev-multi-cluster.sh up --name "$(K3D_CLUSTER)" --nodes $(MULTI_REGION_NODE_SIZE) --clusters 1
+test/single-cluster/up: bin/k3d bin/kubectl
+	 PATH="$(PWD)/bin:${PATH}" ./tests/k3d/dev-multi-cluster.sh up --name "$(K3D_CLUSTER)" --nodes $(MULTI_REGION_NODE_SIZE) --clusters 1
 
 test/multi-cluster/down: bin/k3d
 	 ./tests/k3d/dev-multi-cluster.sh down

--- a/tests/k3d/dev-cluster.sh
+++ b/tests/k3d/dev-cluster.sh
@@ -174,7 +174,7 @@ case $COMMAND in
                 exit 1
             fi
             sleep 2
-            ((retry_count++))
+            retry_count=$((retry_count + 1))
         done
         echo "Cluster is ready"
         ;;


### PR DESCRIPTION
Switch the heavy e2e, integration, advanced-features, and k8s compatibility jobs from the GitHub-hosted `ubuntu-latest-4-core` runners to the self-hosted `[self-hosted, ubuntu_2404]` pool.

## Fixes needed to make the move work

The first run on the new pool failed in four jobs (`Helm-E2E-Test`, `Helm-rotate-cert-Test`, `controller-migration-e2e`, `manual-migration-e2e`), all with the same signature:

```
./tests/k3d/dev-cluster.sh: line 134: kubectl: command not found
...
Cluster 'chart-testing-cluster' created and configured successfully
Waiting for cluster to be ready...
make: *** [Makefile:122: test/cluster/up/1] Error 1
```

**`kubectl` is not installed on the self-hosted image.** The GitHub-hosted ubuntu images preinstall it, so this never surfaced before. The cluster setup scripts (`tests/k3d/dev-cluster.sh`, `tests/k3d/dev-multi-cluster.sh`) invoke bare `kubectl` from `PATH`. `bin/kubectl` was already being downloaded, and `./bin` is on `PATH` for the `go test` recipes — but `test/cluster/up` is a *prerequisite* target whose recipe never set `PATH`, so the scripts got the system `kubectl`.

Fixed by adding `bin/kubectl` as a prerequisite and exporting `PATH` on the two targets that shell out to those scripts (`test/cluster/up/%` and `test/single-cluster/up`). The teardown targets are untouched — neither `down` path calls `kubectl`.

**The readiness loop aborted after a single poll.** In `dev-cluster.sh`, `((retry_count++))` under `set -euo pipefail` returns exit status 1 on the first iteration, because post-increment evaluates to the pre-increment value of `0`:

```
$ bash -c 'set -euo pipefail; c=0; echo before; ((c++)); echo after'
before
$ echo $?
1
```

So instead of 30 retries and a "Timed out waiting for cluster to be ready" message, the script died 2 seconds in with a bare exit 1. Changed to `retry_count=$((retry_count + 1))`.

## Known follow-ups, not addressed here

- `if ! create_cluster; then` (`dev-cluster.sh:160`) suspends `errexit` for the entire function body. That is what swallowed `kubectl: command not found` and let the script report "created and configured successfully" while the node topology labels were silently never applied. With `kubectl` on `PATH` the labels now apply, but the next failure inside `create_cluster` will be masked the same way.
- Image import logs errors while reporting success:
  ```
  ERRO failed to import images in node 'k3d-chart-testing-cluster-server-0':
       ctr: content digest sha256:18f31f6a...: not found
  INFO Successfully imported 9 image(s)
  ```
  Same digest in all four failed jobs. This is the usual symptom of Docker's containerd image store being enabled — `docker save` emits an OCI index with attestation descriptors that `ctr images import` cannot fully resolve. k3d exits 0 regardless, so it does not fail the job, but preloaded images may not actually be in the cluster, which would show up as pull-time slowness or `ImagePullBackOff`.

## Runner requirements

For reference, what the new pool needs beyond what the workflows install themselves (Go via `setup-go`, gcloud via `setup-gcloud`, and cockroach/helm/k3d/kind/kubectl/yq/jq via the Makefile):

- Docker Engine, rootful, daemon running, runner user in the `docker` group
- `make`, `git`, `curl`, `tar`, `bash`, `awk`, `sed`
- `python3` (the gcloud SDK that `setup-gcloud` downloads is not the bundled-python build)
- No distro-packaged gcloud on `PATH` — `gcloud components install gke-gcloud-auth-plugin` fails against apt/snap installs
- Raised `fs.inotify.max_user_watches` / `max_user_instances`; multi-region brings up 3 clusters x 3 nodes
- At least the old 4 vCPU / 16 GB, and generous disk

One thing that gets *worse* on ephemeral self-hosted runners: no layer cache survives a job, and the pool shares one NAT egress IP, so anonymous Docker Hub pulls will hit rate limits far sooner than they did from GitHub-hosted. Worth a pull-through cache before the scheduled workflows go green.
