### PR TITLE
Add OpenShift advanced E2E CI support

### DIFF
--- a/.github/workflows/advanced-features-tests.yaml
+++ b/.github/workflows/advanced-features-tests.yaml
@@ -6,14 +6,21 @@ on:
   # Allow manual trigger on any branch
   workflow_dispatch:
 
+env:
+  OPENSHIFT_VERSION: "4.17.16"
+  SUBCTL_VERSION: "v0.24.0"
+
 jobs:
   advanced-features-single-region:
     runs-on: [self-hosted, ubuntu_2404]
     strategy:
       fail-fast: false
       matrix:
-        provider: [k3d, kind, gcp]
-    timeout-minutes: 120
+        provider: [k3d, kind, gcp, openshift]
+    timeout-minutes: 300
+    concurrency:
+      group: ${{ matrix.provider == 'openshift' && 'advanced-features-openshift' || format('advanced-features-{0}-{1}-{2}', github.run_id, github.job, matrix.provider) }}
+      cancel-in-progress: false
     permissions:
       contents: read
       id-token: write
@@ -30,7 +37,9 @@ jobs:
         id: auth
         with:
           token_format: access_token
-          project_id: 'cockroach-helm-testing'
+          create_credentials_file: true
+          export_environment_variables: true
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       - name: Set up gcloud CLI
@@ -38,22 +47,123 @@ jobs:
       - name: Install gke-gcloud-auth-plugin
         run: |
           gcloud components install gke-gcloud-auth-plugin
