### PR TITLE
ci: disable Slack test notifications

### DIFF
--- a/.github/workflows/advanced-features-tests.yaml
+++ b/.github/workflows/advanced-features-tests.yaml
@@ -165,7 +165,9 @@ jobs:
             rm -rf "${install_dir}"
           done
       - name: Slack notification
-        if: ${{ always() && github.ref_name == 'master' }}
+        # Temporarily disabled because notification failures can mask test results.
+        # Re-enable or replace once CC-36671 is resolved.
+        if: ${{ false }}
         uses: ./.github/actions/slack-test-notification
         with:
           test-name: "Advanced features single-region"
@@ -334,7 +336,9 @@ jobs:
             rm -rf "${install_dir}"
           done
       - name: Slack notification
-        if: ${{ always() && github.ref_name == 'master' }}
+        # Temporarily disabled because notification failures can mask test results.
+        # Re-enable or replace once CC-36671 is resolved.
+        if: ${{ false }}
         uses: ./.github/actions/slack-test-notification
         with:
           test-name: "Advanced features multi-region"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -53,7 +53,9 @@ jobs:
             test_output.log
             test_output.json
       - name: Slack notification (multi-region)
-        if: ${{ always() && github.ref_name == 'master' }}
+        # Temporarily disabled because notification failures can mask test results.
+        # Re-enable or replace once CC-36671 is resolved.
+        if: ${{ false }}
         uses: ./.github/actions/slack-test-notification
         with:
           test-name: "Multi-region e2e"
@@ -105,7 +107,9 @@ jobs:
             test_output.log
             test_output.json
       - name: Slack notification (single-region)
-        if: ${{ always() && github.ref_name == 'master' }}
+        # Temporarily disabled because notification failures can mask test results.
+        # Re-enable or replace once CC-36671 is resolved.
+        if: ${{ false }}
         uses: ./.github/actions/slack-test-notification
         with:
           test-name: "Single-region e2e"


### PR DESCRIPTION
## Summary
- Temporarily disable Slack notification steps in integration and advanced feature workflows.
- Leave inline CC-36671 comments at each disabled step so the notification path can be re-enabled or replaced later.

## Rationale
The Slack notification action can fail after tests pass, which masks the real test result and makes failures harder to debug. Disabling these steps keeps CI focused on the test outcomes until https://cockroachlabs.atlassian.net/browse/CC-36671 is resolved.

## Testing
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "parsed #{f}" }' .github/workflows/integration-tests.yaml .github/workflows/advanced-features-tests.yaml`\n- `actionlint` was not installed locally.