+      - name: Install OpenShift tools
+        if: ${{ matrix.provider == 'openshift' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p bin
+
+          curl -fsSL "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OPENSHIFT_VERSION}/openshift-install-linux.tar.gz" \
+            -o "${RUNNER_TEMP}/openshift-install-linux.tar.gz"
+          tar -xzf "${RUNNER_TEMP}/openshift-install-linux.tar.gz" -C bin openshift-install
+
+          curl -fsSL "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OPENSHIFT_VERSION}/openshift-client-linux.tar.gz" \
+            -o "${RUNNER_TEMP}/openshift-client-linux.tar.gz"
+          tar -xzf "${RUNNER_TEMP}/openshift-client-linux.tar.gz" -C bin oc kubectl
+
+          chmod +x bin/openshift-install bin/oc bin/kubectl
+
+          echo "${PWD}/bin" >> "${GITHUB_PATH}"
+          bin/openshift-install version
+          bin/oc version --client
+          bin/kubectl version --client
+      - name: Generate OpenShift SSH key
+        if: ${{ matrix.provider == 'openshift' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ssh-keygen -t ed25519 -N "" -f "${RUNNER_TEMP}/openshift-ci-ssh-key" -C "helm-charts-ci@cockroachlabs.com"
+          {
+            echo "OPENSHIFT_SSH_PUB_KEY<<EOF"
+            cat "${RUNNER_TEMP}/openshift-ci-ssh-key.pub"
+            echo "EOF"
+          } >> "${GITHUB_ENV}"
       - name: Run tests (advanced features - single region)
+        if: ${{ matrix.provider != 'openshift' }}
         env:
           PROVIDER: ${{ matrix.provider }}
           TEST_ADVANCED_FEATURES: true
-          USE_GKE_GCLOUD_AUTH_PLUGIN: True
+          USE_GKE_GCLOUD_AUTH_PLUGIN: true
         run: |
           set -euo pipefail
           make test/nightly-e2e/advanced/single-region | tee test_output.log
+      - name: Run tests (advanced features - single region - OpenShift)
+        if: ${{ matrix.provider == 'openshift' }}
+        env:
+          PROVIDER: ${{ matrix.provider }}
+          TEST_ADVANCED_FEATURES: true
+          USE_GKE_GCLOUD_AUTH_PLUGIN: true
+          TMPDIR: ${{ runner.temp }}
+          OPENSHIFT_DEBUG_DIR: ${{ runner.temp }}/openshift-debug
+          OPENSHIFT_DEBUG_GCS_URI: gs://${{ secrets.GCP_PROJECT_ID }}-openshift-ci-debug/${{ github.run_id }}/${{ github.run_attempt }}/single-region
+          OPENSHIFT_BASE_DOMAIN: ${{ secrets.OPENSHIFT_BASE_DOMAIN }}
+          OPENSHIFT_PULL_SECRET: ${{ secrets.OPENSHIFT_PULL_SECRET }}
+          OPENSHIFT_ENABLE_SUBMARINER: "false"
+          OPENSHIFT_SKIP_TEARDOWN: "false"
+        run: |
+          set -euo pipefail
+
+          ./build/openshift-ci-debug.sh ensure-gcs
+          ./build/openshift-ci-debug.sh snapshot before-single-region
+          ./build/openshift-ci-debug.sh watch 120 &
+          debug_pid="$!"
+          finish_debug() {
+            status="$?"
+            kill "${debug_pid}" 2>/dev/null || true
+            wait "${debug_pid}" 2>/dev/null || true
+            ./build/openshift-ci-debug.sh snapshot after-single-region || true
+            ./build/openshift-ci-debug.sh sync || true
+            exit "${status}"
+          }
+          trap finish_debug EXIT
+
+          unset OPENSHIFT_REUSE_CONTEXTS OPENSHIFT_REUSE_KUBECONFIG OPENSHIFT_REUSE_KUBECONFIGS
+          stdbuf -oL -eL make test/nightly-e2e/advanced/single-region 2>&1 | tee test_output.log
       - name: Archive test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: advanced-single-region-results-${{ matrix.provider }}
+          if-no-files-found: ignore
+          include-hidden-files: true
           path: |
             test_output.log
             test_output.json
+            ${{ runner.temp }}/openshift-debug/*.log
+            ${{ runner.temp }}/helm-charts-ocp-*/.openshift_install.log
+            ${{ runner.temp }}/helm-charts-ocp-*/metadata.json
+      - name: Clean up OpenShift installer state
+        if: ${{ always() && matrix.provider == 'openshift' }}
+        shell: bash
+        env:
+          TMPDIR: ${{ runner.temp }}
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          OPENSHIFT_DEBUG_DIR: ${{ runner.temp }}/openshift-debug
+          OPENSHIFT_DEBUG_GCS_URI: gs://${{ secrets.GCP_PROJECT_ID }}-openshift-ci-debug/${{ github.run_id }}/${{ github.run_attempt }}/single-region
+          OPENSHIFT_BASE_DOMAIN: ${{ secrets.OPENSHIFT_BASE_DOMAIN }}
+          OPENSHIFT_SKIP_TEARDOWN: "false"
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          if [[ "${OPENSHIFT_SKIP_TEARDOWN}" == "true" ]]; then
+            echo "OPENSHIFT_SKIP_TEARDOWN=true; preserving OpenShift installer state"
+            ./build/openshift-ci-debug.sh snapshot skip-teardown-single-region || true
+            ./build/openshift-ci-debug.sh sync || true
+            exit 0
+          fi
+
+          ./build/openshift-ci-debug.sh cleanup-multicluster || true
+
+          for install_dir in "${TMPDIR}"/helm-charts-ocp-*; do
+            [[ -d "${install_dir}" ]] || continue
+            echo "Destroying leftover OpenShift cluster from ${install_dir}"
+            openshift-install destroy cluster --dir "${install_dir}" --log-level info || true
+            rm -rf "${install_dir}"
+          done
       - name: Slack notification
         if: ${{ always() && github.ref_name == 'master' }}
         uses: ./.github/actions/slack-test-notification
@@ -67,8 +177,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        provider: [k3d, kind, gcp]
-    timeout-minutes: 120
+        provider: [k3d, kind, gcp, openshift]
+    timeout-minutes: 420
+    concurrency:
+      group: ${{ matrix.provider == 'openshift' && 'advanced-features-openshift' || format('advanced-features-{0}-{1}-{2}', github.run_id, github.job, matrix.provider) }}
+      cancel-in-progress: false
     permissions:
       contents: read
       id-token: write
@@ -85,7 +198,9 @@ jobs:
         id: auth
         with:
           token_format: access_token
-          project_id: 'cockroach-helm-testing'
+          create_credentials_file: true
+          export_environment_variables: true
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       - name: Set up gcloud CLI
@@ -93,22 +208,131 @@ jobs:
       - name: Install gke-gcloud-auth-plugin
         run: |
           gcloud components install gke-gcloud-auth-plugin
+      - name: Install OpenShift tools
+        if: ${{ matrix.provider == 'openshift' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p bin
+
+          curl -fsSL "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OPENSHIFT_VERSION}/openshift-install-linux.tar.gz" \
+            -o "${RUNNER_TEMP}/openshift-install-linux.tar.gz"
+          tar -xzf "${RUNNER_TEMP}/openshift-install-linux.tar.gz" -C bin openshift-install
+
+          curl -fsSL "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OPENSHIFT_VERSION}/openshift-client-linux.tar.gz" \
+            -o "${RUNNER_TEMP}/openshift-client-linux.tar.gz"
+          tar -xzf "${RUNNER_TEMP}/openshift-client-linux.tar.gz" -C bin oc kubectl
+
+          chmod +x bin/openshift-install bin/oc bin/kubectl
+
+          make bin/subctl
+          bin/subctl version
+
+          echo "${PWD}/bin" >> "${GITHUB_PATH}"
+          bin/openshift-install version
+          bin/oc version --client
+          bin/kubectl version --client
+      - name: Generate OpenShift SSH key
+        if: ${{ matrix.provider == 'openshift' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ssh-keygen -t ed25519 -N "" -f "${RUNNER_TEMP}/openshift-ci-ssh-key" -C "helm-charts-ci@cockroachlabs.com"
+          {
+            echo "OPENSHIFT_SSH_PUB_KEY<<EOF"
+            cat "${RUNNER_TEMP}/openshift-ci-ssh-key.pub"
+            echo "EOF"
+          } >> "${GITHUB_ENV}"
       - name: Run tests (advanced features - multi region)
+        if: ${{ matrix.provider != 'openshift' }}
         env:
           PROVIDER: ${{ matrix.provider }}
           TEST_ADVANCED_FEATURES: true
-          USE_GKE_GCLOUD_AUTH_PLUGIN: True
+          USE_GKE_GCLOUD_AUTH_PLUGIN: true
         run: |
           set -euo pipefail
           make test/nightly-e2e/advanced/multi-region | tee test_output.log
+      - name: Run tests (advanced features - multi region - OpenShift)
+        if: ${{ matrix.provider == 'openshift' }}
+        env:
+          PROVIDER: ${{ matrix.provider }}
+          TEST_ADVANCED_FEATURES: true
+          USE_GKE_GCLOUD_AUTH_PLUGIN: true
+          TMPDIR: ${{ runner.temp }}
+          OPENSHIFT_DEBUG_DIR: ${{ runner.temp }}/openshift-debug
+          OPENSHIFT_DEBUG_GCS_URI: gs://${{ secrets.GCP_PROJECT_ID }}-openshift-ci-debug/${{ github.run_id }}/${{ github.run_attempt }}/multi-region
+          OPENSHIFT_BASE_DOMAIN: ${{ secrets.OPENSHIFT_BASE_DOMAIN }}
+          OPENSHIFT_PULL_SECRET: ${{ secrets.OPENSHIFT_PULL_SECRET }}
+          OPENSHIFT_ENABLE_SUBMARINER: "true"
+          OPENSHIFT_SKIP_TEARDOWN: "false"
+        run: |
+          set -euo pipefail
+
+          ./build/openshift-ci-debug.sh ensure-gcs
+          ./build/openshift-ci-debug.sh snapshot before-multi-region
+          ./build/openshift-ci-debug.sh watch 60 &
+          debug_pid="$!"
+          while true; do
+            ./build/openshift-ci-debug.sh sync || true
+            sleep 15
+          done &
+          sync_pid="$!"
+          finish_debug() {
+            status="$?"
+            kill "${debug_pid}" "${sync_pid}" 2>/dev/null || true
+            wait "${debug_pid}" "${sync_pid}" 2>/dev/null || true
+            ./build/openshift-ci-debug.sh snapshot after-multi-region || true
+            ./build/openshift-ci-debug.sh sync || true
+            exit "${status}"
+          }
+          trap finish_debug EXIT
+
+          unset OPENSHIFT_REUSE_CONTEXTS OPENSHIFT_REUSE_KUBECONFIG OPENSHIFT_REUSE_KUBECONFIGS
+          stdbuf -oL -eL make test/nightly-e2e/advanced/multi-region > >(tee test_output.log) 2>&1
       - name: Archive test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: advanced-multi-region-results-${{ matrix.provider }}
+          if-no-files-found: ignore
+          include-hidden-files: true
           path: |
             test_output.log
             test_output.json
+            ${{ runner.temp }}/openshift-debug/*.log
+            ${{ runner.temp }}/helm-charts-ocp-*/.openshift_install.log
+            ${{ runner.temp }}/helm-charts-ocp-*/metadata.json
+      - name: Clean up OpenShift installer state
+        if: ${{ always() && matrix.provider == 'openshift' }}
+        shell: bash
+        env:
+          TMPDIR: ${{ runner.temp }}
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          OPENSHIFT_DEBUG_DIR: ${{ runner.temp }}/openshift-debug
+          OPENSHIFT_DEBUG_GCS_URI: gs://${{ secrets.GCP_PROJECT_ID }}-openshift-ci-debug/${{ github.run_id }}/${{ github.run_attempt }}/multi-region
+          OPENSHIFT_BASE_DOMAIN: ${{ secrets.OPENSHIFT_BASE_DOMAIN }}
+          OPENSHIFT_SKIP_TEARDOWN: "false"
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          if [[ "${OPENSHIFT_SKIP_TEARDOWN}" == "true" ]]; then
+            echo "OPENSHIFT_SKIP_TEARDOWN=true; preserving OpenShift installer state"
+            ./build/openshift-ci-debug.sh snapshot skip-teardown-multi-region || true
+            ./build/openshift-ci-debug.sh sync || true
+            exit 0
+          fi
+
+          ./build/openshift-ci-debug.sh cleanup-multicluster || true
+
+          for install_dir in "${TMPDIR}"/helm-charts-ocp-*; do
+            [[ -d "${install_dir}" ]] || continue
+            echo "Destroying leftover OpenShift cluster from ${install_dir}"
+            openshift-install destroy cluster --dir "${install_dir}" --log-level info || true
+            rm -rf "${install_dir}"
+          done
       - name: Slack notification
         if: ${{ always() && github.ref_name == 'master' }}
         uses: ./.github/actions/slack-test-notification

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ ifeq ($(UNAME_S),Linux)
   JQ_BIN ?= https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
   OPM_TAR ?= https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.8/opm-linux-4.8.57.tar.gz
   OPM_BIN ?= opm
+  SUBCTL_BIN ?= https://github.com/submariner-io/releases/releases/download/$(SUBCTL_VERSION)/subctl-$(SUBCTL_VERSION)-linux-amd64.tar.xz
 endif
 ifeq ($(UNAME_S),Darwin)
   COCKROACH_BIN ?= https://binaries.cockroachdb.com/cockroach-v26.2.1.darwin-10.9-amd64.tgz
@@ -21,6 +22,7 @@ ifeq ($(UNAME_S),Darwin)
   JQ_BIN ?= https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64
   OPM_TAR ?= https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.8/opm-mac-4.8.57.tar.gz
   OPM_BIN ?= darwin-amd64-opm
+  SUBCTL_BIN ?= https://github.com/submariner-io/releases/releases/download/$(SUBCTL_VERSION)/subctl-$(SUBCTL_VERSION)-darwin-arm64.tar.xz
 endif
 
 K3D_CLUSTER ?= chart-testing
@@ -30,6 +32,7 @@ DOCKER_NETWORK_NAME ?= "k3d-${K3D_CLUSTER}"
 LOCAL_REGISTRY ?= "localhost:5000"
 MULTI_REGION_NODE_SIZE ?= 3
 REGIONS ?= 3
+SUBCTL_VERSION ?= v0.24.0
 
 export BUNDLE_IMAGE ?= cockroach-operator-bundle
 export HELM_OPERATOR_IMAGE ?= cockroach-helm-operator
@@ -140,7 +143,11 @@ test/e2e/%: bin/cockroach bin/kubectl bin/helm build/self-signer test/cluster/up
 	$(MAKE) test/cluster/down; \
 	exit $${EXIT_CODE:-0}
 
-test/e2e/multi-region: bin/cockroach bin/kubectl bin/helm  build/self-signer bin/k3d bin/kind
+ifeq ($(PROVIDER),openshift)
+MULTI_REGION_PROVIDER_DEPS := bin/subctl
+endif
+
+test/e2e/multi-region: bin/cockroach bin/kubectl bin/helm  build/self-signer bin/k3d bin/kind $(MULTI_REGION_PROVIDER_DEPS)
 	@PATH="$(PWD)/bin:${PATH}" go test -timeout 90m -v -test.run TestOperatorInMultiRegion ./tests/e2e/operator/multiRegion/... || (echo "Multi region tests failed with exit code $$?" && exit 1)
 
 test/e2e/single-region: bin/cockroach bin/kubectl bin/helm build/self-signer bin/k3d bin/kind
@@ -173,7 +180,7 @@ test/multi-cluster/down: bin/k3d
 test/nightly-e2e/advanced/single-region: bin/cockroach bin/kubectl bin/helm build/self-signer bin/kind
 	@PATH="$(PWD)/bin:${PATH}" PROVIDER=$${PROVIDER:-kind} TEST_ADVANCED_FEATURES=true go test -timeout 90m -v -test.run TestOperatorInSingleRegion ./tests/e2e/operator/singleRegion/... || (echo "Advanced single-region tests failed with exit code $$?" && exit 1)
 
-test/nightly-e2e/advanced/multi-region: bin/cockroach bin/kubectl bin/helm build/self-signer bin/kind
+test/nightly-e2e/advanced/multi-region: bin/cockroach bin/kubectl bin/helm build/self-signer bin/kind $(MULTI_REGION_PROVIDER_DEPS)
 	@PATH="$(PWD)/bin:${PATH}" PROVIDER=$${PROVIDER:-kind} TEST_ADVANCED_FEATURES=true go test -timeout 90m -v -test.run TestOperatorInMultiRegion ./tests/e2e/operator/multiRegion/... || (echo "Advanced multi-region tests failed with exit code $$?" && exit 1)
 
 
@@ -215,6 +222,11 @@ bin/kubectl: ## install kubectl
 	@mkdir -p bin
 	@curl -Lo bin/kubectl $(KUBECTL_BIN)
 	@chmod +x bin/kubectl
+
+bin/subctl: ## install subctl
+	@mkdir -p bin
+	@curl -L $(SUBCTL_BIN) | tar -xJf - -C bin/ --strip-components 1 subctl-$(SUBCTL_VERSION)/subctl
+	@chmod +x bin/subctl
 
 bin/kind: ## install kind
 	@mkdir -p bin

--- a/build/openshift-ci-debug.sh
+++ b/build/openshift-ci-debug.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_id="${GCP_PROJECT_ID:-}"
+if [[ -z "${project_id}" ]]; then
+  echo "GCP_PROJECT_ID is required" >&2
+  exit 1
+fi
+
+debug_dir="${OPENSHIFT_DEBUG_DIR:-${RUNNER_TEMP:-/tmp}/openshift-debug}"
+mkdir -p "${debug_dir}"
+gcs_uri="${OPENSHIFT_DEBUG_GCS_URI:-}"
+
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+run_gcloud() {
+  echo "+ gcloud $*"
+  gcloud "$@" || true
+}
+
+install_dirs() {
+  local tmpdir="${TMPDIR:-${RUNNER_TEMP:-/tmp}}"
+  find "${tmpdir}" -maxdepth 1 -type d -name "helm-charts-ocp-*" 2>/dev/null | sort || true
+}
+
+infra_ids() {
+  local install_dir metadata infra_id
+  for install_dir in $(install_dirs); do
+    metadata="${install_dir}/metadata.json"
+    [[ -f "${metadata}" ]] || continue
+    infra_id="$(sed -n 's/.*"infraID"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${metadata}" | head -1)"
+    [[ -n "${infra_id}" ]] || continue
+    printf "%s\n" "${infra_id}"
+  done
+}
+
+snapshot() {
+  local label="${1:-snapshot}"
+  local file="${debug_dir}/gcp-${label}-$(date -u +"%Y%m%dT%H%M%SZ").log"
+
+  {
+    echo "OpenShift CI debug snapshot: ${label}"
+    echo "Timestamp: $(timestamp)"
+    echo "Project: ${project_id}"
+    echo
+
+    echo "Install directories:"
+    install_dirs
+    echo
+
+    echo "Infra IDs from metadata:"
+    infra_ids
+    echo
+
+    echo "OpenShift networks:"
+    run_gcloud compute networks list \
+      --project="${project_id}" \
+      --filter="name~'^ocp-'" \
+      --format="table(name,description,creationTimestamp)"
+    echo
+
+    echo "OpenShift instances:"
+    run_gcloud compute instances list \
+      --project="${project_id}" \
+      --filter="name~'^ocp-'" \
+      --format="table(name,zone,status,machineType.basename(),networkInterfaces[0].network.basename(),creationTimestamp)"
+    echo
+
+    echo "OpenShift disks:"
+    run_gcloud compute disks list \
+      --project="${project_id}" \
+      --filter="name~'^ocp-'" \
+      --format="table(name,zone,sizeGb,status,users.basename(),creationTimestamp)"
+    echo
+
+    echo "OpenShift forwarding rules:"
+    run_gcloud compute forwarding-rules list \
+      --project="${project_id}" \
+      --filter="name~'^ocp-' OR target~'ocp-'" \
+      --format="table(name,region,IPAddress,IPProtocol,loadBalancingScheme,target.basename(),network.basename(),creationTimestamp)"
+    echo
+
+    echo "OpenShift addresses:"
+    run_gcloud compute addresses list \
+      --project="${project_id}" \
+      --filter="name~'^ocp-' OR users~'ocp-'" \
+      --format="table(name,region,address,status,users.basename(),creationTimestamp)"
+    echo
+
+    echo "OpenShift firewall rules:"
+    run_gcloud compute firewall-rules list \
+      --project="${project_id}" \
+      --filter="name~'^ocp-' OR name~'^k8s-' OR network~'ocp-'" \
+      --format="table(name,network.basename(),sourceRanges.list(),allowed[].map().firewall_rule().list(),targetTags.list(),creationTimestamp)"
+    echo
+
+    echo "OpenShift routers:"
+    run_gcloud compute routers list \
+      --project="${project_id}" \
+      --filter="name~'^ocp-' OR network~'ocp-'" \
+      --format="table(name,region,network.basename(),creationTimestamp)"
+    echo
+
+    echo "OpenShift compute operations:"
+    run_gcloud compute operations list \
+      --project="${project_id}" \
+      --filter="targetLink~'ocp-' OR name~'ocp-'" \
+      --sort-by="~startTime" \
+      --limit=80 \
+      --format="table(name,operationType,status,statusMessage,targetLink.basename(),zone.basename(),region.basename(),startTime,httpErrorStatusCode,httpErrorMessage)"
+    echo
+
+    echo "OpenShift DNS records:"
+    if [[ -n "${OPENSHIFT_BASE_DOMAIN:-}" ]]; then
+      local zone
+      zone="$(printf "%s" "${OPENSHIFT_BASE_DOMAIN}" | tr "." "-")"
+      run_gcloud dns record-sets list \
+        --project="${project_id}" \
+        --zone="${zone}" \
+        --format="table(name,type,ttl,rrdatas)"
+    else
+      echo "OPENSHIFT_BASE_DOMAIN is unset; skipping DNS record snapshot"
+    fi
+    echo
+  } 2>&1 | tee "${file}"
+  sync_file "${file}"
+}
+
+watch() {
+  local interval="${1:-120}"
+  while true; do
+    snapshot "periodic"
+    sleep "${interval}"
+  done
+}
+
+ensure_gcs() {
+  [[ -n "${gcs_uri}" ]] || return 0
+  local bucket="${gcs_uri#gs://}"
+  bucket="${bucket%%/*}"
+  [[ -n "${bucket}" && "${bucket}" != "${gcs_uri}" ]] || return 0
+
+  if ! gcloud storage buckets describe "gs://${bucket}" >/dev/null 2>&1; then
+    echo "Warning: debug bucket gs://${bucket} is unavailable; GCS sync may fail"
+  fi
+  return 0
+}
+
+sync_file() {
+  [[ -n "${gcs_uri}" ]] || return 0
+  local file="$1"
+  local destination="${2:-$(basename "${file}")}"
+  [[ -f "${file}" ]] || return 0
+  gcloud storage cp "${file}" "${gcs_uri}/${destination}" >/dev/null 2>&1 || true
+}
+
+sync_debug() {
+  [[ -n "${gcs_uri}" ]] || return 0
+  local file install_dir install_dir_name
+  for file in "${debug_dir}"/*.log test_output.log test_output.json; do
+    [[ -f "${file}" ]] || continue
+    sync_file "${file}"
+  done
+  for install_dir in $(install_dirs); do
+    install_dir_name="$(basename "${install_dir}")"
+    for file in "${install_dir}"/.openshift_install.log "${install_dir}"/metadata.json; do
+      [[ -f "${file}" ]] || continue
+      sync_file "${file}" "${install_dir_name}-$(basename "${file}")"
+    done
+  done
+}
+
+short_infra_id() {
+  local infra_id="$1"
+  IFS="-" read -r first second _ <<< "${infra_id}"
+  if [[ -n "${first}" && -n "${second}" ]]; then
+    printf "%s-%s" "${first}" "${second}"
+  else
+    printf "%s" "${infra_id}"
+  fi
+}
+
+delete_if_exists() {
+  echo "+ gcloud $*"
+  gcloud "$@" || true
+}
+
+cleanup_multicluster() {
+  mapfile -t ids < <(infra_ids)
+  if (( ${#ids[@]} == 0 )); then
+    echo "No OpenShift infra IDs found; skipping multi-cluster cleanup"
+    return 0
+  fi
+
+  local infra_id i j a b short_a short_b
+  for infra_id in "${ids[@]}"; do
+    delete_if_exists compute firewall-rules delete \
+      "${infra_id}-submariner-public-ports-ingress" \
+      --project="${project_id}" \
+      --quiet
+    delete_if_exists compute firewall-rules delete \
+      "${infra_id}-submariner-internal-ports-ingress" \
+      --project="${project_id}" \
+      --quiet
+  done
+
+  if (( ${#ids[@]} < 2 )); then
+    echo "Fewer than two OpenShift infra IDs found; skipping peer cleanup"
+    return 0
+  fi
+
+  for ((i = 0; i < ${#ids[@]}; i++)); do
+    for ((j = i + 1; j < ${#ids[@]}; j++)); do
+      a="${ids[$i]}"
+      b="${ids[$j]}"
+      short_a="$(short_infra_id "${a}")"
+      short_b="$(short_infra_id "${b}")"
+
+      delete_if_exists compute firewall-rules delete \
+        "${short_a}-allow-peer-${short_b}" \
+        --project="${project_id}" \
+        --quiet
+      delete_if_exists compute firewall-rules delete \
+        "${short_b}-allow-peer-${short_a}" \
+        --project="${project_id}" \
+        --quiet
+
+      delete_if_exists compute networks peerings delete \
+        "${short_a}-to-${short_b}" \
+        --network="${a}-network" \
+        --project="${project_id}" \
+        --quiet
+      delete_if_exists compute networks peerings delete \
+        "${short_b}-to-${short_a}" \
+        --network="${b}-network" \
+        --project="${project_id}" \
+        --quiet
+    done
+  done
+}
+
+case "${1:-}" in
+  snapshot)
+    snapshot "${2:-snapshot}"
+    ;;
+  watch)
+    watch "${2:-120}"
+    ;;
+  cleanup-multicluster)
+    cleanup_multicluster
+    ;;
+  ensure-gcs)
+    ensure_gcs
+    ;;
+  sync)
+    sync_debug
+    ;;
+  *)
+    echo "usage: $0 {snapshot [label]|watch [seconds]|cleanup-multicluster|ensure-gcs|sync}" >&2
+    exit 2
+    ;;
+esac

--- a/tests/e2e/operator/encryption/types.go
+++ b/tests/e2e/operator/encryption/types.go
@@ -81,7 +81,7 @@ func GenerateAndEncodeEncryptionKey(t *testing.T) (rawKey []byte, base64Key stri
 
 // SetupEncryptionSecretsWithName dispatches to the appropriate setup path based on platform type.
 // CMEK providers (GCP_CLOUD_KMS, AWS_KMS) go through KMS encryption; file-based (UNKNOWN_KEY_TYPE)
-// writes raw key bytes directly.
+// stores the base64-encoded key directly.
 func SetupEncryptionSecretsWithName(t *testing.T, provider Provider, kubectlOptions *k8s.KubectlOptions, clusterRegion string, secretName string) error {
 	platformConfig := provider.GetEncryptionPlatformConfig()
 
@@ -129,17 +129,11 @@ func setupCMEKEncryptionSecretsWithName(
 func setupFileBasedEncryptionSecretsWithName(t *testing.T, kubectlOptions *k8s.KubectlOptions, providerName string, secretName string) error {
 	t.Logf("%s provider: Setting up file-based encryption secrets (secret: %s)", providerName, secretName)
 
-	rawKey, _ := GenerateAndEncodeEncryptionKey(t)
-	t.Logf("Generated encryption key (%d bytes)", len(rawKey))
-
-	tempDir := t.TempDir()
-	keyPath := filepath.Join(tempDir, "StoreKeyData")
-	if err := os.WriteFile(keyPath, rawKey, 0600); err != nil {
-		return fmt.Errorf("failed to write key to temp file: %w", err)
-	}
+	rawKey, base64Key := GenerateAndEncodeEncryptionKey(t)
+	t.Logf("Generated encryption key (%d bytes, %d base64 characters)", len(rawKey), len(base64Key))
 
 	err := k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", secretName,
-		fmt.Sprintf("--from-file=StoreKeyData=%s", keyPath))
+		fmt.Sprintf("--from-literal=StoreKeyData=%s", base64Key))
 	if err != nil {
 		return fmt.Errorf("failed to create encryption key secret: %w", err)
 	}

--- a/tests/e2e/operator/infra/common.go
+++ b/tests/e2e/operator/infra/common.go
@@ -18,10 +18,11 @@ import (
 
 // Provider types.
 const (
-	ProviderK3D  = "k3d"
-	ProviderKind = "kind"
-	ProviderGCP  = "gcp"
-	ProviderAWS  = "aws"
+	ProviderK3D       = "k3d"
+	ProviderKind      = "kind"
+	ProviderGCP       = "gcp"
+	ProviderAWS       = "aws"
+	ProviderOpenShift = "openshift"
 )
 
 // Common constants.
@@ -51,10 +52,11 @@ const (
 
 // RegionCodes maps provider types to their region codes
 var RegionCodes = map[string][]string{
-	ProviderK3D:  {"us-east1", "us-east2"},
-	ProviderKind: {"us-east1", "us-east2"},
-	ProviderGCP:  {"us-central1", "us-east1"},
-	ProviderAWS:  {"us-east-1", "us-east-2"},
+	ProviderK3D:       {"us-east1", "us-east2"},
+	ProviderKind:      {"us-east1", "us-east2"},
+	ProviderGCP:       {"us-central1", "us-east1"},
+	ProviderAWS:       {"us-east-1", "us-east-2"},
+	ProviderOpenShift: {"us-central1", "us-east1"},
 }
 
 // LoadBalancerAnnotations contains provider-specific service annotations.
@@ -68,8 +70,9 @@ var LoadBalancerAnnotations = map[string]map[string]string{
 		"service.beta.kubernetes.io/aws-load-balancer-type":     "nlb",
 		"service.beta.kubernetes.io/aws-load-balancer-internal": "true",
 	},
-	ProviderK3D:  {},
-	ProviderKind: {},
+	ProviderK3D:       {},
+	ProviderKind:      {},
+	ProviderOpenShift: {},
 }
 
 // NetworkConfigs defines standard network configurations for each provider and region.
@@ -352,6 +355,9 @@ func UpdateCoreDNSConfiguration(t *testing.T, r *operator.Region, kubeConfigPath
 		if err := k8s.RunKubectlE(t, kubectlOpts, "rollout", "restart", "deployment", coreDNSDeploymentName); err != nil {
 			require.NoError(t, err, "failed to restart CoreDNS deployment for cluster %s", clusterName)
 		}
+		if err := k8s.RunKubectlE(t, kubectlOpts, "rollout", "status", "deployment", coreDNSDeploymentName, "--timeout=3m"); err != nil {
+			require.NoError(t, err, "CoreDNS deployment did not finish rolling out for cluster %s", clusterName)
+		}
 
 		t.Logf("[%s] Updated CoreDNS configuration for cluster %s with namespace %s", r.Provider, clusterName, r.Namespace[clusterName])
 	}
@@ -383,4 +389,59 @@ func UpdateCoreDNSWithNamespaces(t *testing.T, r *operator.Region) {
 	UpdateCoreDNSConfiguration(t, r, kubeConfigPath)
 
 	t.Logf("[%s] Updated CoreDNS configuration with test namespaces", r.Provider)
+}
+
+// WaitForReadyNodes waits until at least nodeCount nodes matching nodeSelector
+// are Ready in the selected cluster.
+func WaitForReadyNodes(
+	t *testing.T,
+	provider string,
+	clusterName string,
+	kubeConfigPath string,
+	nodeSelector string,
+	nodeCount int,
+) {
+	t.Helper()
+	kubectlOptions := k8s.NewKubectlOptions(clusterName, kubeConfigPath, "")
+	args := []string{"get", "nodes", "--no-headers"}
+	if nodeSelector != "" {
+		args = append(args, "-l", nodeSelector)
+	}
+
+	for attempt := 1; attempt <= defaultRetries; attempt++ {
+		output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, args...)
+		if err != nil {
+			t.Logf("[%s] attempt %d/%d: failed to list nodes in cluster %q: %v",
+				provider, attempt, defaultRetries, clusterName, err)
+			time.Sleep(defaultRetryInterval)
+			continue
+		}
+
+		readyNodes := countReadyNodes(output)
+		t.Logf("[%s] ready nodes for cluster %q: %d/%d",
+			provider, clusterName, readyNodes, nodeCount)
+		if readyNodes >= nodeCount {
+			return
+		}
+
+		time.Sleep(defaultRetryInterval)
+	}
+
+	t.Fatalf("[%s] timed out waiting for %d ready nodes in cluster %q",
+		provider, nodeCount, clusterName)
+}
+
+func countReadyNodes(kubectlGetNodesOutput string) int {
+	readyNodes := 0
+	for _, line := range strings.Split(strings.TrimSpace(kubectlGetNodesOutput), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		status := fields[1]
+		if strings.Contains(status, "Ready") && !strings.Contains(status, "NotReady") {
+			readyNodes++
+		}
+	}
+	return readyNodes
 }

--- a/tests/e2e/operator/infra/openshift.go
+++ b/tests/e2e/operator/infra/openshift.go
@@ -1,0 +1,1573 @@
+package infra
+
+import (
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/encryption"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+const (
+	envOpenShiftPullSecret       = "OPENSHIFT_PULL_SECRET"
+	envOpenShiftSSHPubKey        = "OPENSHIFT_SSH_PUB_KEY"
+	envOpenShiftBaseDomain       = "OPENSHIFT_BASE_DOMAIN"
+	envOpenShiftInstallLogLevel  = "OPENSHIFT_INSTALL_LOG_LEVEL"
+	envOpenShiftReuseKubeconfig  = "OPENSHIFT_REUSE_KUBECONFIG"
+	envOpenShiftReuseKubeconfigs = "OPENSHIFT_REUSE_KUBECONFIGS"
+	envOpenShiftReuseContexts    = "OPENSHIFT_REUSE_CONTEXTS"
+	envOpenShiftEnableSubmariner = "OPENSHIFT_ENABLE_SUBMARINER"
+	envOpenShiftSkipTeardown     = "OPENSHIFT_SKIP_TEARDOWN"
+	envOpenShiftStorageClass     = "OPENSHIFT_STORAGE_CLASS"
+)
+
+const (
+	defaultOpenShiftInstallLogLevel = "info"
+	defaultOpenShiftStorageClass    = "standard-csi"
+	openShiftCockroachNofileLimit   = 1048576
+	openShiftScaleUpExtraWorkers    = 1
+)
+
+const (
+	openShiftCRIOMachineConfigName = "99-worker-cockroach-ulimits"
+	openShiftCRIOUlimitsPath       = "/etc/crio/crio.conf.d/99-cockroach-ulimits.conf"
+	openShiftSubmarinerNamespace   = "submariner-operator"
+	openShiftSubmarinerBrokerFile  = "broker-info.subm"
+	openShiftSubmarinerGatewayTag  = "submariner-io-gateway-node"
+)
+
+const (
+	openShiftSubmarinerPublicFirewallRule   = "submariner-public-ports"
+	openShiftSubmarinerInternalFirewallRule = "submariner-internal-ports"
+	openShiftSubmarinerPublicPorts          = "udp:4500,udp:4490,esp,ah"
+	openShiftSubmarinerInternalPorts        = "udp:4800"
+)
+
+type openShiftNetworkConfig struct {
+	MachineCIDR    string
+	ClusterNetwork string
+	HostPrefix     int
+	ServiceNetwork string
+}
+
+var openShiftNetworkConfigs = []openShiftNetworkConfig{
+	{
+		MachineCIDR:    "10.0.0.0/16",
+		ClusterNetwork: "10.128.0.0/14",
+		HostPrefix:     23,
+		ServiceNetwork: "172.30.0.0/16",
+	},
+	{
+		MachineCIDR:    "10.1.0.0/16",
+		ClusterNetwork: "10.132.0.0/14",
+		HostPrefix:     23,
+		ServiceNetwork: "172.31.0.0/16",
+	},
+}
+
+var openShiftInstallConfigTemplate = template.Must(template.New("install-config").Parse(`apiVersion: v1
+baseDomain: {{ .BaseDomain }}
+metadata:
+  name: {{ .ClusterName }}
+compute:
+- architecture: amd64
+  hyperthreading: Enabled
+  name: worker
+  platform: {}
+  replicas: {{ .WorkerReplicas }}
+controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
+  name: master
+  platform: {}
+  replicas: 3
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: {{ .MachineCIDR }}
+  clusterNetwork:
+  - cidr: {{ .ClusterNetwork }}
+    hostPrefix: {{ .HostPrefix }}
+  serviceNetwork:
+  - {{ .ServiceNetwork }}
+platform:
+  gcp:
+    projectID: {{ .ProjectID }}
+    region: {{ .Region }}
+pullSecret: '{{ .PullSecret }}'
+sshKey: '{{ .SSHPubKey }}'
+`))
+
+type openShiftInstallConfigData struct {
+	BaseDomain     string
+	ClusterName    string
+	ProjectID      string
+	Region         string
+	PullSecret     string
+	SSHPubKey      string
+	WorkerReplicas int
+	MachineCIDR    string
+	ClusterNetwork string
+	HostPrefix     int
+	ServiceNetwork string
+}
+
+type openShiftMetadata struct {
+	InfraID string `json:"infraID"`
+}
+
+type openShiftSubmarinerGatewayNode struct {
+	nodeName     string
+	instanceName string
+	zone         string
+}
+
+// OpenShiftRegion provisions OpenShift clusters on GCP using openshift-install.
+type OpenShiftRegion struct {
+	*operator.Region
+
+	installDirs     map[string]string
+	createdClusters map[string]bool
+	infraIDs        map[string]string
+}
+
+func (r *OpenShiftRegion) SetUpInfra(t *testing.T) {
+	if r.ReusingInfra {
+		t.Logf("[%s] Reusing existing infrastructure", ProviderOpenShift)
+		return
+	}
+	if len(r.Clusters) == 0 {
+		t.Fatalf("[%s] no clusters configured", ProviderOpenShift)
+	}
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		t.Fatalf("[%s] kubectl not found in PATH: %v", ProviderOpenShift, err)
+	}
+
+	if len(r.RegionCodes) == 0 {
+		r.RegionCodes = GetRegionCodes(ProviderOpenShift)
+	}
+
+	r.installDirs = make(map[string]string)
+	r.createdClusters = make(map[string]bool)
+	r.infraIDs = make(map[string]string)
+	r.Clients = make(map[string]client.Client)
+
+	if len(r.RegionCodes) < len(r.Clusters) {
+		t.Fatalf("[%s] need %d region codes, got %d", ProviderOpenShift, len(r.Clusters), len(r.RegionCodes))
+	}
+
+	if reuseContexts := openShiftReuseContexts(t, len(r.Clusters)); len(reuseContexts) > 0 {
+		r.Clusters = reuseContexts
+		kubeConfigPath, err := r.EnsureKubeConfigPath()
+		require.NoError(t, err)
+		require.NoError(t, os.Setenv("KUBECONFIG", kubeConfigPath))
+		for _, clusterName := range r.Clusters {
+			r.validateOpenShiftCluster(t, kubeConfigPath, clusterName)
+		}
+		r.initializeOpenShiftClients(t)
+		r.configureOpenShiftMultiCluster(t, kubeConfigPath)
+		r.ReusingInfra = true
+		t.Logf("[%s] Infrastructure setup complete using reused contexts", ProviderOpenShift)
+		return
+	}
+
+	if reuseKubeconfigs := openShiftReuseKubeconfigs(t, len(r.Clusters)); len(reuseKubeconfigs) > 0 {
+		for i, clusterName := range r.Clusters {
+			r.reuseCluster(t, clusterName, reuseKubeconfigs[i])
+		}
+		r.initializeOpenShiftClients(t)
+		kubeConfigPath, err := r.EnsureKubeConfigPath()
+		require.NoError(t, err)
+		r.configureOpenShiftMultiCluster(t, kubeConfigPath)
+		r.ReusingInfra = true
+		t.Logf("[%s] Infrastructure setup complete using reused kubeconfig contexts", ProviderOpenShift)
+		return
+	}
+
+	if _, err := exec.LookPath("openshift-install"); err != nil {
+		t.Fatalf("[%s] openshift-install not found in PATH: %v", ProviderOpenShift, err)
+	}
+
+	projectID := mustOpenShiftEnv(t, "GCP_PROJECT_ID")
+	baseDomain := mustOpenShiftEnv(t, envOpenShiftBaseDomain)
+	pullSecret := readOpenShiftPullSecret(t)
+	sshPubKey := readOpenShiftSSHPubKey(t)
+
+	kubeConfigPath, err := r.EnsureKubeConfigPath()
+	require.NoError(t, err)
+
+	for i, clusterName := range r.Clusters {
+		regionCode := r.RegionCodes[i]
+		workerReplicas := openShiftWorkerReplicasForNodeCount(r.NodeCount)
+		netCfg := openShiftNetworkConfigForCluster(t, i)
+		t.Logf("[%s] Provisioning cluster %q in region %s (project %s, workers %d, machine CIDR %s, pod CIDR %s, service CIDR %s)",
+			ProviderOpenShift, clusterName, regionCode, projectID, workerReplicas,
+			netCfg.MachineCIDR, netCfg.ClusterNetwork, netCfg.ServiceNetwork)
+
+		installDir, infraID, err := r.provisionCluster(
+			t,
+			clusterName,
+			regionCode,
+			projectID,
+			baseDomain,
+			pullSecret,
+			sshPubKey,
+			workerReplicas,
+			netCfg,
+		)
+		require.NoError(t, err, "[%s] failed to provision cluster %q", ProviderOpenShift, clusterName)
+
+		r.installDirs[clusterName] = installDir
+		r.createdClusters[clusterName] = true
+		r.infraIDs[clusterName] = infraID
+		t.Logf("[%s] Cluster %q created with infraID %q", ProviderOpenShift, clusterName, infraID)
+
+		generatedKubeconfig := filepath.Join(installDir, "auth", "kubeconfig")
+		require.NoError(t, mergeOpenShiftKubeconfig(generatedKubeconfig, kubeConfigPath, clusterName))
+		r.validateOpenShiftCluster(t, kubeConfigPath, clusterName)
+	}
+
+	r.initializeOpenShiftClients(t)
+	r.configureOpenShiftMultiCluster(t, kubeConfigPath)
+	r.ReusingInfra = true
+	t.Logf("[%s] Infrastructure setup complete", ProviderOpenShift)
+}
+
+func (r *OpenShiftRegion) reuseCluster(t *testing.T, clusterName, sourceKubeconfig string) {
+	t.Helper()
+
+	kubeConfigPath, err := r.EnsureKubeConfigPath()
+	require.NoError(t, err)
+	require.NoError(t, mergeOpenShiftKubeconfig(sourceKubeconfig, kubeConfigPath, clusterName),
+		"[%s] failed to import reused kubeconfig %s", ProviderOpenShift, sourceKubeconfig)
+	require.NoError(t, os.Setenv("KUBECONFIG", kubeConfigPath))
+
+	r.validateOpenShiftCluster(t, kubeConfigPath, clusterName)
+	t.Logf("[%s] Reusing cluster from %s as test context %q", ProviderOpenShift, sourceKubeconfig, clusterName)
+}
+
+func (r *OpenShiftRegion) TeardownInfra(t *testing.T) {
+	if r.ReusingInfra && len(r.createdClusters) == 0 {
+		t.Logf("[%s] Reused infrastructure; skipping cluster teardown", ProviderOpenShift)
+		return
+	}
+	if parseBoolEnv(envOpenShiftSkipTeardown) {
+		t.Logf("[%s] %s=true; skipping cluster teardown", ProviderOpenShift, envOpenShiftSkipTeardown)
+		for clusterName, installDir := range r.installDirs {
+			t.Logf("[%s] Preserved install dir for %q: %s", ProviderOpenShift, clusterName, installDir)
+		}
+		return
+	}
+
+	projectID := strings.TrimSpace(os.Getenv("GCP_PROJECT_ID"))
+	if projectID != "" {
+		r.cleanupOpenShiftMultiClusterResources(t, projectID)
+	} else if len(r.Clusters) > 1 {
+		t.Logf("[%s] GCP_PROJECT_ID is unset; skipping custom multi-cluster resource cleanup", ProviderOpenShift)
+	}
+
+	for clusterName, installDir := range r.installDirs {
+		t.Logf("[%s] Destroying cluster %q", ProviderOpenShift, clusterName)
+		cmd := exec.Command("openshift-install", "destroy", "cluster", "--dir", installDir, "--log-level", "info")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Env = openShiftInstallerEnv()
+
+		if err := cmd.Run(); err != nil {
+			t.Logf("[%s] Warning: failed to destroy cluster %q: %v", ProviderOpenShift, clusterName, err)
+		}
+		if err := os.RemoveAll(installDir); err != nil {
+			t.Logf("[%s] Warning: failed to remove install dir %s: %v", ProviderOpenShift, installDir, err)
+		}
+	}
+}
+
+func (r *OpenShiftRegion) cleanupOpenShiftMultiClusterResources(t *testing.T, projectID string) {
+	t.Helper()
+	if len(r.Clusters) <= 1 {
+		return
+	}
+
+	for _, clusterName := range r.Clusters {
+		infraID := r.infraIDs[clusterName]
+		if infraID == "" {
+			t.Logf("[%s] Skipping Submariner cleanup for %q: missing infra ID", ProviderOpenShift, clusterName)
+			continue
+		}
+		deleteOpenShiftFirewallRule(t, projectID, openShiftSubmarinerFirewallName(infraID, openShiftSubmarinerPublicFirewallRule))
+		deleteOpenShiftFirewallRule(t, projectID, openShiftSubmarinerFirewallName(infraID, openShiftSubmarinerInternalFirewallRule))
+	}
+
+	for i := 0; i < len(r.Clusters); i++ {
+		for j := i + 1; j < len(r.Clusters); j++ {
+			clusterA := r.Clusters[i]
+			clusterB := r.Clusters[j]
+			infraA := r.infraIDs[clusterA]
+			infraB := r.infraIDs[clusterB]
+			if infraA == "" || infraB == "" {
+				t.Logf("[%s] Skipping custom cleanup for %q/%q: missing infra IDs (%q, %q)",
+					ProviderOpenShift, clusterA, clusterB, infraA, infraB)
+				continue
+			}
+
+			t.Logf("[%s] Removing custom multi-cluster resources between %q and %q",
+				ProviderOpenShift, infraA, infraB)
+			deleteOpenShiftFirewallRule(t, projectID, openShiftPeerFirewallName(infraA, infraB))
+			deleteOpenShiftFirewallRule(t, projectID, openShiftPeerFirewallName(infraB, infraA))
+			deleteOpenShiftVPCPeering(t, projectID, openShiftNetworkName(infraA), openShiftPeeringName(infraA, infraB))
+			deleteOpenShiftVPCPeering(t, projectID, openShiftNetworkName(infraB), openShiftPeeringName(infraB, infraA))
+		}
+	}
+}
+
+func (r *OpenShiftRegion) ScaleNodePool(t *testing.T, location string, nodeCount, index int) {
+	if index >= len(r.Clusters) {
+		t.Fatalf("[%s] invalid cluster index %d, only have %d clusters", ProviderOpenShift, index, len(r.Clusters))
+	}
+
+	clusterName := r.Clusters[index]
+	kubeConfigPath, err := r.EnsureKubeConfigPath()
+	require.NoError(t, err)
+
+	t.Logf("[%s] validating pre-provisioned worker capacity for cluster %q: need %d ready workers",
+		ProviderOpenShift, clusterName, nodeCount)
+	WaitForReadyNodes(t, ProviderOpenShift, clusterName, kubeConfigPath, "node-role.kubernetes.io/worker", nodeCount)
+}
+
+func (r *OpenShiftRegion) CanScale() bool {
+	return true
+}
+
+func (r *OpenShiftRegion) GetEncryptionProvider() encryption.Provider {
+	return r
+}
+
+func (r *OpenShiftRegion) SetupEncryptionInfrastructure(t *testing.T) (func(), error) {
+	t.Logf("[%s] No KMS infrastructure needed for file-based encryption (UNKNOWN_KEY_TYPE)", ProviderOpenShift)
+	return func() {
+		t.Logf("[%s] No KMS infrastructure to clean up", ProviderOpenShift)
+	}, nil
+}
+
+func (r *OpenShiftRegion) GetEncryptionPlatformConfig() *encryption.PlatformConfig {
+	return &encryption.PlatformConfig{
+		Platform:                     "UNKNOWN_KEY_TYPE",
+		RequiresCredentialsSecret:    false,
+		DefaultCredentialsSecretName: "",
+	}
+}
+
+func (r *OpenShiftRegion) EncryptKey(plaintextKey []byte, clusterRegion string) (string, error) {
+	return "", fmt.Errorf("EncryptKey not supported for %s (file-based encryption / UNKNOWN_KEY_TYPE)", ProviderOpenShift)
+}
+
+func (r *OpenShiftRegion) CreateKeySecret(kubectlOptions *k8s.KubectlOptions, secretName string, encryptedKeyData string, clusterRegion string) error {
+	return fmt.Errorf("CreateKeySecret not supported for %s (file-based encryption / UNKNOWN_KEY_TYPE)", ProviderOpenShift)
+}
+
+func (r *OpenShiftRegion) CreateCredentialsSecret(kubectlOptions *k8s.KubectlOptions) (string, error) {
+	return "", fmt.Errorf("CreateCredentialsSecret not supported for %s (file-based encryption / UNKNOWN_KEY_TYPE)", ProviderOpenShift)
+}
+
+func (r *OpenShiftRegion) provisionCluster(
+	t *testing.T,
+	clusterName, region, projectID, baseDomain, pullSecret, sshPubKey string,
+	workerReplicas int,
+	netCfg openShiftNetworkConfig,
+) (string, string, error) {
+	installerName := shortOpenShiftInstallerName(clusterName)
+	installDir, err := os.MkdirTemp("", fmt.Sprintf("helm-charts-ocp-%s-*", installerName))
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create OpenShift install dir: %w", err)
+	}
+
+	configPath := filepath.Join(installDir, "install-config.yaml")
+	configFile, err := os.Create(configPath)
+	if err != nil {
+		_ = os.RemoveAll(installDir)
+		return "", "", fmt.Errorf("failed to create install-config.yaml: %w", err)
+	}
+
+	data := openShiftInstallConfigData{
+		BaseDomain:     baseDomain,
+		ClusterName:    installerName,
+		ProjectID:      projectID,
+		Region:         region,
+		PullSecret:     pullSecret,
+		SSHPubKey:      sshPubKey,
+		WorkerReplicas: workerReplicas,
+		MachineCIDR:    netCfg.MachineCIDR,
+		ClusterNetwork: netCfg.ClusterNetwork,
+		HostPrefix:     netCfg.HostPrefix,
+		ServiceNetwork: netCfg.ServiceNetwork,
+	}
+	if err := openShiftInstallConfigTemplate.Execute(configFile, data); err != nil {
+		_ = configFile.Close()
+		_ = os.RemoveAll(installDir)
+		return "", "", fmt.Errorf("failed to render install-config.yaml: %w", err)
+	}
+	if err := configFile.Close(); err != nil {
+		_ = os.RemoveAll(installDir)
+		return "", "", fmt.Errorf("failed to close install-config.yaml: %w", err)
+	}
+
+	logLevel := strings.TrimSpace(os.Getenv(envOpenShiftInstallLogLevel))
+	if logLevel == "" {
+		logLevel = defaultOpenShiftInstallLogLevel
+	}
+
+	if err := r.createInstallManifests(t, installDir, logLevel); err != nil {
+		_ = os.RemoveAll(installDir)
+		return "", "", err
+	}
+
+	t.Logf("[%s] Running openshift-install create cluster in %s", ProviderOpenShift, installDir)
+	cmd := exec.Command("openshift-install", "create", "cluster", "--dir", installDir, "--log-level", logLevel)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = openShiftInstallerEnv()
+
+	if err := cmd.Run(); err != nil {
+		if parseBoolEnv(envOpenShiftSkipTeardown) {
+			t.Logf("[%s] openshift-install failed; %s=true, preserving failed install dir and cluster resources: %s",
+				ProviderOpenShift, envOpenShiftSkipTeardown, installDir)
+			return "", "", fmt.Errorf("openshift-install create cluster failed: %w", err)
+		}
+
+		t.Logf("[%s] openshift-install failed, attempting cleanup", ProviderOpenShift)
+		destroyCmd := exec.Command("openshift-install", "destroy", "cluster", "--dir", installDir, "--log-level", "warn")
+		destroyCmd.Stdout = os.Stdout
+		destroyCmd.Stderr = os.Stderr
+		destroyCmd.Env = openShiftInstallerEnv()
+		_ = destroyCmd.Run()
+		_ = os.RemoveAll(installDir)
+		return "", "", fmt.Errorf("openshift-install create cluster failed: %w", err)
+	}
+
+	infraID, err := readOpenShiftInfraID(installDir)
+	if err != nil {
+		t.Logf("[%s] Warning: could not read metadata infraID, using installer name %q: %v", ProviderOpenShift, installerName, err)
+		infraID = installerName
+	}
+
+	return installDir, infraID, nil
+}
+
+func (r *OpenShiftRegion) createInstallManifests(t *testing.T, installDir, logLevel string) error {
+	t.Helper()
+
+	t.Logf("[%s] Running openshift-install create manifests in %s", ProviderOpenShift, installDir)
+	cmd := exec.Command("openshift-install", "create", "manifests", "--dir", installDir, "--log-level", logLevel)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = openShiftInstallerEnv()
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("openshift-install create manifests failed: %w", err)
+	}
+
+	if err := writeOpenShiftCRIOUlimitsMachineConfig(installDir); err != nil {
+		return fmt.Errorf("failed to write OpenShift CRI-O ulimit MachineConfig: %w", err)
+	}
+	return nil
+}
+
+func writeOpenShiftCRIOUlimitsMachineConfig(installDir string) error {
+	crioConfig := fmt.Sprintf(`[crio.runtime]
+default_ulimits = ["nofile=%d:%d"]
+`, openShiftCockroachNofileLimit, openShiftCockroachNofileLimit)
+
+	manifest := fmt.Sprintf(`apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: %s
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - path: %s
+        mode: 420
+        overwrite: true
+        contents:
+          source: data:text/plain;charset=utf-8;base64,%s
+`, openShiftCRIOMachineConfigName, openShiftCRIOUlimitsPath, base64.StdEncoding.EncodeToString([]byte(crioConfig)))
+
+	manifestDir := filepath.Join(installDir, "openshift")
+	if err := os.MkdirAll(manifestDir, 0755); err != nil {
+		return err
+	}
+	manifestPath := filepath.Join(manifestDir, openShiftCRIOMachineConfigName+".yaml")
+	return os.WriteFile(manifestPath, []byte(manifest), 0644)
+}
+
+func (r *OpenShiftRegion) initializeOpenShiftClients(t *testing.T) {
+	for _, clusterName := range r.Clusters {
+		restCfg, err := config.GetConfigWithContext(clusterName)
+		require.NoError(t, err, "[%s] failed to get kube config for %q", ProviderOpenShift, clusterName)
+
+		k8sClient, err := client.New(restCfg, client.Options{})
+		require.NoError(t, err, "[%s] failed to create k8s client for %q", ProviderOpenShift, clusterName)
+
+		r.Clients[clusterName] = k8sClient
+	}
+}
+
+func (r *OpenShiftRegion) validateOpenShiftCluster(t *testing.T, kubeConfigPath, clusterName string) {
+	kubectlOptions := k8s.NewKubectlOptions(clusterName, kubeConfigPath, "")
+
+	_, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "get", "nodes")
+	require.NoError(t, err, "[%s] failed to list OpenShift nodes", ProviderOpenShift)
+
+	_, err = k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"wait", "--for=condition=Available", "clusteroperators.config.openshift.io", "--all", "--timeout=15m")
+	require.NoError(t, err, "[%s] OpenShift cluster operators did not become Available", ProviderOpenShift)
+
+	storageClassName := openShiftStorageClassName()
+	_, err = k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "get", "storageclass", storageClassName)
+	require.NoError(t, err, "[%s] required StorageClass %q was not found", ProviderOpenShift, storageClassName)
+
+	r.validateOpenShiftWorkloadPrereqs(t, kubeConfigPath, clusterName, storageClassName)
+}
+
+func (r *OpenShiftRegion) validateOpenShiftWorkloadPrereqs(
+	t *testing.T, kubeConfigPath, clusterName, storageClassName string,
+) {
+	namespace := fmt.Sprintf("openshift-preflight-%s", shortOpenShiftInstallerName(clusterName))
+	kubectlOptions := k8s.NewKubectlOptions(clusterName, kubeConfigPath, namespace)
+	clusterOptions := k8s.NewKubectlOptions(clusterName, kubeConfigPath, "")
+
+	t.Cleanup(func() {
+		_ = k8s.RunKubectlE(t, clusterOptions, "delete", "namespace", namespace, "--ignore-not-found=true")
+	})
+
+	require.NoError(t, k8s.RunKubectlE(t, clusterOptions, "create", "namespace", namespace),
+		"[%s] failed to create preflight namespace", ProviderOpenShift)
+	require.NoError(t, k8s.RunKubectlE(t, kubectlOptions, "create", "serviceaccount", "preflight"),
+		"[%s] failed to create preflight service account", ProviderOpenShift)
+
+	manifest := fmt.Sprintf(`apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: preflight-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: %s
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: preflight-pod
+spec:
+  restartPolicy: Never
+  serviceAccountName: preflight
+  containers:
+  - name: preflight
+    image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+    command:
+    - /bin/sh
+    - -c
+    - |
+      hard="$(ulimit -Hn)"
+      case "$hard" in
+        unlimited) ;;
+        ''|*[!0-9]*)
+          echo "unexpected nofile hard limit: ${hard}" >&2
+          exit 1
+          ;;
+        *)
+          if [ "$hard" -lt %d ]; then
+            echo "nofile hard limit ${hard} is below required %d" >&2
+            exit 1
+          fi
+          ;;
+      esac
+      echo "nofile soft=$(ulimit -Sn) hard=${hard}" > /data/preflight
+      sleep 30
+    volumeMounts:
+    - name: data
+      mountPath: /data
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: preflight-pvc
+`, storageClassName, openShiftCockroachNofileLimit, openShiftCockroachNofileLimit)
+
+	require.NoError(t, k8s.KubectlApplyFromStringE(t, kubectlOptions, manifest),
+		"[%s] failed to apply preflight PVC/pod", ProviderOpenShift)
+	_, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+		"wait", "--for=condition=Ready", "pod/preflight-pod", "--timeout=5m")
+	if err != nil {
+		if logs, logErr := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "logs", "pod/preflight-pod"); logErr == nil {
+			t.Logf("[%s] preflight pod logs:\n%s", ProviderOpenShift, logs)
+		}
+	}
+	require.NoError(t, err, "[%s] preflight pod did not become ready", ProviderOpenShift)
+}
+
+func (r *OpenShiftRegion) configureOpenShiftMultiCluster(t *testing.T, kubeConfigPath string) {
+	t.Helper()
+	if len(r.Clusters) <= 1 {
+		return
+	}
+
+	projectID := mustOpenShiftEnv(t, "GCP_PROJECT_ID")
+	for _, clusterName := range r.Clusters {
+		if r.infraIDs[clusterName] == "" {
+			r.infraIDs[clusterName] = discoverOpenShiftInfraID(t, kubeConfigPath, clusterName)
+		}
+	}
+
+	r.configureOpenShiftVPCPeering(t, projectID)
+	r.configureOpenShiftSubmariner(t, kubeConfigPath, projectID)
+	r.deployOpenShiftCoreDNS(t, kubeConfigPath)
+	r.configureOpenShiftDNSForwarding(t, kubeConfigPath)
+	r.validateOpenShiftDNSForwarding(t, kubeConfigPath)
+	if OpenShiftSubmarinerEnabled() {
+		t.Logf("[%s] OpenShift clusters paired with VPC peering, Submariner service/pod routing, and custom-domain DNS forwarding", ProviderOpenShift)
+	} else {
+		t.Logf("[%s] OpenShift clusters paired for node-network routing and custom-domain DNS forwarding; service/pod CIDR routing still requires a multi-cluster networking layer", ProviderOpenShift)
+	}
+}
+
+func (r *OpenShiftRegion) validateOpenShiftDNSForwarding(t *testing.T, kubeConfigPath string) {
+	t.Helper()
+	for i, clusterName := range r.Clusters {
+		kubectlOptions := k8s.NewKubectlOptions(clusterName, kubeConfigPath, "")
+		for j := range r.Clusters {
+			if i == j {
+				continue
+			}
+			host := fmt.Sprintf("kubernetes.default.svc.%s", operator.CustomDomains[j])
+			probeName := fmt.Sprintf("openshift-dns-probe-%d-%d", i, j)
+			output, err := retry.DoWithRetryE(t, fmt.Sprintf("resolve %s from %s", host, clusterName), 12, 10*time.Second,
+				func() (string, error) {
+					_ = k8s.RunKubectlE(t, kubectlOptions, "delete", "pod", probeName, "--ignore-not-found=true", "--wait=false")
+					return k8s.RunKubectlAndGetOutputE(t, kubectlOptions,
+						"run", probeName,
+						"--image=registry.access.redhat.com/ubi9/ubi-minimal:latest",
+						"--restart=Never",
+						"--rm",
+						"-i",
+						"--quiet",
+						"--command",
+						"--",
+						"/bin/sh",
+						"-c",
+						fmt.Sprintf("getent hosts %s", host),
+					)
+				})
+			require.NoError(t, err, "[%s] failed to resolve %s from cluster %q", ProviderOpenShift, host, clusterName)
+			require.NotEmpty(t, strings.TrimSpace(output), "[%s] empty DNS result for %s from cluster %q", ProviderOpenShift, host, clusterName)
+		}
+	}
+}
+
+func (r *OpenShiftRegion) configureOpenShiftVPCPeering(t *testing.T, projectID string) {
+	t.Helper()
+	for i := 0; i < len(r.Clusters); i++ {
+		for j := i + 1; j < len(r.Clusters); j++ {
+			clusterA := r.Clusters[i]
+			clusterB := r.Clusters[j]
+			infraA := r.infraIDs[clusterA]
+			infraB := r.infraIDs[clusterB]
+			networkA := openShiftNetworkName(infraA)
+			networkB := openShiftNetworkName(infraB)
+
+			createOpenShiftVPCPeering(t, projectID, networkA, networkB, openShiftPeeringName(infraA, infraB))
+			createOpenShiftVPCPeering(t, projectID, networkB, networkA, openShiftPeeringName(infraB, infraA))
+
+			netCfgA := openShiftNetworkConfigForCluster(t, i)
+			netCfgB := openShiftNetworkConfigForCluster(t, j)
+			createOpenShiftPeerFirewallRule(t, projectID, networkA, openShiftPeerFirewallName(infraA, infraB), netCfgB)
+			createOpenShiftPeerFirewallRule(t, projectID, networkB, openShiftPeerFirewallName(infraB, infraA), netCfgA)
+		}
+	}
+}
+
+func createOpenShiftVPCPeering(t *testing.T, projectID, network, peerNetwork, peeringName string) {
+	t.Helper()
+	_, err := runOpenShiftGCloud(t,
+		"compute", "networks", "peerings", "create", peeringName,
+		"--project", projectID,
+		"--network", network,
+		"--peer-network", peerNetwork,
+		"--export-custom-routes",
+		"--import-custom-routes",
+	)
+	if err == nil || isOpenShiftGCloudAlreadyExists(err) {
+		return
+	}
+	require.NoError(t, err, "[%s] failed to create VPC peering %s", ProviderOpenShift, peeringName)
+}
+
+func deleteOpenShiftVPCPeering(t *testing.T, projectID, network, peeringName string) {
+	t.Helper()
+	_, err := runOpenShiftGCloud(t,
+		"compute", "networks", "peerings", "delete", peeringName,
+		"--project", projectID,
+		"--network", network,
+		"--quiet",
+	)
+	if err == nil || isOpenShiftGCloudNotFound(err) {
+		return
+	}
+	t.Logf("[%s] Warning: failed to delete VPC peering %s from %s: %v",
+		ProviderOpenShift, peeringName, network, err)
+}
+
+func createOpenShiftPeerFirewallRule(
+	t *testing.T, projectID, network, firewallName string, peerNetCfg openShiftNetworkConfig,
+) {
+	t.Helper()
+	sourceRanges := strings.Join([]string{
+		peerNetCfg.MachineCIDR,
+		peerNetCfg.ClusterNetwork,
+		peerNetCfg.ServiceNetwork,
+	}, ",")
+	_, err := runOpenShiftGCloud(t,
+		"compute", "firewall-rules", "create", firewallName,
+		"--project", projectID,
+		"--network", network,
+		"--direction", "INGRESS",
+		"--priority", "1000",
+		"--source-ranges", sourceRanges,
+		"--allow", "tcp,udp,icmp,esp",
+	)
+	if err == nil || isOpenShiftGCloudAlreadyExists(err) {
+		return
+	}
+	require.NoError(t, err, "[%s] failed to create peer firewall rule %s", ProviderOpenShift, firewallName)
+}
+
+func deleteOpenShiftFirewallRule(t *testing.T, projectID, firewallName string) {
+	t.Helper()
+	_, err := runOpenShiftGCloud(t,
+		"compute", "firewall-rules", "delete", firewallName,
+		"--project", projectID,
+		"--quiet",
+	)
+	if err == nil || isOpenShiftGCloudNotFound(err) {
+		return
+	}
+	t.Logf("[%s] Warning: failed to delete firewall rule %s: %v",
+		ProviderOpenShift, firewallName, err)
+}
+
+func (r *OpenShiftRegion) deployOpenShiftCoreDNS(t *testing.T, kubeConfigPath string) {
+	t.Helper()
+	r.CorednsClusterOptions = make(map[string]coredns.CoreDNSClusterOption)
+
+	for i, clusterName := range r.Clusters {
+		domain := operator.CustomDomains[i]
+		localOptions := map[string]coredns.CoreDNSClusterOption{
+			domain: {
+				Domain:    domain,
+				Namespace: r.Namespace[clusterName],
+			},
+		}
+
+		kubectlOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, coreDNSNamespace)
+		require.NoError(t, deployCoreDNSResources(t, kubectlOpts, domain, localOptions),
+			"[%s] failed to deploy CoreDNS resources to %s", ProviderOpenShift, clusterName)
+		require.NoError(t, deployOpenShiftCoreDNSNodePortService(t, kubectlOpts),
+			"[%s] failed to deploy CoreDNS NodePort service to %s", ProviderOpenShift, clusterName)
+
+		service, err := k8s.GetServiceE(t, kubectlOpts, coreDNSServiceName)
+		require.NoError(t, err, "[%s] failed to read CoreDNS service in %s", ProviderOpenShift, clusterName)
+		require.NotEmpty(t, service.Spec.Ports, "[%s] CoreDNS service has no ports in %s", ProviderOpenShift, clusterName)
+
+		nodePort := service.Spec.Ports[0].NodePort
+		workerIPs := openShiftWorkerInternalIPs(t, kubeConfigPath, clusterName)
+		upstreams := make([]string, 0, len(workerIPs))
+		for _, workerIP := range workerIPs {
+			upstreams = append(upstreams, fmt.Sprintf("%s:%d", workerIP, nodePort))
+		}
+
+		r.CorednsClusterOptions[domain] = coredns.CoreDNSClusterOption{
+			IPs:       upstreams,
+			Namespace: r.Namespace[clusterName],
+			Domain:    domain,
+		}
+	}
+
+	UpdateCoreDNSConfiguration(t, r.Region, kubeConfigPath)
+}
+
+func deployOpenShiftCoreDNSNodePortService(t *testing.T, kubectlOpts *k8s.KubectlOptions) error {
+	t.Helper()
+	_ = k8s.RunKubectlE(t, kubectlOpts,
+		"patch", "service", coreDNSServiceName, "--type=merge", "-p", `{"metadata":{"finalizers":null}}`)
+	_ = k8s.RunKubectlE(t, kubectlOpts,
+		"delete", "service", coreDNSServiceName, "--ignore-not-found=true", "--wait=true")
+
+	service := fmt.Sprintf(`apiVersion: v1
+kind: Service
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    k8s-app: kube-dns
+spec:
+  type: NodePort
+  selector:
+    k8s-app: kube-dns
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+`, coreDNSServiceName, coreDNSNamespace)
+	return k8s.KubectlApplyFromStringE(t, kubectlOpts, service)
+}
+
+func (r *OpenShiftRegion) configureOpenShiftDNSForwarding(t *testing.T, kubeConfigPath string) {
+	t.Helper()
+	for _, clusterName := range r.Clusters {
+		servers := make([]map[string]interface{}, 0, len(r.Clusters))
+		for j := range r.Clusters {
+			domain := operator.CustomDomains[j]
+			option := r.CorednsClusterOptions[domain]
+			require.NotEmpty(t, option.IPs, "[%s] no CoreDNS upstreams configured for domain %s", ProviderOpenShift, domain)
+			servers = append(servers, map[string]interface{}{
+				"name":  strings.ReplaceAll(domain, ".", "-"),
+				"zones": []string{domain},
+				"forwardPlugin": map[string]interface{}{
+					"policy":    "Sequential",
+					"upstreams": option.IPs,
+				},
+			})
+		}
+
+		patch, err := json.Marshal(map[string]interface{}{
+			"spec": map[string]interface{}{
+				"servers": servers,
+			},
+		})
+		require.NoError(t, err)
+
+		kubectlOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, "")
+		require.NoError(t, k8s.RunKubectlE(t, kubectlOpts,
+			"patch", "dns.operator.openshift.io/default", "--type=merge", "-p", string(patch)),
+			"[%s] failed to configure DNS forwarding in %s", ProviderOpenShift, clusterName)
+		require.NoError(t, k8s.RunKubectlE(t, kubectlOpts,
+			"-n", "openshift-dns", "rollout", "status", "daemonset/dns-default", "--timeout=3m"),
+			"[%s] OpenShift DNS did not roll out in %s", ProviderOpenShift, clusterName)
+	}
+}
+
+func (r *OpenShiftRegion) configureOpenShiftSubmariner(t *testing.T, kubeConfigPath, projectID string) {
+	t.Helper()
+	if !OpenShiftSubmarinerEnabled() {
+		t.Logf("[%s] %s=false; skipping Submariner setup", ProviderOpenShift, envOpenShiftEnableSubmariner)
+		return
+	}
+	if _, err := exec.LookPath("subctl"); err != nil {
+		t.Fatalf("[%s] subctl not found in PATH: %v", ProviderOpenShift, err)
+	}
+
+	credentialsPath := openShiftGCPCredentialsPath(t)
+
+	for i, clusterName := range r.Clusters {
+		netCfg := openShiftNetworkConfigForCluster(t, i)
+		r.prepareOpenShiftSubmarinerGCP(t, kubeConfigPath, projectID, clusterName, r.RegionCodes[i], r.infraIDs[clusterName], credentialsPath)
+		t.Logf("[%s] Prepared GCP infrastructure for Submariner cluster %q (pod CIDR %s, service CIDR %s)",
+			ProviderOpenShift, clusterName, netCfg.ClusterNetwork, netCfg.ServiceNetwork)
+	}
+
+	brokerDir := t.TempDir()
+	brokerInfoPath := filepath.Join(brokerDir, openShiftSubmarinerBrokerFile)
+	require.NoError(t, runOpenShiftSubctl(t, brokerDir,
+		"deploy-broker",
+		"--kubeconfig", kubeConfigPath,
+		"--context", r.Clusters[0],
+		"--globalnet=false",
+	), "[%s] failed to deploy Submariner broker", ProviderOpenShift)
+	require.FileExists(t, brokerInfoPath, "[%s] Submariner broker info file was not created", ProviderOpenShift)
+
+	for i, clusterName := range r.Clusters {
+		netCfg := openShiftNetworkConfigForCluster(t, i)
+		gatewayNode := labelOpenShiftSubmarinerGatewayNode(t, kubeConfigPath, clusterName)
+		tagOpenShiftSubmarinerGatewayInstance(t, projectID, gatewayNode)
+		t.Logf("[%s] Using node %q / instance %q as the Submariner gateway for cluster %q",
+			ProviderOpenShift, gatewayNode.nodeName, gatewayNode.instanceName, clusterName)
+		require.NoError(t, runOpenShiftSubctl(t, "",
+			"join", brokerInfoPath,
+			"--kubeconfig", kubeConfigPath,
+			"--context", clusterName,
+			"--clusterid", openShiftSubmarinerClusterID(i),
+			"--clustercidr", netCfg.ClusterNetwork,
+			"--servicecidr", netCfg.ServiceNetwork,
+			"--globalnet=false",
+			"--load-balancer",
+			"--label-gateway=false",
+		), "[%s] failed to join %s to Submariner", ProviderOpenShift, clusterName)
+		waitForOpenShiftSubmariner(t, kubeConfigPath, clusterName)
+	}
+
+	r.verifyOpenShiftSubmariner(t, kubeConfigPath)
+}
+
+func (r *OpenShiftRegion) prepareOpenShiftSubmarinerGCP(
+	t *testing.T,
+	kubeConfigPath, projectID, clusterName, regionCode, infraID, credentialsPath string,
+) {
+	t.Helper()
+	if openShiftGCPServiceAccountCredentials(t, credentialsPath) {
+		r.prepareOpenShiftSubmarinerGCPWithSubctl(t, kubeConfigPath, projectID, clusterName, regionCode, infraID, credentialsPath)
+		return
+	}
+
+	t.Logf("[%s] Preparing GCP infrastructure for Submariner cluster %q with gcloud; subctl cloud prepare requires service_account JSON credentials",
+		ProviderOpenShift, clusterName)
+	r.prepareOpenShiftSubmarinerGCPWithGCloud(t, kubeConfigPath, projectID, clusterName, infraID)
+}
+
+func (r *OpenShiftRegion) prepareOpenShiftSubmarinerGCPWithSubctl(
+	t *testing.T,
+	kubeConfigPath, projectID, clusterName, regionCode, infraID, credentialsPath string,
+) {
+	t.Helper()
+	args := []string{
+		"cloud", "prepare", "gcp",
+		"--kubeconfig", kubeConfigPath,
+		"--context", clusterName,
+		"--project-id", projectID,
+		"--region", regionCode,
+		"--infra-id", infraID,
+		"--vpc-name", openShiftNetworkName(infraID),
+		"--credentials", credentialsPath,
+	}
+	require.NoError(t, runOpenShiftSubctl(t, "", args...),
+		"[%s] failed to prepare GCP infrastructure for Submariner cluster %s", ProviderOpenShift, clusterName)
+}
+
+func (r *OpenShiftRegion) prepareOpenShiftSubmarinerGCPWithGCloud(
+	t *testing.T,
+	kubeConfigPath, projectID, clusterName, infraID string,
+) {
+	t.Helper()
+	network := openShiftNetworkName(infraID)
+	upsertOpenShiftFirewallRule(t, projectID, openShiftSubmarinerFirewallName(infraID, openShiftSubmarinerPublicFirewallRule),
+		[]string{
+			"--network", network,
+			"--direction", "INGRESS",
+			"--priority", "1000",
+			"--source-ranges", "0.0.0.0/0",
+			"--target-tags", openShiftSubmarinerGatewayTag,
+			"--allow", openShiftSubmarinerPublicPorts,
+		},
+		[]string{
+			"--priority", "1000",
+			"--source-ranges", "0.0.0.0/0",
+			"--target-tags", openShiftSubmarinerGatewayTag,
+			"--allow", openShiftSubmarinerPublicPorts,
+		},
+	)
+
+	if openShiftSubmarinerNeedsInternalVXLAN(t, kubeConfigPath, clusterName) {
+		submarinerTags := strings.Join([]string{infraID + "-worker", infraID + "-master"}, ",")
+		upsertOpenShiftFirewallRule(t, projectID, openShiftSubmarinerFirewallName(infraID, openShiftSubmarinerInternalFirewallRule),
+			[]string{
+				"--network", network,
+				"--direction", "INGRESS",
+				"--priority", "1000",
+				"--source-tags", submarinerTags,
+				"--target-tags", submarinerTags,
+				"--allow", openShiftSubmarinerInternalPorts,
+			},
+			[]string{
+				"--priority", "1000",
+				"--source-tags", submarinerTags,
+				"--target-tags", submarinerTags,
+				"--allow", openShiftSubmarinerInternalPorts,
+			},
+		)
+	}
+}
+
+func waitForOpenShiftSubmariner(t *testing.T, kubeConfigPath, clusterName string) {
+	t.Helper()
+	kubectlOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, openShiftSubmarinerNamespace)
+	resources := []string{
+		"deployment/submariner-operator",
+		"deployment/submariner-lighthouse-agent",
+		"deployment/submariner-lighthouse-coredns",
+		"daemonset/submariner-gateway",
+		"daemonset/submariner-metrics-proxy",
+		"daemonset/submariner-routeagent",
+	}
+	for _, resource := range resources {
+		_, err := retry.DoWithRetryE(t, fmt.Sprintf("wait for %s in %s", resource, clusterName), defaultRetries, defaultRetryInterval,
+			func() (string, error) {
+				return k8s.RunKubectlAndGetOutputE(t, kubectlOpts,
+					"rollout", "status", resource, "--timeout=2m")
+			})
+		require.NoError(t, err, "[%s] Submariner resource %s did not roll out in %s", ProviderOpenShift, resource, clusterName)
+	}
+}
+
+func labelOpenShiftSubmarinerGatewayNode(t *testing.T, kubeConfigPath, clusterName string) openShiftSubmarinerGatewayNode {
+	t.Helper()
+	kubectlOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, "")
+	nodeName, err := k8s.RunKubectlAndGetOutputE(t, kubectlOpts,
+		"get", "nodes",
+		"-l", "node-role.kubernetes.io/worker",
+		"--sort-by=.metadata.name",
+		"-o", "jsonpath={.items[0].metadata.name}")
+	require.NoError(t, err, "[%s] failed to find a worker gateway node in %s", ProviderOpenShift, clusterName)
+	nodeName = strings.TrimSpace(nodeName)
+	require.NotEmpty(t, nodeName, "[%s] no worker gateway node found in %s", ProviderOpenShift, clusterName)
+
+	require.NoError(t, k8s.RunKubectlE(t, kubectlOpts,
+		"label", "node", nodeName, "submariner.io/gateway=true", "--overwrite"),
+		"[%s] failed to label Submariner gateway node %s in %s", ProviderOpenShift, nodeName, clusterName)
+
+	return openShiftSubmarinerGatewayNodeDetails(t, kubectlOpts, nodeName)
+}
+
+func openShiftSubmarinerGatewayNodeDetails(
+	t *testing.T, kubectlOpts *k8s.KubectlOptions, nodeName string,
+) openShiftSubmarinerGatewayNode {
+	t.Helper()
+	output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOpts, "get", "node", nodeName, "-o", "json")
+	require.NoError(t, err, "[%s] failed to read Submariner gateway node %s", ProviderOpenShift, nodeName)
+
+	var node struct {
+		Metadata struct {
+			Annotations map[string]string `json:"annotations"`
+			Labels      map[string]string `json:"labels"`
+		} `json:"metadata"`
+		Spec struct {
+			ProviderID string `json:"providerID"`
+		} `json:"spec"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(output), &node),
+		"[%s] failed to parse Submariner gateway node %s", ProviderOpenShift, nodeName)
+
+	instanceName := openShiftInstanceNameFromMachineAnnotation(node.Metadata.Annotations["machine.openshift.io/machine"])
+	zone := strings.TrimSpace(node.Metadata.Labels["topology.kubernetes.io/zone"])
+	if instanceName == "" || zone == "" {
+		providerZone, providerInstance := openShiftGCPProviderIDDetails(node.Spec.ProviderID)
+		if instanceName == "" {
+			instanceName = providerInstance
+		}
+		if zone == "" {
+			zone = providerZone
+		}
+	}
+
+	require.NotEmpty(t, instanceName, "[%s] failed to determine GCP instance for Submariner gateway node %s",
+		ProviderOpenShift, nodeName)
+	require.NotEmpty(t, zone, "[%s] failed to determine GCP zone for Submariner gateway node %s",
+		ProviderOpenShift, nodeName)
+
+	return openShiftSubmarinerGatewayNode{
+		nodeName:     nodeName,
+		instanceName: instanceName,
+		zone:         zone,
+	}
+}
+
+func tagOpenShiftSubmarinerGatewayInstance(t *testing.T, projectID string, gatewayNode openShiftSubmarinerGatewayNode) {
+	t.Helper()
+	_, err := runOpenShiftGCloud(t,
+		"compute", "instances", "add-tags", gatewayNode.instanceName,
+		"--project", projectID,
+		"--zone", gatewayNode.zone,
+		"--tags", openShiftSubmarinerGatewayTag,
+		"--quiet",
+	)
+	require.NoError(t, err, "[%s] failed to tag GCP instance %s as a Submariner gateway",
+		ProviderOpenShift, gatewayNode.instanceName)
+}
+
+func (r *OpenShiftRegion) verifyOpenShiftSubmariner(t *testing.T, kubeConfigPath string) {
+	t.Helper()
+	for i := 0; i < len(r.Clusters); i++ {
+		for j := i + 1; j < len(r.Clusters); j++ {
+			require.NoError(t, runOpenShiftSubctl(t, "",
+				"verify",
+				"--kubeconfig", kubeConfigPath,
+				"--context", r.Clusters[i],
+				"--toconfig", kubeConfigPath,
+				"--tocontext", r.Clusters[j],
+				"--only", "connectivity,basic-connectivity",
+				"--skip-src-ip-check",
+				"--connection-attempts", "3",
+				"--connection-timeout", "60",
+				"--operation-timeout", "300",
+			), "[%s] Submariner connectivity verification failed between %s and %s", ProviderOpenShift, r.Clusters[i], r.Clusters[j])
+		}
+	}
+}
+
+func openShiftWorkerInternalIPs(t *testing.T, kubeConfigPath, clusterName string) []string {
+	t.Helper()
+	kubectlOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, "")
+	output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOpts,
+		"get", "nodes",
+		"-l", "node-role.kubernetes.io/worker",
+		"-o", "jsonpath={range .items[*]}{.status.addresses[?(@.type==\"InternalIP\")].address}{\"\\n\"}{end}")
+	require.NoError(t, err, "[%s] failed to list OpenShift worker IPs for %s", ProviderOpenShift, clusterName)
+
+	var workerIPs []string
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			workerIPs = append(workerIPs, line)
+		}
+	}
+	require.NotEmpty(t, workerIPs, "[%s] no OpenShift worker IPs found for %s", ProviderOpenShift, clusterName)
+	return workerIPs
+}
+
+func discoverOpenShiftInfraID(t *testing.T, kubeConfigPath, clusterName string) string {
+	t.Helper()
+	kubectlOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, "")
+	output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOpts,
+		"get", "nodes", "-o", "jsonpath={.items[0].metadata.name}")
+	require.NoError(t, err, "[%s] failed to discover infraID from nodes for %s", ProviderOpenShift, clusterName)
+
+	nodeName := strings.TrimSpace(strings.Split(output, ".")[0])
+	for _, marker := range []string{"-master-", "-worker-"} {
+		if idx := strings.Index(nodeName, marker); idx > 0 {
+			return nodeName[:idx]
+		}
+	}
+	t.Fatalf("[%s] could not derive infraID from node name %q", ProviderOpenShift, nodeName)
+	return ""
+}
+
+func openShiftNetworkName(infraID string) string {
+	return infraID + "-network"
+}
+
+func openShiftPeeringName(localInfraID, peerInfraID string) string {
+	return fmt.Sprintf("%s-to-%s", openShiftShortInfraID(localInfraID), openShiftShortInfraID(peerInfraID))
+}
+
+func openShiftPeerFirewallName(localInfraID, peerInfraID string) string {
+	return fmt.Sprintf("%s-allow-peer-%s", openShiftShortInfraID(localInfraID), openShiftShortInfraID(peerInfraID))
+}
+
+func openShiftSubmarinerFirewallName(infraID, ruleName string) string {
+	return fmt.Sprintf("%s-%s-ingress", infraID, ruleName)
+}
+
+func openShiftShortInfraID(infraID string) string {
+	parts := strings.Split(infraID, "-")
+	if len(parts) >= 2 {
+		return parts[0] + "-" + parts[1]
+	}
+	return infraID
+}
+
+func runOpenShiftGCloud(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("gcloud", args...)
+	cmd.Env = openShiftGCloudEnv()
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return string(output), nil
+}
+
+func openShiftGCloudEnv() []string {
+	env := openShiftInstallerEnv()
+	env = append(env, "CLOUDSDK_CORE_DISABLE_PROMPTS=1")
+	if creds := strings.TrimSpace(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")); creds != "" {
+		env = appendWithoutEnvKey(env, "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE")
+		env = append(env, "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE="+creds)
+	}
+	return env
+}
+
+func isOpenShiftGCloudAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "already exists") ||
+		strings.Contains(message, "alreadyexists")
+}
+
+func isOpenShiftGCloudNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "not found") ||
+		strings.Contains(message, "notfound") ||
+		strings.Contains(message, "was not found") ||
+		strings.Contains(message, "does not exist")
+}
+
+func upsertOpenShiftFirewallRule(t *testing.T, projectID, firewallName string, createFlags, updateFlags []string) {
+	t.Helper()
+	createArgs := append([]string{"compute", "firewall-rules", "create", firewallName, "--project", projectID}, createFlags...)
+	_, err := runOpenShiftGCloud(t, createArgs...)
+	if err == nil {
+		return
+	}
+	if !isOpenShiftGCloudAlreadyExists(err) {
+		require.NoError(t, err, "[%s] failed to create firewall rule %s", ProviderOpenShift, firewallName)
+		return
+	}
+
+	updateArgs := append([]string{"compute", "firewall-rules", "update", firewallName, "--project", projectID}, updateFlags...)
+	_, err = runOpenShiftGCloud(t, updateArgs...)
+	require.NoError(t, err, "[%s] failed to update firewall rule %s", ProviderOpenShift, firewallName)
+}
+
+func runOpenShiftSubctl(t *testing.T, dir string, args ...string) error {
+	t.Helper()
+	cmd := exec.Command("subctl", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Env = openShiftInstallerEnv()
+	output, err := cmd.CombinedOutput()
+	t.Logf("[%s] subctl %s\n%s", ProviderOpenShift, strings.Join(args, " "), strings.TrimSpace(string(output)))
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func openShiftGCPServiceAccountCredentials(t *testing.T, credentialsPath string) bool {
+	t.Helper()
+	if strings.TrimSpace(credentialsPath) == "" {
+		return false
+	}
+
+	data, err := os.ReadFile(credentialsPath)
+	if err != nil {
+		t.Logf("[%s] Could not read credentials file %s for subctl cloud prepare, using gcloud fallback: %v",
+			ProviderOpenShift, credentialsPath, err)
+		return false
+	}
+
+	var credentials struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &credentials); err != nil {
+		t.Logf("[%s] Credentials file %s is not JSON, using gcloud fallback: %v", ProviderOpenShift, credentialsPath, err)
+		return false
+	}
+	return credentials.Type == "service_account"
+}
+
+func openShiftGCPCredentialsPath(t *testing.T) string {
+	t.Helper()
+	if credentialsPath := strings.TrimSpace(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")); credentialsPath != "" {
+		return credentialsPath
+	}
+
+	googleCredentials := strings.TrimSpace(os.Getenv("GOOGLE_CREDENTIALS"))
+	if googleCredentials == "" {
+		return getServiceAccountKeyPath()
+	}
+	if !json.Valid([]byte(googleCredentials)) {
+		return googleCredentials
+	}
+
+	credentialsPath := filepath.Join(t.TempDir(), "gcp-credentials.json")
+	require.NoError(t, os.WriteFile(credentialsPath, []byte(googleCredentials), 0600),
+		"[%s] failed to write GOOGLE_CREDENTIALS for Submariner cloud prepare", ProviderOpenShift)
+	return credentialsPath
+}
+
+func openShiftSubmarinerNeedsInternalVXLAN(t *testing.T, kubeConfigPath, clusterName string) bool {
+	t.Helper()
+	kubectlOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, "")
+	networkPlugin, err := k8s.RunKubectlAndGetOutputE(t, kubectlOpts,
+		"get", "network.operator.openshift.io/cluster", "-o", "jsonpath={.spec.defaultNetwork.type}")
+	if err != nil {
+		t.Logf("[%s] Could not determine OpenShift network plugin for %s, opening Submariner internal VXLAN port: %v",
+			ProviderOpenShift, clusterName, err)
+		return true
+	}
+	networkPlugin = strings.TrimSpace(networkPlugin)
+	if networkPlugin == "OVNKubernetes" {
+		t.Logf("[%s] Cluster %q uses OVNKubernetes; Submariner internal VXLAN firewall rule is not required",
+			ProviderOpenShift, clusterName)
+		return false
+	}
+	return true
+}
+
+func openShiftInstanceNameFromMachineAnnotation(annotation string) string {
+	annotation = strings.TrimSpace(annotation)
+	if annotation == "" {
+		return ""
+	}
+	parts := strings.Split(annotation, "/")
+	return strings.TrimSpace(parts[len(parts)-1])
+}
+
+func openShiftGCPProviderIDDetails(providerID string) (string, string) {
+	providerID = strings.TrimSpace(providerID)
+	parts := strings.Split(providerID, "/")
+	if len(parts) < 2 {
+		return "", ""
+	}
+	instanceName := strings.TrimSpace(parts[len(parts)-1])
+	zone := strings.TrimSpace(parts[len(parts)-2])
+	return zone, instanceName
+}
+
+func readOpenShiftInfraID(installDir string) (string, error) {
+	metadataPath := filepath.Join(installDir, "metadata.json")
+	data, err := os.ReadFile(metadataPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read metadata.json: %w", err)
+	}
+
+	var metadata openShiftMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return "", fmt.Errorf("failed to parse metadata.json: %w", err)
+	}
+	if metadata.InfraID == "" {
+		return "", fmt.Errorf("metadata.json has empty infraID")
+	}
+	return metadata.InfraID, nil
+}
+
+func mergeOpenShiftKubeconfig(generatedKubeconfig, destinationKubeconfig, clusterAlias string) error {
+	sourceConfig, err := clientcmd.LoadFromFile(generatedKubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to load generated kubeconfig: %w", err)
+	}
+
+	destinationConfig, err := clientcmd.LoadFromFile(destinationKubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to load destination kubeconfig: %w", err)
+	}
+	if destinationConfig.Clusters == nil {
+		destinationConfig.Clusters = make(map[string]*clientcmdapi.Cluster)
+	}
+	if destinationConfig.AuthInfos == nil {
+		destinationConfig.AuthInfos = make(map[string]*clientcmdapi.AuthInfo)
+	}
+	if destinationConfig.Contexts == nil {
+		destinationConfig.Contexts = make(map[string]*clientcmdapi.Context)
+	}
+
+	sourceContextName := sourceConfig.CurrentContext
+	if sourceContextName == "" {
+		for contextName := range sourceConfig.Contexts {
+			sourceContextName = contextName
+			break
+		}
+	}
+	sourceContext := sourceConfig.Contexts[sourceContextName]
+	if sourceContext == nil {
+		return fmt.Errorf("generated kubeconfig has no usable context")
+	}
+
+	sourceCluster := sourceConfig.Clusters[sourceContext.Cluster]
+	if sourceCluster == nil {
+		return fmt.Errorf("generated kubeconfig context %q references missing cluster %q", sourceContextName, sourceContext.Cluster)
+	}
+	sourceAuth := sourceConfig.AuthInfos[sourceContext.AuthInfo]
+	if sourceAuth == nil {
+		return fmt.Errorf("generated kubeconfig context %q references missing user %q", sourceContextName, sourceContext.AuthInfo)
+	}
+
+	userAlias := "admin-" + clusterAlias
+	destinationConfig.Clusters[clusterAlias] = sourceCluster
+	destinationConfig.AuthInfos[userAlias] = sourceAuth
+	destinationConfig.Contexts[clusterAlias] = &clientcmdapi.Context{
+		Cluster:   clusterAlias,
+		AuthInfo:  userAlias,
+		Namespace: sourceContext.Namespace,
+	}
+	destinationConfig.CurrentContext = clusterAlias
+
+	if err := clientcmd.WriteToFile(*destinationConfig, destinationKubeconfig); err != nil {
+		return fmt.Errorf("failed to write merged kubeconfig: %w", err)
+	}
+	return nil
+}
+
+func readOpenShiftPullSecret(t *testing.T) string {
+	value := mustOpenShiftEnv(t, envOpenShiftPullSecret)
+	value = readEnvValueOrFile(t, value)
+	if !json.Valid([]byte(value)) {
+		t.Fatalf("[%s] %s must be valid pull-secret JSON or a path to a file containing it", ProviderOpenShift, envOpenShiftPullSecret)
+	}
+	return strings.TrimSpace(value)
+}
+
+func readOpenShiftSSHPubKey(t *testing.T) string {
+	value := mustOpenShiftEnv(t, envOpenShiftSSHPubKey)
+	return strings.TrimSpace(readEnvValueOrFile(t, value))
+}
+
+func readEnvValueOrFile(t *testing.T, value string) string {
+	t.Helper()
+	if data, err := os.ReadFile(value); err == nil {
+		return strings.TrimSpace(string(data))
+	}
+	return value
+}
+
+func mustOpenShiftEnv(t *testing.T, envName string) string {
+	t.Helper()
+	value := strings.TrimSpace(os.Getenv(envName))
+	if value == "" {
+		t.Fatalf("[%s] required environment variable %s is not set", ProviderOpenShift, envName)
+	}
+	return value
+}
+
+func openShiftStorageClassName() string {
+	if storageClassName := strings.TrimSpace(os.Getenv(envOpenShiftStorageClass)); storageClassName != "" {
+		return storageClassName
+	}
+	return defaultOpenShiftStorageClass
+}
+
+func OpenShiftSubmarinerEnabled() bool {
+	value := strings.TrimSpace(os.Getenv(envOpenShiftEnableSubmariner))
+	if value == "" {
+		return true
+	}
+	return parseBoolEnv(envOpenShiftEnableSubmariner)
+}
+
+func openShiftReuseKubeconfigs(t *testing.T, clusterCount int) []string {
+	t.Helper()
+
+	reuseKubeconfigs := strings.TrimSpace(os.Getenv(envOpenShiftReuseKubeconfigs))
+	if reuseKubeconfigs != "" {
+		paths := filepath.SplitList(reuseKubeconfigs)
+		if len(paths) != clusterCount {
+			t.Fatalf("[%s] %s must contain %d kubeconfig paths, got %d",
+				ProviderOpenShift, envOpenShiftReuseKubeconfigs, clusterCount, len(paths))
+		}
+		return paths
+	}
+
+	reuseKubeconfig := strings.TrimSpace(os.Getenv(envOpenShiftReuseKubeconfig))
+	if reuseKubeconfig == "" {
+		return nil
+	}
+	if clusterCount != 1 {
+		t.Fatalf("[%s] %s only supports single-cluster reuse; use %s for %d clusters",
+			ProviderOpenShift, envOpenShiftReuseKubeconfig, envOpenShiftReuseKubeconfigs, clusterCount)
+	}
+	return []string{reuseKubeconfig}
+}
+
+func openShiftReuseContexts(t *testing.T, clusterCount int) []string {
+	t.Helper()
+	reuseContexts := strings.TrimSpace(os.Getenv(envOpenShiftReuseContexts))
+	if reuseContexts == "" {
+		return nil
+	}
+	contexts := filepath.SplitList(reuseContexts)
+	if len(contexts) != clusterCount {
+		t.Fatalf("[%s] %s must contain %d context names, got %d",
+			ProviderOpenShift, envOpenShiftReuseContexts, clusterCount, len(contexts))
+	}
+	return contexts
+}
+
+func openShiftSubmarinerClusterID(clusterIndex int) string {
+	return fmt.Sprintf("openshift-%d", clusterIndex+1)
+}
+
+func openShiftInstallerEnv() []string {
+	env := os.Environ()
+	env = appendWithoutEnvKey(env, "GODEBUG")
+	env = append(env, "GODEBUG="+withOpenShiftInstallerGODEBUG(os.Getenv("GODEBUG")))
+
+	googleCreds := os.Getenv("GOOGLE_CREDENTIALS")
+	if googleCreds == "" || json.Valid([]byte(googleCreds)) {
+		return env
+	}
+
+	env = appendWithoutEnvKey(env, "GOOGLE_APPLICATION_CREDENTIALS")
+	return append(env, "GOOGLE_APPLICATION_CREDENTIALS="+googleCreds)
+}
+
+func withOpenShiftInstallerGODEBUG(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "netdns=go"
+	}
+	if strings.Contains(value, "netdns=") {
+		return value
+	}
+	return value + ",netdns=go"
+}
+
+func appendWithoutEnvKey(env []string, key string) []string {
+	prefix := key + "="
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
+func parseBoolEnv(envName string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(envName))) {
+	case "1", "t", "true", "y", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+func openShiftWorkerReplicasForNodeCount(nodeCount int) int {
+	if nodeCount < 1 {
+		return 3 + openShiftScaleUpExtraWorkers
+	}
+	return nodeCount + openShiftScaleUpExtraWorkers
+}
+
+func openShiftNetworkConfigForCluster(t *testing.T, clusterIndex int) openShiftNetworkConfig {
+	t.Helper()
+	if clusterIndex >= len(openShiftNetworkConfigs) {
+		t.Fatalf("[%s] no OpenShift network config defined for cluster index %d", ProviderOpenShift, clusterIndex)
+	}
+	return openShiftNetworkConfigs[clusterIndex]
+}
+
+func shortOpenShiftInstallerName(clusterName string) string {
+	sum := sha1.Sum([]byte(clusterName + time.Now().UTC().Format(time.RFC3339Nano)))
+	return "ocp-" + hex.EncodeToString(sum[:])[:10]
+}
+
+var _ CloudProvider = (*OpenShiftRegion)(nil)
+var _ encryption.Provider = (*OpenShiftRegion)(nil)

--- a/tests/e2e/operator/infra/openshift_runtime.go
+++ b/tests/e2e/operator/infra/openshift_runtime.go
@@ -1,0 +1,79 @@
+package infra
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	openShiftChartCloudProvider   = ProviderGCP
+	openShiftDefaultClusterDomain = "cluster.local"
+)
+
+type openShiftRuntime struct{}
+
+func (openShiftRuntime) ChartCloudProvider(_ string) string {
+	return openShiftChartCloudProvider
+}
+
+func (openShiftRuntime) ClusterDomain(region *operator.Region, index int) string {
+	if region != nil && len(region.Clusters) > 1 {
+		if domain, ok := operator.CustomDomains[index]; ok {
+			return domain
+		}
+	}
+	return openShiftDefaultClusterDomain
+}
+
+func (openShiftRuntime) PatchHelmValues(values map[string]string) map[string]string {
+	if values == nil {
+		values = make(map[string]string)
+	}
+	values["cockroachdb.crdbCluster.dataStore.volumeClaimTemplate.spec.storageClassName"] = openShiftStorageClassName()
+	return values
+}
+
+func (openShiftRuntime) ConfigureNamespace(
+	t *testing.T, kubectlOptions *k8s.KubectlOptions, namespace string,
+) {
+	bindingName := openShiftAnyUIDBindingName(namespace)
+	group := fmt.Sprintf("system:serviceaccounts:%s", namespace)
+	manifest := fmt.Sprintf(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: %s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: %s
+`, bindingName, group)
+
+	require.NoError(t, k8s.KubectlApplyFromStringE(t, kubectlOptions, manifest),
+		"failed to apply OpenShift SCC binding %s", bindingName)
+}
+
+func (openShiftRuntime) HelmDeleteArgs(args []string) []string {
+	deleteArgs := append([]string{}, args...)
+	return append(deleteArgs, "--no-hooks")
+}
+
+func (openShiftRuntime) CleanupNamespace(
+	t *testing.T, kubectlOptions *k8s.KubectlOptions, namespace string,
+) {
+	bindingName := openShiftAnyUIDBindingName(namespace)
+	_ = k8s.RunKubectlE(t, kubectlOptions, "delete", "clusterrolebinding", bindingName, "--ignore-not-found=true")
+}
+
+func openShiftAnyUIDBindingName(namespace string) string {
+	return fmt.Sprintf("cockroach-anyuid-%s", namespace)
+}
+
+var _ operator.ProviderRuntime = openShiftRuntime{}

--- a/tests/e2e/operator/infra/provider.go
+++ b/tests/e2e/operator/infra/provider.go
@@ -34,7 +34,7 @@ type CloudProvider interface {
 func ResolveProvider(t *testing.T) string {
 	if p := strings.TrimSpace(strings.ToLower(os.Getenv("PROVIDER"))); p != "" {
 		switch p {
-		case ProviderK3D, ProviderKind, ProviderGCP, ProviderAWS:
+		case ProviderK3D, ProviderKind, ProviderGCP, ProviderAWS, ProviderOpenShift:
 			return p
 		default:
 			t.Fatalf("Unsupported provider override: %s", p)
@@ -65,6 +65,11 @@ func ProviderFactory(providerType string, region *operator.Region) CloudProvider
 	case ProviderAWS:
 		p := AwsRegion{Region: region}
 		p.RegionCodes = GetRegionCodes(providerType)
+		cp = &p
+	case ProviderOpenShift:
+		p := OpenShiftRegion{Region: region}
+		p.RegionCodes = GetRegionCodes(providerType)
+		region.SetProviderRuntime(openShiftRuntime{})
 		cp = &p
 	default:
 		return nil

--- a/tests/e2e/operator/provider_runtime.go
+++ b/tests/e2e/operator/provider_runtime.go
@@ -1,0 +1,85 @@
+package operator
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+)
+
+const defaultClusterDomain = "cluster.local"
+
+// ProviderRuntime lets a provider adjust chart install and cleanup behavior
+// without leaking provider-specific rules into the shared Region workflow.
+type ProviderRuntime interface {
+	ChartCloudProvider(provider string) string
+	ClusterDomain(region *Region, index int) string
+	PatchHelmValues(values map[string]string) map[string]string
+	ConfigureNamespace(t *testing.T, kubectlOptions *k8s.KubectlOptions, namespace string)
+	HelmDeleteArgs(args []string) []string
+	CleanupNamespace(t *testing.T, kubectlOptions *k8s.KubectlOptions, namespace string)
+}
+
+type defaultProviderRuntime struct{}
+
+func (defaultProviderRuntime) ChartCloudProvider(provider string) string {
+	return provider
+}
+
+func (defaultProviderRuntime) ClusterDomain(_ *Region, index int) string {
+	if domain, ok := CustomDomains[index]; ok {
+		return domain
+	}
+	return defaultClusterDomain
+}
+
+func (defaultProviderRuntime) PatchHelmValues(values map[string]string) map[string]string {
+	return values
+}
+
+func (defaultProviderRuntime) ConfigureNamespace(_ *testing.T, _ *k8s.KubectlOptions, _ string) {
+}
+
+func (defaultProviderRuntime) HelmDeleteArgs(args []string) []string {
+	return args
+}
+
+func (defaultProviderRuntime) CleanupNamespace(_ *testing.T, _ *k8s.KubectlOptions, _ string) {
+}
+
+func (r *Region) runtime() ProviderRuntime {
+	if r.providerRuntime != nil {
+		return r.providerRuntime
+	}
+	return defaultProviderRuntime{}
+}
+
+func (r *Region) chartCloudProvider() string {
+	return r.runtime().ChartCloudProvider(r.Provider)
+}
+
+func (r *Region) clusterDomain(index int) string {
+	return r.runtime().ClusterDomain(r, index)
+}
+
+func (r *Region) prepareNamespace(t *testing.T, kubectlOptions *k8s.KubectlOptions, namespace string) {
+	k8s.CreateNamespace(t, kubectlOptions, namespace)
+	r.runtime().ConfigureNamespace(t, kubectlOptions, namespace)
+}
+
+func (r *Region) CockroachDBHelmValues(index int, values map[string]string) map[string]string {
+	if values == nil {
+		values = make(map[string]string)
+	}
+	if _, ok := values["cockroachdb.clusterDomain"]; !ok {
+		values["cockroachdb.clusterDomain"] = r.clusterDomain(index)
+	}
+	return r.runtime().PatchHelmValues(PatchHelmValues(values))
+}
+
+func (r *Region) helmDeleteArgs(args ...string) []string {
+	return r.runtime().HelmDeleteArgs(args)
+}
+
+func (r *Region) cleanupNamespace(t *testing.T, kubectlOptions *k8s.KubectlOptions, namespace string) {
+	r.runtime().CleanupNamespace(t, kubectlOptions, namespace)
+}

--- a/tests/e2e/operator/region.go
+++ b/tests/e2e/operator/region.go
@@ -84,10 +84,15 @@ type Region struct {
 	encryptionProvider    encryption.Provider
 	encryptionInfraSetup  bool
 	encryptionCleanupFunc func()
+	providerRuntime       ProviderRuntime
 }
 
 func (r *Region) SetEncryptionProvider(p encryption.Provider) {
 	r.encryptionProvider = p
+}
+
+func (r *Region) SetProviderRuntime(runtime ProviderRuntime) {
+	r.providerRuntime = runtime
 }
 
 func (r *Region) CleanupEncryptionInfra() {
@@ -132,7 +137,7 @@ func (r *Region) InstallCharts(t *testing.T, cluster string, index int) {
 	certManagerK8sOptions := k8s.NewKubectlOptions(cluster, kubeConfig, testutil.CertManagerNamespace)
 
 	// Create a namespace.
-	k8s.CreateNamespace(t, kubectlOptions, r.Namespace[cluster])
+	r.prepareNamespace(t, kubectlOptions, r.Namespace[cluster])
 
 	if r.IsCertManager {
 		testutil.InstallCertManager(t, certManagerK8sOptions)
@@ -155,8 +160,7 @@ func (r *Region) InstallCharts(t *testing.T, cluster string, index int) {
 	}
 
 	if r.IsCertManager {
-		crdbOp = PatchHelmValues(map[string]string{
-			"cockroachdb.clusterDomain":               CustomDomains[index],
+		crdbOp = r.CockroachDBHelmValues(index, map[string]string{
 			"cockroachdb.tls.enabled":                 "true",
 			"cockroachdb.tls.selfSigner.enabled":      "false",
 			"cockroachdb.tls.certManager.enabled":     "true",
@@ -164,8 +168,7 @@ func (r *Region) InstallCharts(t *testing.T, cluster string, index int) {
 			"cockroachdb.tls.certManager.caConfigMap": testutil.CAConfigMapName,
 		})
 	} else {
-		crdbOp = PatchHelmValues(map[string]string{
-			"cockroachdb.clusterDomain":             CustomDomains[index],
+		crdbOp = r.CockroachDBHelmValues(index, map[string]string{
 			"cockroachdb.tls.enabled":               "true",
 			"cockroachdb.tls.selfSigner.caProvided": "true",
 			"cockroachdb.tls.selfSigner.caSecret":   customCASecret,
@@ -175,14 +178,16 @@ func (r *Region) InstallCharts(t *testing.T, cluster string, index int) {
 	// next restart, so the inter-node pause can be kept short.
 	crdbOp["cockroachdb.crdbCluster.rollingRestartDelay"] = "10s"
 
+	jsonValues := map[string]string{
+		"cockroachdb.crdbCluster.regions": MustMarshalJSON(r.OperatorRegions(index, r.NodeCount)),
+	}
+
 	// Helm install cockroach CR with operator region config.
 	crdbOptions := &helm.Options{
 		KubectlOptions: kubectlOptions,
 		SetValues:      crdbOp,
-		SetJsonValues: map[string]string{
-			"cockroachdb.crdbCluster.regions": MustMarshalJSON(r.OperatorRegions(index, r.NodeCount)),
-		},
-		ExtraArgs: helmExtraArgs,
+		SetJsonValues:  jsonValues,
+		ExtraArgs:      helmExtraArgs,
 	}
 
 	helm.Install(t, crdbOptions, helmChartPath, ReleaseName)
@@ -321,7 +326,7 @@ func (r *Region) ValidateMultiRegionSetup(t *testing.T) {
 		// Verify regions output
 		for _, clusterRegion := range r.RegionCodes {
 			// For multi-region validation, check for cloud provider prefixed region names
-			expectedRegion := fmt.Sprintf("%s-%s", r.Provider, clusterRegion)
+			expectedRegion := fmt.Sprintf("%s-%s", r.chartCloudProvider(), clusterRegion)
 			require.Contains(t, stdout, expectedRegion, "Expected region %s to be present in cluster output", expectedRegion)
 		}
 
@@ -361,7 +366,7 @@ func (r *Region) ValidateMultiRegionSetup(t *testing.T) {
 
 		// Verify node count per region matches desired nodes.
 		for _, region := range r.RegionCodes {
-			region = fmt.Sprintf("%s-%s", r.Provider, region)
+			region = fmt.Sprintf("%s-%s", r.chartCloudProvider(), region)
 			require.Equal(t, r.NodeCount, nodesPerRegion[region],
 				"Region %s has %d nodes, expected %d",
 				region, nodesPerRegion[region], r.NodeCount)
@@ -475,12 +480,14 @@ func (r *Region) CleanupResources(t *testing.T) {
 	for cluster, namespace := range r.Namespace {
 		kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, namespace)
 		certManagerK8sOptions := k8s.NewKubectlOptions(cluster, kubeConfig, testutil.CertManagerNamespace)
+		clusterOptions := k8s.NewKubectlOptions(cluster, kubeConfig, "")
 
+		deleteFlags := r.helmDeleteArgs(
+			"--wait",
+			"--debug",
+		)
 		extraArgs := map[string][]string{
-			"delete": {
-				"--wait",
-				"--debug",
-			},
+			"delete": deleteFlags,
 		}
 		helmOptions := &helm.Options{
 			KubectlOptions: kubectlOptions,
@@ -492,6 +499,7 @@ func (r *Region) CleanupResources(t *testing.T) {
 		if err := helm.DeleteE(t, helmOptions, operatorReleaseName, true); err != nil {
 			t.Logf("Warning: helm delete %s failed (may not exist): %v", operatorReleaseName, err)
 		}
+		r.cleanupNamespace(t, clusterOptions, namespace)
 
 		if r.IsCertManager {
 			testutil.DeleteBundle(t, kubectlOptions)
@@ -535,13 +543,13 @@ func (r *Region) createOperatorRegions(
 	buildRegion := func(i int) map[string]interface{} {
 		region := map[string]interface{}{
 			"code":          r.RegionCodes[i],
-			"cloudProvider": r.Provider,
+			"cloudProvider": r.chartCloudProvider(),
 			"nodes":         nodes,
 			"namespace":     r.Namespace[r.Clusters[i]],
 		}
 		if len(r.Clusters) > i && r.Clusters[i] != "" {
-			if domain, ok := customDomains[i]; ok {
-				region["domain"] = domain
+			if _, ok := customDomains[i]; ok {
+				region["domain"] = r.clusterDomain(i)
 			}
 		}
 		return region
@@ -922,12 +930,12 @@ func (r *Region) BaseRegionConfig(cluster string, index int) map[string]interfac
 	}
 	region := map[string]interface{}{
 		"code":          code,
-		"cloudProvider": r.Provider,
+		"cloudProvider": r.chartCloudProvider(),
 		"nodes":         r.NodeCount,
 		"namespace":     r.Namespace[cluster],
 	}
-	if domain, ok := CustomDomains[index]; ok {
-		region["domain"] = domain
+	if _, ok := CustomDomains[index]; ok {
+		region["domain"] = r.clusterDomain(index)
 	}
 	return region
 }
@@ -1006,7 +1014,7 @@ func (r *Region) InstallChartsWithAdvancedConfig(
 	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
 
 	// Create a namespace.
-	k8s.CreateNamespace(t, kubectlOptions, r.Namespace[cluster])
+	r.prepareNamespace(t, kubectlOptions, r.Namespace[cluster])
 
 	// create CA Secret.
 	err := k8s.RunKubectlE(t, kubectlOptions, "create", "secret", "generic", customCASecret, "--from-file=ca.crt",
@@ -1044,8 +1052,7 @@ func (r *Region) InstallChartsWithAdvancedConfig(
 	}
 
 	// Build helm values
-	helmValues := PatchHelmValues(map[string]string{
-		"cockroachdb.clusterDomain":             CustomDomains[index],
+	helmValues := r.CockroachDBHelmValues(index, map[string]string{
 		"cockroachdb.tls.selfSigner.caProvided": "true",
 		"cockroachdb.tls.selfSigner.caSecret":   customCASecret,
 	})
@@ -1499,7 +1506,7 @@ func (r *Region) ValidatePCR(t *testing.T, cfg *AdvancedValidationConfig) {
 	t.Log("Generating connection URI for primary cluster using cockroach convert-url")
 	primaryClusterDomain := validationConfig.PCR.PrimaryClusterDomain
 	if primaryClusterDomain == "" {
-		primaryClusterDomain = CustomDomains[0]
+		primaryClusterDomain = r.clusterDomain(0)
 	}
 	primaryHost := fmt.Sprintf("cockroachdb-public.%s.svc.%s:26257", primaryNamespace, primaryClusterDomain)
 	primaryConnString := fmt.Sprintf("postgresql://%s:%s@%s?options=-ccluster%%3Dsystem", pcrSourceUser, pcrSourcePassword, primaryHost)

--- a/tests/e2e/operator/singleRegion/cockroachdb_single_region_advanced_features_test.go
+++ b/tests/e2e/operator/singleRegion/cockroachdb_single_region_advanced_features_test.go
@@ -78,8 +78,7 @@ func (r *singleRegion) TestWALFailoverDisable(t *testing.T) {
 	helmChartPath, _ := operator.HelmChartPaths()
 
 	// Upgrade with WAL failover disabled
-	disableConfig := operator.PatchHelmValues(map[string]string{
-		"cockroachdb.clusterDomain":                      operator.CustomDomains[0],
+	disableConfig := r.CockroachDBHelmValues(0, map[string]string{
 		"cockroachdb.tls.selfSigner.caProvided":          "true",
 		"cockroachdb.tls.selfSigner.caSecret":            "cockroachdb-ca-secret",
 		"cockroachdb.crdbCluster.walFailoverSpec.status": "disable",

--- a/tests/testutil/cert-manager.go
+++ b/tests/testutil/cert-manager.go
@@ -68,8 +68,7 @@ func InstallTrustManager(t *testing.T, kubectlOptions *k8s.KubectlOptions, trust
 
 	// Wait for Bundle CRD to be installed (CRDs are cluster-scoped, so use default namespace)
 	t.Log("Waiting for Bundle CRD to be available...")
-	defaultKubectlOptions := k8s.NewKubectlOptions(
-		kubectlOptions.ContextName, kubectlOptions.ConfigPath, "default")
+	defaultKubectlOptions := k8s.NewKubectlOptions(kubectlOptions.ContextName, kubectlOptions.ConfigPath, "default")
 	maxRetries := 60
 	crdFound := false
 	for i := 0; i < maxRetries; i++ {
@@ -233,6 +232,12 @@ spec:
 
 // DeleteBundle deletes the bundle.
 func DeleteBundle(t *testing.T, kubectlOptions *k8s.KubectlOptions) {
+	if _, err := os.Stat(bundleYaml); os.IsNotExist(err) {
+		return
+	} else {
+		require.NoError(t, err)
+	}
+
 	k8s.RunKubectl(t, kubectlOptions, "delete", "-f", bundleYaml)
 	_ = os.Remove(bundleYaml)
 }


### PR DESCRIPTION
## Summary
- Add OpenShift as an advanced-features E2E provider for both single-region and multi-region when the existing advanced-features workflow is run.
- Add OpenShift installer-backed test infra, including install config generation, kubeconfig merge, OpenShift SCC setup, storage class and Helm value patching, cluster domain handling, and teardown.
- Add multi-region OpenShift setup for Submariner, GCP peer networking, DNS forwarding, debug snapshots, and CI log upload.

## Trigger behavior
This keeps `advanced-features-tests` trigger behavior unchanged from `master`: weekly schedule plus `workflow_dispatch` only. This PR does not add `push` or `pull_request` triggers, so OpenShift runs only when the existing advanced workflow is scheduled or manually dispatched.

## Why this is not just a matrix extension
OpenShift is not a drop-in variant of the existing providers. Extending the matrix starts the jobs, but the shared tests also need provider-specific runtime behavior: cloud provider naming, cluster domains, Helm values, namespace setup, OpenShift `anyuid` SCC binding, Helm uninstall flags, kubeconfig handling, and cleanup.

The provider-runtime interface keeps those differences explicit and out of individual test bodies. That lets the same single-region and multi-region test flows run across k3d, kind, GCP, and OpenShift without spreading provider conditionals through the tests.

The test code changes are limited to the places where the existing shared flow needed provider-specific behavior. The larger OpenShift implementation lives behind the infra/provider boundary rather than extending the matrix with scripts that the Go tests cannot observe or clean up correctly.

## Operational debugging
Where to look:
- GitHub Actions job logs for the failing OpenShift job.
- GitHub artifacts for the captured `test_output.log` and JSON test output.
- GCS debug snapshots under `gs://<GCP_PROJECT_ID>-openshift-ci-debug/<run_id>/<attempt>/<single-region|multi-region>/`.

How to look:
- `gh run view <run_id> --repo cockroachdb/helm-charts --log` for CI logs.
- `gcloud storage ls gs://cockroach-helm-testing-openshift-ci-debug/<run_id>/<attempt>/<mode>/` for uploaded logs and snapshots.
- `gcloud storage cat .../test_output.log` for the Go test stream.
- GCS uploads include `test_output.log`, `test_output.json`, `.openshift_install.log`, `metadata.json`, before/after GCP snapshots, and periodic GCP resource snapshots.

Retrieval notes:
- GitHub logs are the easiest path and are available for all workflow failures.
- GCS debug uploads are best-effort and require project/storage access. If setup fails before the OpenShift test step starts, rely on GitHub logs and artifacts.
- For intentionally preserved clusters, set `OPENSHIFT_SKIP_TEARDOWN=true`; normal scheduled/manual runs leave this false.

Retention:
- CI no longer creates the debug bucket or mutates bucket lifecycle policy. The debug bucket and 30-day retention lifecycle are tracked in cockroachlabs/crl-infrastructure#6230.

## Teardown
Normal scheduled/manual CI runs use `OPENSHIFT_SKIP_TEARDOWN=false`. The Go test cleanup tears down OpenShift clusters and custom multi-region resources. The workflow fallback cleanup now deletes Submariner firewall rules for every known OpenShift infra ID, even when a partial multi-cluster setup only produced one metadata file, then removes peer firewalls and VPC peerings when both sides exist.

## Validation
- `bash -n build/openshift-ci-debug.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/advanced-features-tests.yaml"); puts "yaml ok"'`
- `go test ./tests/e2e/operator/infra ./tests/e2e/operator/multiRegion -run '^$'`
- `git diff --check`

CI evidence:
- OpenShift-only dry run passed: https://github.com/cockroachdb/helm-charts/actions/runs/31000700366
- Temporary full-matrix branch dry run had both OpenShift jobs pass with teardown enabled; the overall run failed in non-OpenShift matrix jobs: https://github.com/cockroachdb/helm-charts/actions/runs/31070731699
- The GCP multi-region failure in that dry run happened inside `TestWALFailoverMultiRegion` after GKE infra came up, and its cleanup completed. The GCP single-region job did not publish retrievable logs/artifacts, so its exact failure point is unavailable from GitHub. These were not OpenShift-provider job failures.
- Temporary branch push runs used while validating this PR were cancelled after restoring trigger behavior.

Pre-PR review follow-up:
- Removed CI-side GCS lifecycle mutation; bucket/lifecycle belongs in Terraform.
- Hardened fallback cleanup for partial multi-cluster setup failures.
- Kept GCS observability explicitly best-effort in the operational notes.
