### PR TITLE
ci: add Azure E2E infrastructure

### DIFF
--- a/.github/workflows/advanced-features-tests.yaml
+++ b/.github/workflows/advanced-features-tests.yaml
@@ -16,10 +16,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        provider: [k3d, kind, gcp, openshift]
+        provider: [k3d, kind, gcp, openshift, azure]
     timeout-minutes: 300
     concurrency:
-      group: ${{ matrix.provider == 'openshift' && 'advanced-features-openshift' || format('advanced-features-{0}-{1}-{2}', github.run_id, github.job, matrix.provider) }}
+      group: ${{ matrix.provider == 'azure' && format('helm-charts-azure-e2e-{0}-advanced-single-region', github.ref_name) || matrix.provider == 'openshift' && 'advanced-features-openshift' || format('advanced-features-{0}-{1}-{2}', github.run_id, github.job, matrix.provider) }}
       cancel-in-progress: false
     permissions:
       contents: read
@@ -33,6 +33,7 @@ jobs:
         with:
           go-version: 1.26
       - name: Authenticate to Google Cloud
+        if: ${{ matrix.provider == 'gcp' || matrix.provider == 'openshift' }}
         uses: 'google-github-actions/auth@v2'
         id: auth
         with:
@@ -43,10 +44,43 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       - name: Set up gcloud CLI
+        if: ${{ matrix.provider == 'gcp' || matrix.provider == 'openshift' }}
         uses: google-github-actions/setup-gcloud@v2
       - name: Install gke-gcloud-auth-plugin
+        if: ${{ matrix.provider == 'gcp' || matrix.provider == 'openshift' }}
         run: |
           gcloud components install gke-gcloud-auth-plugin
+      - name: Authenticate to Azure
+        if: ${{ matrix.provider == 'azure' }}
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Verify Azure CLI
+        if: ${{ matrix.provider == 'azure' }}
+        shell: bash
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        run: |
+          set -euo pipefail
+          az version
+          az account show --subscription "${AZURE_SUBSCRIPTION_ID}" --output table
+      - name: Clean up stale Azure resource groups
+        if: ${{ matrix.provider == 'azure' }}
+        shell: bash
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_RESOURCE_PREFIX: hc-e2e
+          AZURE_TICKET: CC-35912
+          AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
+        run: |
+          set -euo pipefail
+          ./build/azure-ci-debug.sh snapshot before-stale-cleanup
+          stale_status=0
+          ./build/azure-ci-debug.sh cleanup-old-resource-groups || stale_status="$?"
+          ./build/azure-ci-debug.sh snapshot after-stale-cleanup
+          exit "${stale_status}"
       - name: Install OpenShift tools
         if: ${{ matrix.provider == 'openshift' }}
         shell: bash
@@ -82,7 +116,7 @@ jobs:
             echo "EOF"
           } >> "${GITHUB_ENV}"
       - name: Run tests (advanced features - single region)
-        if: ${{ matrix.provider != 'openshift' }}
+        if: ${{ matrix.provider != 'openshift' && matrix.provider != 'azure' }}
         env:
           PROVIDER: ${{ matrix.provider }}
           TEST_ADVANCED_FEATURES: true
@@ -90,6 +124,35 @@ jobs:
         run: |
           set -euo pipefail
           make test/nightly-e2e/advanced/single-region | tee test_output.log
+      - name: Run tests (advanced features - single region - Azure)
+        if: ${{ matrix.provider == 'azure' }}
+        shell: bash
+        env:
+          PROVIDER: ${{ matrix.provider }}
+          TEST_ADVANCED_FEATURES: true
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_RESOURCE_PREFIX: hc-e2e
+          AZURE_TICKET: CC-35912
+          AZURE_RESOURCE_GROUPS_FILE: ${{ runner.temp }}/azure-resource-groups.txt
+          AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
+          E2E_ADVANCED_SINGLE_REGION_TEST_TIMEOUT: 120m
+        run: |
+          set -euo pipefail
+
+          ./build/azure-ci-debug.sh snapshot before-single-region
+          ./build/azure-ci-debug.sh watch 120 &
+          debug_pid="$!"
+          finish_debug() {
+            status="$?"
+            kill "${debug_pid}" 2>/dev/null || true
+            wait "${debug_pid}" 2>/dev/null || true
+            ./build/azure-ci-debug.sh snapshot after-single-region || true
+            exit "${status}"
+          }
+          trap finish_debug EXIT
+
+          unset AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_REUSE_CONTEXTS AZURE_RESOURCE_GROUP
+          stdbuf -oL -eL make test/nightly-e2e/advanced/single-region 2>&1 | tee test_output.log
       - name: Run tests (advanced features - single region - OpenShift)
         if: ${{ matrix.provider == 'openshift' }}
         env:
@@ -122,6 +185,22 @@ jobs:
 
           unset OPENSHIFT_REUSE_CONTEXTS OPENSHIFT_REUSE_KUBECONFIG OPENSHIFT_REUSE_KUBECONFIGS
           stdbuf -oL -eL make test/nightly-e2e/advanced/single-region 2>&1 | tee test_output.log
+      - name: Clean up Azure resource groups
+        if: ${{ always() && matrix.provider == 'azure' }}
+        shell: bash
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_TICKET: CC-35912
+          AZURE_RESOURCE_PREFIX: hc-e2e
+          AZURE_RESOURCE_GROUPS_FILE: ${{ runner.temp }}/azure-resource-groups.txt
+          AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
+        run: |
+          set -euo pipefail
+          ./build/azure-ci-debug.sh snapshot cleanup-before-single-region || true
+          cleanup_status=0
+          ./build/azure-ci-debug.sh cleanup-resource-groups || cleanup_status="$?"
+          ./build/azure-ci-debug.sh snapshot cleanup-after-single-region || true
+          exit "${cleanup_status}"
       - name: Archive test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -132,6 +211,8 @@ jobs:
           path: |
             test_output.log
             test_output.json
+            ${{ runner.temp }}/azure-debug/*.log
+            ${{ runner.temp }}/azure-resource-groups.txt
             ${{ runner.temp }}/openshift-debug/*.log
             ${{ runner.temp }}/helm-charts-ocp-*/.openshift_install.log
             ${{ runner.temp }}/helm-charts-ocp-*/metadata.json
@@ -179,10 +260,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        provider: [k3d, kind, gcp, openshift]
+        provider: [k3d, kind, gcp, openshift, azure]
     timeout-minutes: 420
     concurrency:
-      group: ${{ matrix.provider == 'openshift' && 'advanced-features-openshift' || format('advanced-features-{0}-{1}-{2}', github.run_id, github.job, matrix.provider) }}
+      group: ${{ matrix.provider == 'azure' && format('helm-charts-azure-e2e-{0}-advanced-multi-region', github.ref_name) || matrix.provider == 'openshift' && 'advanced-features-openshift' || format('advanced-features-{0}-{1}-{2}', github.run_id, github.job, matrix.provider) }}
       cancel-in-progress: false
     permissions:
       contents: read
@@ -196,6 +277,7 @@ jobs:
         with:
           go-version: 1.26
       - name: Authenticate to Google Cloud
+        if: ${{ matrix.provider == 'gcp' || matrix.provider == 'openshift' }}
         uses: 'google-github-actions/auth@v2'
         id: auth
         with:
@@ -206,10 +288,43 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       - name: Set up gcloud CLI
+        if: ${{ matrix.provider == 'gcp' || matrix.provider == 'openshift' }}
         uses: google-github-actions/setup-gcloud@v2
       - name: Install gke-gcloud-auth-plugin
+        if: ${{ matrix.provider == 'gcp' || matrix.provider == 'openshift' }}
         run: |
           gcloud components install gke-gcloud-auth-plugin
+      - name: Authenticate to Azure
+        if: ${{ matrix.provider == 'azure' }}
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Verify Azure CLI
+        if: ${{ matrix.provider == 'azure' }}
+        shell: bash
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        run: |
+          set -euo pipefail
+          az version
+          az account show --subscription "${AZURE_SUBSCRIPTION_ID}" --output table
+      - name: Clean up stale Azure resource groups
+        if: ${{ matrix.provider == 'azure' }}
+        shell: bash
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_RESOURCE_PREFIX: hc-e2e
+          AZURE_TICKET: CC-35912
+          AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
+        run: |
+          set -euo pipefail
+          ./build/azure-ci-debug.sh snapshot before-stale-cleanup
+          stale_status=0
+          ./build/azure-ci-debug.sh cleanup-old-resource-groups || stale_status="$?"
+          ./build/azure-ci-debug.sh snapshot after-stale-cleanup
+          exit "${stale_status}"
       - name: Install OpenShift tools
         if: ${{ matrix.provider == 'openshift' }}
         shell: bash
@@ -248,7 +363,7 @@ jobs:
             echo "EOF"
           } >> "${GITHUB_ENV}"
       - name: Run tests (advanced features - multi region)
-        if: ${{ matrix.provider != 'openshift' }}
+        if: ${{ matrix.provider != 'openshift' && matrix.provider != 'azure' }}
         env:
           PROVIDER: ${{ matrix.provider }}
           TEST_ADVANCED_FEATURES: true
@@ -256,6 +371,35 @@ jobs:
         run: |
           set -euo pipefail
           make test/nightly-e2e/advanced/multi-region | tee test_output.log
+      - name: Run tests (advanced features - multi region - Azure)
+        if: ${{ matrix.provider == 'azure' }}
+        shell: bash
+        env:
+          PROVIDER: ${{ matrix.provider }}
+          TEST_ADVANCED_FEATURES: true
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_RESOURCE_PREFIX: hc-e2e
+          AZURE_TICKET: CC-35912
+          AZURE_RESOURCE_GROUPS_FILE: ${{ runner.temp }}/azure-resource-groups.txt
+          AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
+          E2E_ADVANCED_MULTI_REGION_TEST_TIMEOUT: 120m
+        run: |
+          set -euo pipefail
+
+          ./build/azure-ci-debug.sh snapshot before-multi-region
+          ./build/azure-ci-debug.sh watch 120 &
+          debug_pid="$!"
+          finish_debug() {
+            status="$?"
+            kill "${debug_pid}" 2>/dev/null || true
+            wait "${debug_pid}" 2>/dev/null || true
+            ./build/azure-ci-debug.sh snapshot after-multi-region || true
+            exit "${status}"
+          }
+          trap finish_debug EXIT
+
+          unset AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_REUSE_CONTEXTS AZURE_RESOURCE_GROUP
+          stdbuf -oL -eL make test/nightly-e2e/advanced/multi-region 2>&1 | tee test_output.log
       - name: Run tests (advanced features - multi region - OpenShift)
         if: ${{ matrix.provider == 'openshift' }}
         env:
@@ -293,6 +437,22 @@ jobs:
 
           unset OPENSHIFT_REUSE_CONTEXTS OPENSHIFT_REUSE_KUBECONFIG OPENSHIFT_REUSE_KUBECONFIGS
           stdbuf -oL -eL make test/nightly-e2e/advanced/multi-region > >(tee test_output.log) 2>&1
+      - name: Clean up Azure resource groups
+        if: ${{ always() && matrix.provider == 'azure' }}
+        shell: bash
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_TICKET: CC-35912
+          AZURE_RESOURCE_PREFIX: hc-e2e
+          AZURE_RESOURCE_GROUPS_FILE: ${{ runner.temp }}/azure-resource-groups.txt
+          AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
+        run: |
+          set -euo pipefail
+          ./build/azure-ci-debug.sh snapshot cleanup-before-multi-region || true
+          cleanup_status=0
+          ./build/azure-ci-debug.sh cleanup-resource-groups || cleanup_status="$?"
+          ./build/azure-ci-debug.sh snapshot cleanup-after-multi-region || true
+          exit "${cleanup_status}"
       - name: Archive test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -303,6 +463,8 @@ jobs:
           path: |
             test_output.log
             test_output.json
+            ${{ runner.temp }}/azure-debug/*.log
+            ${{ runner.temp }}/azure-resource-groups.txt
             ${{ runner.temp }}/openshift-debug/*.log
             ${{ runner.temp }}/helm-charts-ocp-*/.openshift_install.log
             ${{ runner.temp }}/helm-charts-ocp-*/metadata.json

--- a/.github/workflows/advanced-features-tests.yaml
+++ b/.github/workflows/advanced-features-tests.yaml
@@ -72,7 +72,6 @@ jobs:
         env:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_RESOURCE_PREFIX: hc-e2e
-          AZURE_TICKET: CC-35912
           AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
         run: |
           set -euo pipefail
@@ -132,7 +131,6 @@ jobs:
           TEST_ADVANCED_FEATURES: true
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_RESOURCE_PREFIX: hc-e2e
-          AZURE_TICKET: CC-35912
           AZURE_RESOURCE_GROUPS_FILE: ${{ runner.temp }}/azure-resource-groups.txt
           AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
           E2E_ADVANCED_SINGLE_REGION_TEST_TIMEOUT: 120m
@@ -190,7 +188,6 @@ jobs:
         shell: bash
         env:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_TICKET: CC-35912
           AZURE_RESOURCE_PREFIX: hc-e2e
           AZURE_RESOURCE_GROUPS_FILE: ${{ runner.temp }}/azure-resource-groups.txt
           AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
@@ -316,7 +313,6 @@ jobs:
         env:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_RESOURCE_PREFIX: hc-e2e
-          AZURE_TICKET: CC-35912
           AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
         run: |
           set -euo pipefail
@@ -379,7 +375,6 @@ jobs:
           TEST_ADVANCED_FEATURES: true
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_RESOURCE_PREFIX: hc-e2e
-          AZURE_TICKET: CC-35912
           AZURE_RESOURCE_GROUPS_FILE: ${{ runner.temp }}/azure-resource-groups.txt
           AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
           E2E_ADVANCED_MULTI_REGION_TEST_TIMEOUT: 120m
@@ -442,7 +437,6 @@ jobs:
         shell: bash
         env:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_TICKET: CC-35912
           AZURE_RESOURCE_PREFIX: hc-e2e
           AZURE_RESOURCE_GROUPS_FILE: ${{ runner.temp }}/azure-resource-groups.txt
           AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -12,8 +12,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        provider: [kind, gcp]
-    timeout-minutes: 90
+        provider: [kind, gcp, azure]
+    timeout-minutes: ${{ matrix.provider == 'azure' && 180 || 90 }}
+    concurrency:
+      group: ${{ matrix.provider == 'azure' && format('helm-charts-azure-e2e-{0}-integration-multi-region', github.ref_name) || format('integration-tests-{0}-{1}-{2}', github.run_id, github.job, matrix.provider) }}
+      cancel-in-progress: false
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -26,6 +29,7 @@ jobs:
         with:
           go-version: 1.26
       - name: Authenticate to Google Cloud
+        if: ${{ matrix.provider == 'gcp' }}
         uses: 'google-github-actions/auth@v2'
         id: auth
         with:
@@ -33,17 +37,95 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       - name: Set up gcloud CLI
+        if: ${{ matrix.provider == 'gcp' }}
         uses: google-github-actions/setup-gcloud@v2
       - name: Install gke-gcloud-auth-plugin
+        if: ${{ matrix.provider == 'gcp' }}
         run: |
           gcloud components install gke-gcloud-auth-plugin
+      - name: Authenticate to Azure
+        if: ${{ matrix.provider == 'azure' }}
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Verify Azure CLI
+        if: ${{ matrix.provider == 'azure' }}
+        shell: bash
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        run: |
+          set -euo pipefail
+          az version
+          az account show --subscription "${AZURE_SUBSCRIPTION_ID}" --output table
+      - name: Clean up stale Azure resource groups
+        if: ${{ matrix.provider == 'azure' }}
+        shell: bash
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_RESOURCE_PREFIX: hc-e2e
+          AZURE_TICKET: CC-35912
+          AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
+        run: |
+          set -euo pipefail
+          ./build/azure-ci-debug.sh snapshot before-stale-cleanup
+          stale_status=0
+          ./build/azure-ci-debug.sh cleanup-old-resource-groups || stale_status="$?"
+          ./build/azure-ci-debug.sh snapshot after-stale-cleanup
+          exit "${stale_status}"
       - name: Run tests (multi-region)
+        if: ${{ matrix.provider != 'azure' }}
         env:
           PROVIDER: ${{ matrix.provider }}
           USE_GKE_GCLOUD_AUTH_PLUGIN: True
         run: |
           set -euo pipefail
           make test/e2e/multi-region | tee test_output.log
+      - name: Run tests (multi-region - Azure)
+        if: ${{ matrix.provider == 'azure' }}
+        shell: bash
+        env:
+          PROVIDER: ${{ matrix.provider }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_RESOURCE_PREFIX: hc-e2e
+          AZURE_TICKET: CC-35912
+          AZURE_RESOURCE_GROUPS_FILE: ${{ runner.temp }}/azure-resource-groups.txt
+          AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
+          E2E_MULTI_REGION_TEST_TIMEOUT: 150m
+        run: |
+          set -euo pipefail
+
+          ./build/azure-ci-debug.sh snapshot before-multi-region
+          ./build/azure-ci-debug.sh watch 120 &
+          debug_pid="$!"
+          finish_debug() {
+            status="$?"
+            kill "${debug_pid}" 2>/dev/null || true
+            wait "${debug_pid}" 2>/dev/null || true
+            ./build/azure-ci-debug.sh snapshot after-multi-region || true
+            exit "${status}"
+          }
+          trap finish_debug EXIT
+
+          unset AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_REUSE_CONTEXTS AZURE_RESOURCE_GROUP
+          stdbuf -oL -eL make test/e2e/multi-region 2>&1 | tee test_output.log
+      - name: Clean up Azure resource groups
+        if: ${{ always() && matrix.provider == 'azure' }}
+        shell: bash
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_TICKET: CC-35912
+          AZURE_RESOURCE_PREFIX: hc-e2e
+          AZURE_RESOURCE_GROUPS_FILE: ${{ runner.temp }}/azure-resource-groups.txt
+          AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
+        run: |
+          set -euo pipefail
+          ./build/azure-ci-debug.sh snapshot cleanup-before-multi-region || true
+          cleanup_status=0
+          ./build/azure-ci-debug.sh cleanup-resource-groups || cleanup_status="$?"
+          ./build/azure-ci-debug.sh snapshot cleanup-after-multi-region || true
+          exit "${cleanup_status}"
       - name: Archive test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -52,6 +134,8 @@ jobs:
           path: |
             test_output.log
             test_output.json
+            ${{ runner.temp }}/azure-debug/*.log
+            ${{ runner.temp }}/azure-resource-groups.txt
       - name: Slack notification (multi-region)
         # Temporarily disabled because notification failures can mask test results.
         # Re-enable or replace once CC-36671 is resolved.
@@ -65,8 +149,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        provider: [kind, gcp]
-    timeout-minutes: 90
+        provider: [kind, gcp, azure]
+    timeout-minutes: ${{ matrix.provider == 'azure' && 150 || 90 }}
+    concurrency:
+      group: ${{ matrix.provider == 'azure' && format('helm-charts-azure-e2e-{0}-integration-single-region', github.ref_name) || format('integration-tests-{0}-{1}-{2}', github.run_id, github.job, matrix.provider) }}
+      cancel-in-progress: false
     permissions:
       contents: read
       id-token: write
@@ -79,6 +166,7 @@ jobs:
         with:
           go-version: 1.26
       - name: Authenticate to Google Cloud
+        if: ${{ matrix.provider == 'gcp' }}
         uses: 'google-github-actions/auth@v2'
         id: auth
         with:
@@ -87,17 +175,95 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       - name: Set up gcloud CLI
+        if: ${{ matrix.provider == 'gcp' }}
         uses: google-github-actions/setup-gcloud@v2
       - name: Install gke-gcloud-auth-plugin
+        if: ${{ matrix.provider == 'gcp' }}
         run: |
           gcloud components install gke-gcloud-auth-plugin
+      - name: Authenticate to Azure
+        if: ${{ matrix.provider == 'azure' }}
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Verify Azure CLI
+        if: ${{ matrix.provider == 'azure' }}
+        shell: bash
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        run: |
+          set -euo pipefail
+          az version
+          az account show --subscription "${AZURE_SUBSCRIPTION_ID}" --output table
+      - name: Clean up stale Azure resource groups
+        if: ${{ matrix.provider == 'azure' }}
+        shell: bash
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_RESOURCE_PREFIX: hc-e2e
+          AZURE_TICKET: CC-35912
+          AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
+        run: |
+          set -euo pipefail
+          ./build/azure-ci-debug.sh snapshot before-stale-cleanup
+          stale_status=0
+          ./build/azure-ci-debug.sh cleanup-old-resource-groups || stale_status="$?"
+          ./build/azure-ci-debug.sh snapshot after-stale-cleanup
+          exit "${stale_status}"
       - name: Run tests (single-region)
+        if: ${{ matrix.provider != 'azure' }}
         env:
           PROVIDER: ${{ matrix.provider }}
           USE_GKE_GCLOUD_AUTH_PLUGIN: True
         run: |
           set -euo pipefail
           make test/e2e/single-region | tee test_output.log
+      - name: Run tests (single-region - Azure)
+        if: ${{ matrix.provider == 'azure' }}
+        shell: bash
+        env:
+          PROVIDER: ${{ matrix.provider }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_RESOURCE_PREFIX: hc-e2e
+          AZURE_TICKET: CC-35912
+          AZURE_RESOURCE_GROUPS_FILE: ${{ runner.temp }}/azure-resource-groups.txt
+          AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
+          E2E_SINGLE_REGION_TEST_TIMEOUT: 120m
+        run: |
+          set -euo pipefail
+
+          ./build/azure-ci-debug.sh snapshot before-single-region
+          ./build/azure-ci-debug.sh watch 120 &
+          debug_pid="$!"
+          finish_debug() {
+            status="$?"
+            kill "${debug_pid}" 2>/dev/null || true
+            wait "${debug_pid}" 2>/dev/null || true
+            ./build/azure-ci-debug.sh snapshot after-single-region || true
+            exit "${status}"
+          }
+          trap finish_debug EXIT
+
+          unset AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_REUSE_CONTEXTS AZURE_RESOURCE_GROUP
+          stdbuf -oL -eL make test/e2e/single-region 2>&1 | tee test_output.log
+      - name: Clean up Azure resource groups
+        if: ${{ always() && matrix.provider == 'azure' }}
+        shell: bash
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_TICKET: CC-35912
+          AZURE_RESOURCE_PREFIX: hc-e2e
+          AZURE_RESOURCE_GROUPS_FILE: ${{ runner.temp }}/azure-resource-groups.txt
+          AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
+        run: |
+          set -euo pipefail
+          ./build/azure-ci-debug.sh snapshot cleanup-before-single-region || true
+          cleanup_status=0
+          ./build/azure-ci-debug.sh cleanup-resource-groups || cleanup_status="$?"
+          ./build/azure-ci-debug.sh snapshot cleanup-after-single-region || true
+          exit "${cleanup_status}"
       - name: Archive test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -106,6 +272,8 @@ jobs:
           path: |
             test_output.log
             test_output.json
+            ${{ runner.temp }}/azure-debug/*.log
+            ${{ runner.temp }}/azure-resource-groups.txt
       - name: Slack notification (single-region)
         # Temporarily disabled because notification failures can mask test results.
         # Re-enable or replace once CC-36671 is resolved.

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -65,7 +65,6 @@ jobs:
         env:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_RESOURCE_PREFIX: hc-e2e
-          AZURE_TICKET: CC-35912
           AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
         run: |
           set -euo pipefail
@@ -89,7 +88,6 @@ jobs:
           PROVIDER: ${{ matrix.provider }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_RESOURCE_PREFIX: hc-e2e
-          AZURE_TICKET: CC-35912
           AZURE_RESOURCE_GROUPS_FILE: ${{ runner.temp }}/azure-resource-groups.txt
           AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
           E2E_MULTI_REGION_TEST_TIMEOUT: 150m
@@ -115,7 +113,6 @@ jobs:
         shell: bash
         env:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_TICKET: CC-35912
           AZURE_RESOURCE_PREFIX: hc-e2e
           AZURE_RESOURCE_GROUPS_FILE: ${{ runner.temp }}/azure-resource-groups.txt
           AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
@@ -203,7 +200,6 @@ jobs:
         env:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_RESOURCE_PREFIX: hc-e2e
-          AZURE_TICKET: CC-35912
           AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
         run: |
           set -euo pipefail
@@ -227,7 +223,6 @@ jobs:
           PROVIDER: ${{ matrix.provider }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_RESOURCE_PREFIX: hc-e2e
-          AZURE_TICKET: CC-35912
           AZURE_RESOURCE_GROUPS_FILE: ${{ runner.temp }}/azure-resource-groups.txt
           AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug
           E2E_SINGLE_REGION_TEST_TIMEOUT: 120m
@@ -253,7 +248,6 @@ jobs:
         shell: bash
         env:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          AZURE_TICKET: CC-35912
           AZURE_RESOURCE_PREFIX: hc-e2e
           AZURE_RESOURCE_GROUPS_FILE: ${{ runner.temp }}/azure-resource-groups.txt
           AZURE_DEBUG_DIR: ${{ runner.temp }}/azure-debug

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ LOCAL_REGISTRY ?= "localhost:5000"
 MULTI_REGION_NODE_SIZE ?= 3
 REGIONS ?= 3
 SUBCTL_VERSION ?= v0.24.0
+E2E_SINGLE_REGION_TEST_TIMEOUT ?= 90m
+E2E_MULTI_REGION_TEST_TIMEOUT ?= 90m
+E2E_ADVANCED_SINGLE_REGION_TEST_TIMEOUT ?= 90m
 E2E_ADVANCED_MULTI_REGION_TEST_TIMEOUT ?= 3h
 
 export BUNDLE_IMAGE ?= cockroach-operator-bundle
@@ -149,10 +152,10 @@ MULTI_REGION_PROVIDER_DEPS := bin/subctl
 endif
 
 test/e2e/multi-region: bin/cockroach bin/kubectl bin/helm  build/self-signer bin/k3d bin/kind $(MULTI_REGION_PROVIDER_DEPS)
-	@PATH="$(PWD)/bin:${PATH}" go test -timeout 90m -v -test.run TestOperatorInMultiRegion ./tests/e2e/operator/multiRegion/... || (echo "Multi region tests failed with exit code $$?" && exit 1)
+	@PATH="$(PWD)/bin:${PATH}" go test -timeout $(E2E_MULTI_REGION_TEST_TIMEOUT) -v -test.run TestOperatorInMultiRegion ./tests/e2e/operator/multiRegion/... || (echo "Multi region tests failed with exit code $$?" && exit 1)
 
 test/e2e/single-region: bin/cockroach bin/kubectl bin/helm build/self-signer bin/k3d bin/kind
-	@PATH="$(PWD)/bin:${PATH}" go test -timeout 90m -v -test.run TestOperatorInSingleRegion ./tests/e2e/operator/singleRegion/... || (echo "Single region tests failed with exit code $$?" && exit 1)
+	@PATH="$(PWD)/bin:${PATH}" go test -timeout $(E2E_SINGLE_REGION_TEST_TIMEOUT) -v -test.run TestOperatorInSingleRegion ./tests/e2e/operator/singleRegion/... || (echo "Single region tests failed with exit code $$?" && exit 1)
 
 test/e2e/chart-compatibility: bin/cockroach bin/kubectl bin/helm build/self-signer bin/k3d bin/kind
 	@PATH="$(PWD)/bin:${PATH}" go test -timeout 60m -v -test.run TestChartCompatibilityUpgrade ./tests/e2e/operator/compatibility/... || (echo "Chart compatibility tests failed with exit code $$?" && exit 1)
@@ -179,7 +182,7 @@ test/multi-cluster/down: bin/k3d
 	 ./tests/k3d/dev-multi-cluster.sh down
 
 test/nightly-e2e/advanced/single-region: bin/cockroach bin/kubectl bin/helm build/self-signer bin/kind
-	@PATH="$(PWD)/bin:${PATH}" PROVIDER=$${PROVIDER:-kind} TEST_ADVANCED_FEATURES=true go test -timeout 90m -v -test.run TestOperatorInSingleRegion ./tests/e2e/operator/singleRegion/... || (echo "Advanced single-region tests failed with exit code $$?" && exit 1)
+	@PATH="$(PWD)/bin:${PATH}" PROVIDER=$${PROVIDER:-kind} TEST_ADVANCED_FEATURES=true go test -timeout $(E2E_ADVANCED_SINGLE_REGION_TEST_TIMEOUT) -v -test.run TestOperatorInSingleRegion ./tests/e2e/operator/singleRegion/... || (echo "Advanced single-region tests failed with exit code $$?" && exit 1)
 
 test/nightly-e2e/advanced/multi-region: bin/cockroach bin/kubectl bin/helm build/self-signer bin/kind $(MULTI_REGION_PROVIDER_DEPS)
 	@PATH="$(PWD)/bin:${PATH}" PROVIDER=$${PROVIDER:-kind} TEST_ADVANCED_FEATURES=true go test -timeout $(E2E_ADVANCED_MULTI_REGION_TEST_TIMEOUT) -v -test.run TestOperatorInMultiRegion ./tests/e2e/operator/multiRegion/... || (echo "Advanced multi-region tests failed with exit code $$?" && exit 1)

--- a/build/azure-ci-debug.sh
+++ b/build/azure-ci-debug.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+subscription_id="${AZURE_SUBSCRIPTION_ID:-}"
+if [[ -z "${subscription_id}" ]]; then
+  echo "AZURE_SUBSCRIPTION_ID is required" >&2
+  exit 1
+fi
+
+debug_dir="${AZURE_DEBUG_DIR:-${RUNNER_TEMP:-/tmp}/azure-debug}"
+mkdir -p "${debug_dir}"
+
+resource_groups_file="${AZURE_RESOURCE_GROUPS_FILE:-${RUNNER_TEMP:-/tmp}/azure-resource-groups.txt}"
+resource_prefix="${AZURE_RESOURCE_PREFIX:-helm-charts-e2e}"
+ticket="${AZURE_TICKET:-}"
+current_run_id="${GITHUB_RUN_ID:-}"
+current_workflow="${GITHUB_WORKFLOW:-}"
+current_job="${GITHUB_JOB:-}"
+current_ref_name="${GITHUB_REF_NAME:-}"
+cleanup_wait_seconds="${AZURE_CLEANUP_WAIT_SECONDS:-3600}"
+
+timestamp() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+run_az() {
+  echo "+ az $*"
+  az "$@" || true
+}
+
+delete_resource_group_async() {
+  local rg="$1"
+  local output
+
+  echo "Deleting Azure resource group ${rg}"
+  if output="$(az group delete \
+    --name "${rg}" \
+    --subscription "${subscription_id}" \
+    --yes \
+    --no-wait \
+    --output none 2>&1)"; then
+    [[ -n "${output}" ]] && echo "${output}"
+    return 0
+  fi
+
+  if [[ "${output}" == *"ResourceGroupNotFound"* || "${output}" == *"could not be found"* || "${output}" == *"was not found"* ]]; then
+    echo "Azure resource group ${rg} is already deleted"
+    return 0
+  fi
+
+  echo "Failed to start async deletion for Azure resource group ${rg}: ${output}" >&2
+  return 1
+}
+
+resource_groups() {
+  [[ -f "${resource_groups_file}" ]] || return 0
+  sed '/^[[:space:]]*$/d' "${resource_groups_file}" | sort -u
+}
+
+old_resource_groups() {
+  if [[ -z "${ticket}" ]]; then
+    echo "AZURE_TICKET is required for old artifact cleanup" >&2
+    return 1
+  fi
+
+  local query="[?starts_with(name, '${resource_prefix}-rg-') && tags.ManagedBy=='helm-charts-e2e' && tags.Ticket=='${ticket}'"
+  if [[ -n "${current_run_id}" ]]; then
+    query+=" && tags.GitHubRunID!='${current_run_id}'"
+  fi
+  if [[ -n "${current_workflow}" ]]; then
+    query+=" && tags.GitHubWorkflow=='${current_workflow}'"
+  fi
+  if [[ -n "${current_job}" ]]; then
+    query+=" && tags.GitHubJob=='${current_job}'"
+  fi
+  if [[ -n "${current_ref_name}" ]]; then
+    query+=" && tags.GitHubRefName=='${current_ref_name}'"
+  fi
+  query+="].name"
+
+  az group list \
+    --subscription "${subscription_id}" \
+    --query "${query}" \
+    --output tsv
+}
+
+resource_group_exists() {
+  local rg="$1"
+  local exists
+  local stderr_file
+  stderr_file="$(mktemp)"
+  if ! exists="$(az group exists --name "${rg}" --subscription "${subscription_id}" --output tsv 2>"${stderr_file}")"; then
+    local err_output
+    err_output="$(cat "${stderr_file}")"
+    rm -f "${stderr_file}"
+    echo "Failed to check Azure resource group ${rg}: ${err_output}" >&2
+    return 2
+  fi
+  rm -f "${stderr_file}"
+
+  case "${exists}" in
+    true)
+      return 0
+      ;;
+    false)
+      return 1
+      ;;
+    *)
+      echo "Unexpected Azure resource group existence response for ${rg}: ${exists}" >&2
+      return 2
+      ;;
+  esac
+}
+
+wait_resource_group_deleted() {
+  local rg="$1"
+  local deadline=$((SECONDS + cleanup_wait_seconds))
+
+  while true; do
+    if resource_group_exists "${rg}"; then
+      if (( SECONDS >= deadline )); then
+        echo "Timed out waiting for Azure resource group ${rg} to be deleted" >&2
+        return 1
+      fi
+      echo "Waiting for Azure resource group ${rg} deletion to finish"
+      sleep 30
+      continue
+    fi
+
+    local exists_status="$?"
+    if [[ "${exists_status}" == "1" ]]; then
+      echo "Azure resource group ${rg} deletion finished"
+      return 0
+    fi
+    return "${exists_status}"
+  done
+}
+
+snapshot_resource_group() {
+  local rg="$1"
+  echo "Resource group: ${rg}"
+  echo
+
+  echo "Resource group details:"
+  run_az group show \
+    --name "${rg}" \
+    --subscription "${subscription_id}" \
+    --output table
+  echo
+
+  echo "Resources:"
+  run_az resource list \
+    --resource-group "${rg}" \
+    --subscription "${subscription_id}" \
+    --query "[].{name:name,type:type,location:location,provisioningState:properties.provisioningState}" \
+    --output table
+  echo
+
+  echo "AKS clusters:"
+  run_az aks list \
+    --resource-group "${rg}" \
+    --subscription "${subscription_id}" \
+    --query "[].{name:name,location:location,kubernetesVersion:kubernetesVersion,provisioningState:provisioningState,powerState:powerState.code,nodeResourceGroup:nodeResourceGroup}" \
+    --output table
+  echo
+
+  echo "Virtual networks:"
+  run_az network vnet list \
+    --resource-group "${rg}" \
+    --subscription "${subscription_id}" \
+    --query "[].{name:name,location:location,addressPrefixes:addressSpace.addressPrefixes}" \
+    --output table
+  echo
+
+  local vnet
+  while IFS= read -r vnet; do
+    [[ -n "${vnet}" ]] || continue
+    echo "VNet peerings for ${vnet}:"
+    run_az network vnet peering list \
+      --resource-group "${rg}" \
+      --vnet-name "${vnet}" \
+      --subscription "${subscription_id}" \
+      --query "[].{name:name,provisioningState:provisioningState,peeringState:peeringState,remoteVirtualNetwork:remoteVirtualNetwork.id}" \
+      --output table
+    echo
+  done < <(az network vnet list \
+    --resource-group "${rg}" \
+    --subscription "${subscription_id}" \
+    --query "[].name" \
+    --output tsv 2>/dev/null || true)
+
+  echo "Public IPs:"
+  run_az network public-ip list \
+    --resource-group "${rg}" \
+    --subscription "${subscription_id}" \
+    --query "[].{name:name,location:location,ipAddress:ipAddress,provisioningState:provisioningState,associatedTo:ipConfiguration.id}" \
+    --output table
+  echo
+
+  echo "Load balancers:"
+  run_az network lb list \
+    --resource-group "${rg}" \
+    --subscription "${subscription_id}" \
+    --query "[].{name:name,location:location,provisioningState:provisioningState,frontendIPConfigurations:frontendIPConfigurations[].name}" \
+    --output table
+  echo
+
+  echo "Disks:"
+  run_az disk list \
+    --resource-group "${rg}" \
+    --subscription "${subscription_id}" \
+    --query "[].{name:name,location:location,diskSizeGb:diskSizeGb,provisioningState:provisioningState,managedBy:managedBy}" \
+    --output table
+  echo
+
+  echo "Recent failed activity log events:"
+  run_az monitor activity-log list \
+    --resource-group "${rg}" \
+    --subscription "${subscription_id}" \
+    --status Failed \
+    --max-events 80 \
+    --query "[].{eventTimestamp:eventTimestamp,operationName:operationName.localizedValue,status:status.localizedValue,subStatus:subStatus.localizedValue,resourceGroupName:resourceGroupName,resourceProviderName:resourceProviderName.localizedValue,resourceId:resourceId,claims:claims.name}" \
+    --output table
+  echo
+}
+
+snapshot() {
+  local label="${1:-snapshot}"
+  local file="${debug_dir}/azure-${label}-$(date -u +"%Y%m%dT%H%M%SZ").log"
+
+  {
+    echo "Azure CI debug snapshot: ${label}"
+    echo "Timestamp: $(timestamp)"
+    echo "Subscription: ${subscription_id}"
+    echo "Resource prefix: ${resource_prefix}"
+    echo "Ticket: ${ticket:-unset}"
+    echo "Current GitHub run ID: ${current_run_id:-unset}"
+    echo "Current GitHub workflow: ${current_workflow:-unset}"
+    echo "Current GitHub job: ${current_job:-unset}"
+    echo "Current GitHub ref name: ${current_ref_name:-unset}"
+    echo "Resource groups file: ${resource_groups_file}"
+    echo
+
+    echo "Azure CLI account:"
+    run_az account show \
+      --subscription "${subscription_id}" \
+      --query "{name:name,id:id,tenantId:tenantId,user:user.name}" \
+      --output table
+    echo
+
+    echo "Recorded resource groups:"
+    resource_groups
+    echo
+
+    echo "Known helm-charts Azure resource groups:"
+    run_az group list \
+      --subscription "${subscription_id}" \
+      --query "[?starts_with(name, '${resource_prefix}-rg-') || tags.ManagedBy=='helm-charts-e2e'].{name:name,location:location,provisioningState:properties.provisioningState,ticket:tags.Ticket,testRun:tags.TestRun}" \
+      --output table
+    echo
+
+    local rg
+    while IFS= read -r rg; do
+      [[ -n "${rg}" ]] || continue
+      snapshot_resource_group "${rg}"
+    done < <(resource_groups)
+  } 2>&1 | tee "${file}"
+}
+
+watch() {
+  local interval="${1:-120}"
+  while true; do
+    snapshot "periodic"
+    sleep "${interval}"
+  done
+}
+
+cleanup_resource_groups() {
+  if [[ "${AZURE_SKIP_TEARDOWN:-false}" == "true" ]]; then
+    echo "AZURE_SKIP_TEARDOWN=true; preserving recorded Azure resource groups"
+    return 0
+  fi
+
+  mapfile -t groups < <(resource_groups)
+  if (( ${#groups[@]} == 0 )); then
+    echo "No recorded Azure resource groups found; skipping cleanup"
+    return 0
+  fi
+
+  local cleanup_status=0
+  local rg
+  for rg in "${groups[@]}"; do
+    [[ -n "${rg}" ]] || continue
+    delete_resource_group_async "${rg}" || cleanup_status="$?"
+  done
+  return "${cleanup_status}"
+}
+
+cleanup_old_resource_groups() {
+  if [[ "${AZURE_CLEANUP_OLD_RESOURCE_GROUPS:-true}" != "true" ]]; then
+    echo "AZURE_CLEANUP_OLD_RESOURCE_GROUPS is not true; skipping old artifact cleanup"
+    return 0
+  fi
+  if [[ -z "${ticket}" ]]; then
+    echo "AZURE_TICKET is required for old artifact cleanup" >&2
+    return 1
+  fi
+
+  local old_groups_output
+  if ! old_groups_output="$(old_resource_groups)"; then
+    return 1
+  fi
+
+  local groups=()
+  if [[ -n "${old_groups_output}" ]]; then
+    mapfile -t groups <<< "${old_groups_output}"
+  fi
+
+  if (( ${#groups[@]} == 0 )); then
+    echo "No old Azure resource groups found for prefix ${resource_prefix} and ticket ${ticket}"
+    return 0
+  fi
+
+  echo "Found old Azure resource groups for prefix ${resource_prefix} and ticket ${ticket}:"
+  printf '  %s\n' "${groups[@]}"
+  echo "Submitting async cleanup for old Azure resource groups, then failing this run before provisioning new infrastructure."
+
+  local cleanup_status=1
+  local rg
+  for rg in "${groups[@]}"; do
+    [[ -n "${rg}" ]] || continue
+    delete_resource_group_async "${rg}" || cleanup_status="$?"
+  done
+
+  return "${cleanup_status}"
+}
+
+case "${1:-}" in
+  snapshot)
+    snapshot "${2:-snapshot}"
+    ;;
+  watch)
+    watch "${2:-120}"
+    ;;
+  cleanup-resource-groups)
+    cleanup_resource_groups
+    ;;
+  cleanup-old-resource-groups)
+    cleanup_old_resource_groups
+    ;;
+  *)
+    echo "usage: $0 {snapshot [label]|watch [seconds]|cleanup-resource-groups|cleanup-old-resource-groups}" >&2
+    exit 2
+    ;;
+esac

--- a/build/azure-ci-debug.sh
+++ b/build/azure-ci-debug.sh
@@ -12,12 +12,10 @@ mkdir -p "${debug_dir}"
 
 resource_groups_file="${AZURE_RESOURCE_GROUPS_FILE:-${RUNNER_TEMP:-/tmp}/azure-resource-groups.txt}"
 resource_prefix="${AZURE_RESOURCE_PREFIX:-helm-charts-e2e}"
-ticket="${AZURE_TICKET:-}"
 current_run_id="${GITHUB_RUN_ID:-}"
 current_workflow="${GITHUB_WORKFLOW:-}"
 current_job="${GITHUB_JOB:-}"
 current_ref_name="${GITHUB_REF_NAME:-}"
-cleanup_wait_seconds="${AZURE_CLEANUP_WAIT_SECONDS:-3600}"
 
 timestamp() {
   date -u +"%Y-%m-%dT%H:%M:%SZ"
@@ -58,12 +56,7 @@ resource_groups() {
 }
 
 old_resource_groups() {
-  if [[ -z "${ticket}" ]]; then
-    echo "AZURE_TICKET is required for old artifact cleanup" >&2
-    return 1
-  fi
-
-  local query="[?starts_with(name, '${resource_prefix}-rg-') && tags.ManagedBy=='helm-charts-e2e' && tags.Ticket=='${ticket}'"
+  local query="[?starts_with(name, '${resource_prefix}-rg-') && tags.ManagedBy=='helm-charts-e2e'"
   if [[ -n "${current_run_id}" ]]; then
     query+=" && tags.GitHubRunID!='${current_run_id}'"
   fi
@@ -82,58 +75,6 @@ old_resource_groups() {
     --subscription "${subscription_id}" \
     --query "${query}" \
     --output tsv
-}
-
-resource_group_exists() {
-  local rg="$1"
-  local exists
-  local stderr_file
-  stderr_file="$(mktemp)"
-  if ! exists="$(az group exists --name "${rg}" --subscription "${subscription_id}" --output tsv 2>"${stderr_file}")"; then
-    local err_output
-    err_output="$(cat "${stderr_file}")"
-    rm -f "${stderr_file}"
-    echo "Failed to check Azure resource group ${rg}: ${err_output}" >&2
-    return 2
-  fi
-  rm -f "${stderr_file}"
-
-  case "${exists}" in
-    true)
-      return 0
-      ;;
-    false)
-      return 1
-      ;;
-    *)
-      echo "Unexpected Azure resource group existence response for ${rg}: ${exists}" >&2
-      return 2
-      ;;
-  esac
-}
-
-wait_resource_group_deleted() {
-  local rg="$1"
-  local deadline=$((SECONDS + cleanup_wait_seconds))
-
-  while true; do
-    if resource_group_exists "${rg}"; then
-      if (( SECONDS >= deadline )); then
-        echo "Timed out waiting for Azure resource group ${rg} to be deleted" >&2
-        return 1
-      fi
-      echo "Waiting for Azure resource group ${rg} deletion to finish"
-      sleep 30
-      continue
-    fi
-
-    local exists_status="$?"
-    if [[ "${exists_status}" == "1" ]]; then
-      echo "Azure resource group ${rg} deletion finished"
-      return 0
-    fi
-    return "${exists_status}"
-  done
 }
 
 snapshot_resource_group() {
@@ -233,7 +174,6 @@ snapshot() {
     echo "Timestamp: $(timestamp)"
     echo "Subscription: ${subscription_id}"
     echo "Resource prefix: ${resource_prefix}"
-    echo "Ticket: ${ticket:-unset}"
     echo "Current GitHub run ID: ${current_run_id:-unset}"
     echo "Current GitHub workflow: ${current_workflow:-unset}"
     echo "Current GitHub job: ${current_job:-unset}"
@@ -255,7 +195,7 @@ snapshot() {
     echo "Known helm-charts Azure resource groups:"
     run_az group list \
       --subscription "${subscription_id}" \
-      --query "[?starts_with(name, '${resource_prefix}-rg-') || tags.ManagedBy=='helm-charts-e2e'].{name:name,location:location,provisioningState:properties.provisioningState,ticket:tags.Ticket,testRun:tags.TestRun}" \
+      --query "[?starts_with(name, '${resource_prefix}-rg-') || tags.ManagedBy=='helm-charts-e2e'].{name:name,location:location,provisioningState:properties.provisioningState,testRun:tags.TestRun}" \
       --output table
     echo
 
@@ -276,11 +216,6 @@ watch() {
 }
 
 cleanup_resource_groups() {
-  if [[ "${AZURE_SKIP_TEARDOWN:-false}" == "true" ]]; then
-    echo "AZURE_SKIP_TEARDOWN=true; preserving recorded Azure resource groups"
-    return 0
-  fi
-
   mapfile -t groups < <(resource_groups)
   if (( ${#groups[@]} == 0 )); then
     echo "No recorded Azure resource groups found; skipping cleanup"
@@ -297,15 +232,6 @@ cleanup_resource_groups() {
 }
 
 cleanup_old_resource_groups() {
-  if [[ "${AZURE_CLEANUP_OLD_RESOURCE_GROUPS:-true}" != "true" ]]; then
-    echo "AZURE_CLEANUP_OLD_RESOURCE_GROUPS is not true; skipping old artifact cleanup"
-    return 0
-  fi
-  if [[ -z "${ticket}" ]]; then
-    echo "AZURE_TICKET is required for old artifact cleanup" >&2
-    return 1
-  fi
-
   local old_groups_output
   if ! old_groups_output="$(old_resource_groups)"; then
     return 1
@@ -317,11 +243,11 @@ cleanup_old_resource_groups() {
   fi
 
   if (( ${#groups[@]} == 0 )); then
-    echo "No old Azure resource groups found for prefix ${resource_prefix} and ticket ${ticket}"
+    echo "No old Azure resource groups found for prefix ${resource_prefix}"
     return 0
   fi
 
-  echo "Found old Azure resource groups for prefix ${resource_prefix} and ticket ${ticket}:"
+  echo "Found old Azure resource groups for prefix ${resource_prefix}:"
   printf '  %s\n' "${groups[@]}"
   echo "Submitting async cleanup for old Azure resource groups, then failing this run before provisioning new infrastructure."
 

--- a/tests/e2e/coredns/coredns.go
+++ b/tests/e2e/coredns/coredns.go
@@ -346,11 +346,83 @@ type CoreDNSClusterOption struct {
 	IPs []string
 }
 
+// CoreDNSCustomConfigMapData returns the AKS-style coredns-custom data map:
+// a "rewrite.override" entry plus "<host>.server" entries for every remote
+// cluster. This is the data AKS's managed CoreDNS reads from the
+// coredns-custom ConfigMap, and matches the map entries CoreDNSConfigMap
+// computes internally for its Corefile.
+func CoreDNSCustomConfigMapData(
+	thisDomain string, allClusters map[string]CoreDNSClusterOption,
+) map[string]string {
+	return buildCoreDNSDataMap(thisDomain, allClusters)
+}
+
+func buildCoreDNSDataMap(
+	thisDomain string, allClusters map[string]CoreDNSClusterOption,
+) map[string]string {
+	dataMap := map[string]string{}
+
+	quotedDomain := regexp.QuoteMeta(thisDomain)
+	rewriteStr := fmt.Sprintf(`rewrite continue {
+		name regex ^(.+)\.%s\.?$ {1}.cluster.local
+		answer name ^(.+)\.cluster\.local\.?$ {1}.%s
+		answer value ^(.+)\.cluster\.local\.?$ {1}.%s
+	}`, quotedDomain, thisDomain, thisDomain)
+	dataMap["rewrite.override"] = rewriteStr
+
+	clusters := make([]string, 0, len(allClusters))
+	for clusterDomain := range allClusters {
+		clusters = append(clusters, clusterDomain)
+	}
+	sort.Strings(clusters)
+
+	for _, clusterDomain := range clusters {
+		if clusterDomain == thisDomain {
+			continue
+		}
+		cluster := allClusters[clusterDomain]
+		if len(cluster.IPs) == 0 {
+			continue
+		}
+
+		sortedIPs := append([]string{}, cluster.IPs...)
+		sort.Strings(sortedIPs)
+		ipAddresses := strings.Join(sortedIPs, " ")
+
+		serverBlockStr := fmt.Sprintf(`{
+	log
+	errors
+	ready
+	cache 30
+	forward . %s {
+		force_tcp
+	}
+}`, ipAddresses)
+
+		var servers []string
+		if cluster.Namespace != "" {
+			servers = append(
+				servers,
+				fmt.Sprintf("%s.svc.%s", cluster.Namespace, clusterDomain),
+				fmt.Sprintf("%s.pod.%s", cluster.Namespace, clusterDomain),
+			)
+		}
+		servers = append(servers, clusterDomain)
+
+		for _, server := range servers {
+			dataMap[fmt.Sprintf("%s.server", server)] = fmt.Sprintf("%s:53 %s\n", server, serverBlockStr)
+		}
+	}
+
+	return dataMap
+}
+
 // CoreDNSConfigMap will have all the rules required to forward
 // service requests of other cluster domains.
-func CoreDNSConfigMap(thisDomain string, allClusters map[string]CoreDNSClusterOption) *corev1.ConfigMap {
+func CoreDNSConfigMap(
+	thisDomain string, allClusters map[string]CoreDNSClusterOption,
+) *corev1.ConfigMap {
 	var data strings.Builder
-	dataMap := map[string]string{}
 
 	// Our addition to the typical default server configuration.
 	quotedDomain := regexp.QuoteMeta(thisDomain)
@@ -359,11 +431,6 @@ func CoreDNSConfigMap(thisDomain string, allClusters map[string]CoreDNSClusterOp
 		answer name ^(.+)\.cluster\.local\.?$ {1}.%s
 		answer value ^(.+)\.cluster\.local\.?$ {1}.%s
 	}`, quotedDomain, thisDomain, thisDomain)
-
-	// We provide the rewrite string to Azure as a ".override" map entry.
-	// We provide it to AWS and GCP by directly constructing the entire
-	// default server string.
-	dataMap["rewrite.override"] = rewriteStr
 	// "It returns the length of s and a nil error, or else it gets the
 	// hose again"
 	// - https://golang.org/pkg/strings/#Builder.WriteString
@@ -448,11 +515,6 @@ func CoreDNSConfigMap(thisDomain string, allClusters map[string]CoreDNSClusterOp
 
 		for _, server := range servers {
 			serverStr := fmt.Sprintf("%s:53 %s\n", server, serverBlockStr)
-			// We provide the server configuration to Azure as a ".server" map
-			// entry.
-			// We provide the server configuration to AWS and GCP as a direct
-			// entry in the Corefile string.
-			dataMap[fmt.Sprintf("%s.server", server)] = serverStr
 			// "It returns the length of s and a nil error, or else it gets the
 			// hose again"
 			// - https://golang.org/pkg/strings/#Builder.WriteString

--- a/tests/e2e/operator/compatibility/chart_compatibility_e2e_test.go
+++ b/tests/e2e/operator/compatibility/chart_compatibility_e2e_test.go
@@ -257,7 +257,7 @@ func installCockroachDBChart(
 		},
 	}
 
-	helm.Install(t, options, chart, operator.ReleaseName)
+	operator.HelmInstallWithRetry(t, options, chart, operator.ReleaseName)
 	k8s.WaitUntilServiceAvailable(t, kubectlOptions, "cockroachdb-public", 30, 5*time.Second)
 }
 
@@ -283,7 +283,7 @@ func upgradeCockroachDBChart(
 		},
 	}
 
-	helm.Upgrade(t, options, chart, operator.ReleaseName)
+	operator.HelmUpgradeWithRetry(t, options, chart, operator.ReleaseName)
 	k8s.WaitUntilServiceAvailable(t, kubectlOptions, "cockroachdb-public", 30, 5*time.Second)
 }
 

--- a/tests/e2e/operator/infra/azure.go
+++ b/tests/e2e/operator/infra/azure.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
-	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -23,7 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -55,8 +52,6 @@ const (
 	envAzureResourcePrefix     = "AZURE_RESOURCE_PREFIX"
 	envAzureReuseContexts      = "AZURE_REUSE_CONTEXTS"
 	envAzureNodeVMSize         = "AZURE_NODE_VM_SIZE"
-	envAzureSkipTeardown       = "AZURE_SKIP_TEARDOWN"
-	envAzureTicket             = "AZURE_TICKET"
 )
 
 type azureClusterConfig struct {
@@ -68,23 +63,6 @@ type azureClusterConfig struct {
 	SubnetCIDR   string
 	ServiceCIDR  string
 	DNSServiceIP string
-}
-
-var azureClusterConfigTemplates = []azureClusterConfig{
-	{
-		Region:       "eastus",
-		VNetCIDR:     "10.10.0.0/16",
-		SubnetCIDR:   "10.10.0.0/24",
-		ServiceCIDR:  "172.28.17.0/24",
-		DNSServiceIP: "172.28.17.10",
-	},
-	{
-		Region:       "westus2",
-		VNetCIDR:     "10.20.0.0/16",
-		SubnetCIDR:   "10.20.0.0/24",
-		ServiceCIDR:  "172.28.49.0/24",
-		DNSServiceIP: "172.28.49.10",
-	},
 }
 
 var azureCLIEnvOverrides = captureAzureCLIEnv()
@@ -127,7 +105,9 @@ func azureCommandContext(ctx context.Context, args ...string) *exec.Cmd {
 	return cmd
 }
 
-func azureCommandWithTimeout(timeout time.Duration, args ...string) (*exec.Cmd, context.CancelFunc) {
+func azureCommandWithTimeout(
+	timeout time.Duration, args ...string,
+) (*exec.Cmd, context.CancelFunc) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	return azureCommandContext(ctx, args...), cancel
 }
@@ -201,9 +181,9 @@ func (r *AzureRegion) SetUpInfra(t *testing.T) {
 	if len(r.Clusters) == 0 {
 		t.Fatalf("[%s] no clusters configured", ProviderAzure)
 	}
-	if len(r.Clusters) > len(azureClusterConfigTemplates) {
+	if len(r.Clusters) > len(NetworkConfigs[ProviderAzure]) {
 		t.Fatalf("[%s] need %d Azure cluster configs, only have %d",
-			ProviderAzure, len(r.Clusters), len(azureClusterConfigTemplates))
+			ProviderAzure, len(r.Clusters), len(NetworkConfigs[ProviderAzure]))
 	}
 	if _, err := exec.LookPath("az"); err != nil {
 		t.Fatalf("[%s] az CLI not found in PATH: %v", ProviderAzure, err)
@@ -234,7 +214,9 @@ func (r *AzureRegion) SetUpInfra(t *testing.T) {
 	uid := strings.ToLower(random.UniqueId())
 	prefix := azureResourcePrefix()
 	r.resourceGroupName = fmt.Sprintf("%s-rg-%s", prefix, uid)
-	r.clusterConfigs = r.buildClusterConfigs(prefix, uid)
+	clusterConfigs, err := r.buildClusterConfigs(prefix, uid)
+	require.NoError(t, err, "[%s] failed to build Azure cluster configs", ProviderAzure)
+	r.clusterConfigs = clusterConfigs
 	require.NoError(t, r.validateGeneratedNames(), "[%s] invalid generated Azure resource names", ProviderAzure)
 	require.NoError(t, r.recordResourceGroupForCI(), "[%s] failed to record Azure resource group for CI cleanup",
 		ProviderAzure)
@@ -267,11 +249,6 @@ func (r *AzureRegion) SetUpInfra(t *testing.T) {
 }
 
 func (r *AzureRegion) TeardownInfra(t *testing.T) {
-	if parseBoolEnv(envAzureSkipTeardown) {
-		t.Logf("[%s] %s=true; skipping resource group teardown", ProviderAzure, envAzureSkipTeardown)
-		return
-	}
-
 	resourceGroup := r.resourceGroupName
 	if resourceGroup == "" {
 		resourceGroup = strings.TrimSpace(os.Getenv(envAzureResourceGroup))
@@ -355,7 +332,10 @@ func (r *AzureRegion) EncryptKey(plaintextKey []byte, clusterRegion string) (str
 }
 
 func (r *AzureRegion) CreateKeySecret(
-	kubectlOptions *k8s.KubectlOptions, secretName string, encryptedKeyData string, clusterRegion string,
+	kubectlOptions *k8s.KubectlOptions,
+	secretName string,
+	encryptedKeyData string,
+	clusterRegion string,
 ) error {
 	return fmt.Errorf("CreateKeySecret not supported for %s (file-based encryption / UNKNOWN_KEY_TYPE)", ProviderAzure)
 }
@@ -421,18 +401,31 @@ func (r *AzureRegion) reuseInfra(t *testing.T) {
 		"[%s] failed to configure DNS on reused AKS infrastructure", ProviderAzure)
 }
 
-func (r *AzureRegion) buildClusterConfigs(prefix, uid string) []azureClusterConfig {
+func (r *AzureRegion) buildClusterConfigs(prefix, uid string) ([]azureClusterConfig, error) {
 	configs := make([]azureClusterConfig, len(r.Clusters))
 	for i, clusterName := range r.Clusters {
-		configs[i] = azureClusterConfigTemplates[i]
-		if len(r.RegionCodes) > i && r.RegionCodes[i] != "" {
-			configs[i].Region = r.RegionCodes[i]
+		region := r.RegionCodes[i]
+		netCfgRaw, ok := NetworkConfigs[ProviderAzure][region]
+		if !ok {
+			return nil, fmt.Errorf("no NetworkConfigs entry for Azure region %q", region)
 		}
-		configs[i].ClusterName = clusterName
-		configs[i].VNetName = fmt.Sprintf("%s-vnet-%d-%s", prefix, i, uid)
-		configs[i].SubnetName = fmt.Sprintf("%s-subnet", clusterName)
+		netCfg, ok := netCfgRaw.(map[string]string)
+		if !ok {
+			return nil, fmt.Errorf("NetworkConfigs entry for Azure region %q has unexpected type %T",
+				region, netCfgRaw)
+		}
+		configs[i] = azureClusterConfig{
+			Region:       region,
+			ClusterName:  clusterName,
+			VNetName:     fmt.Sprintf("%s-vnet-%d-%s", prefix, i, uid),
+			SubnetName:   fmt.Sprintf("%s-subnet", clusterName),
+			VNetCIDR:     netCfg["VNetCIDR"],
+			SubnetCIDR:   netCfg["SubnetCIDR"],
+			ServiceCIDR:  netCfg["ServiceCIDR"],
+			DNSServiceIP: netCfg["DNSServiceIP"],
+		}
 	}
-	return configs
+	return configs, nil
 }
 
 func (r *AzureRegion) createResourceGroup(location, testRun string) error {
@@ -444,9 +437,6 @@ func (r *AzureRegion) createResourceGroup(location, testRun string) error {
 		"--tags",
 		"ManagedBy=helm-charts-e2e",
 		"TestRun=" + testRun,
-	}
-	if ticket := strings.TrimSpace(os.Getenv(envAzureTicket)); ticket != "" {
-		args = append(args, "Ticket="+ticket)
 	}
 	for _, tag := range []struct {
 		key string
@@ -528,12 +518,31 @@ func (r *AzureRegion) createVNetAndSubnet(cfg *azureClusterConfig) error {
 }
 
 func (r *AzureRegion) createAKSClusters(t *testing.T) error {
+	// Create AKS clusters in parallel — each `az aks create` takes ~10-15 minutes.
+	// Kubeconfig writes are serialized below to avoid concurrent writers to the
+	// shared KUBECONFIG file.
+	var wg sync.WaitGroup
+	errs := make(chan error, len(r.Clusters))
 	for i, clusterName := range r.Clusters {
-		cfg := r.clusterConfigs[i]
-		t.Logf("[%s] Creating AKS cluster %s in %s", ProviderAzure, clusterName, cfg.Region)
-		if err := createAKSCluster(t, r.resourceGroupName, cfg, r.NodeCount); err != nil {
+		wg.Add(1)
+		go func(i int, clusterName string) {
+			defer wg.Done()
+			cfg := r.clusterConfigs[i]
+			t.Logf("[%s] Creating AKS cluster %s in %s", ProviderAzure, clusterName, cfg.Region)
+			if err := createAKSCluster(t, r.resourceGroupName, cfg, r.NodeCount); err != nil {
+				errs <- err
+			}
+		}(i, clusterName)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
 			return err
 		}
+	}
+
+	for i, clusterName := range r.Clusters {
 		if err := UpdateKubeconfigAzure(t, r.resourceGroupName, clusterName, clusterName); err != nil {
 			return err
 		}
@@ -551,7 +560,9 @@ func (r *AzureRegion) createAKSClusters(t *testing.T) error {
 	return nil
 }
 
-func createAKSCluster(t *testing.T, resourceGroup string, cfg azureClusterConfig, nodeCount int) error {
+func createAKSCluster(
+	t *testing.T, resourceGroup string, cfg azureClusterConfig, nodeCount int,
+) error {
 	subnetID, err := azureSubnetID(resourceGroup, cfg.VNetName, cfg.SubnetName)
 	if err != nil {
 		return fmt.Errorf("get subnet ID for %s: %w", cfg.SubnetName, err)
@@ -798,7 +809,9 @@ func restartAzureCoreDNS(t *testing.T, kubectlOpts *k8s.KubectlOptions, clusterN
 }
 
 func applyAzureCoreDNSCustom(
-	t *testing.T, kubectlOpts *k8s.KubectlOptions, thisDomain string,
+	t *testing.T,
+	kubectlOpts *k8s.KubectlOptions,
+	thisDomain string,
 	allClusters map[string]coredns.CoreDNSClusterOption,
 ) error {
 	cm := &corev1.ConfigMap{
@@ -810,7 +823,7 @@ func applyAzureCoreDNSCustom(
 			Name:      "coredns-custom",
 			Namespace: coreDNSNamespace,
 		},
-		Data: buildAzureCoreDNSCustomData(thisDomain, allClusters),
+		Data: coredns.CoreDNSCustomConfigMapData(thisDomain, allClusters),
 	}
 	if err := kubectlApplyAzureManifest(t, kubectlOpts, coredns.ToYAML(t, cm)); err != nil {
 		return fmt.Errorf("kubectl apply coredns-custom: %w", err)
@@ -818,90 +831,11 @@ func applyAzureCoreDNSCustom(
 	return nil
 }
 
-func buildAzureCoreDNSCustomData(
-	thisDomain string, allClusters map[string]coredns.CoreDNSClusterOption,
-) map[string]string {
-	data := map[string]string{}
-
-	quotedDomain := regexp.QuoteMeta(thisDomain)
-	data["rewrite.override"] = fmt.Sprintf(`rewrite continue {
-    name regex ^(.+)\.%s\.?$ {1}.cluster.local
-    answer name ^(.+)\.cluster\.local\.?$ {1}.%s
-    answer value ^(.+)\.cluster\.local\.?$ {1}.%s
-}`, quotedDomain, thisDomain, thisDomain)
-
-	domains := make([]string, 0, len(allClusters))
-	for domain := range allClusters {
-		domains = append(domains, domain)
-	}
-	sort.Strings(domains)
-
-	for _, clusterDomain := range domains {
-		if clusterDomain == thisDomain {
-			continue
-		}
-		cluster := allClusters[clusterDomain]
-		if len(cluster.IPs) == 0 {
-			continue
-		}
-
-		ips := append([]string{}, cluster.IPs...)
-		sort.Strings(ips)
-		ipList := strings.Join(ips, " ")
-		serverBlock := func(host string) string {
-			return fmt.Sprintf(`%s:53 {
-    errors
-    ready
-    cache 30
-    forward . %s {
-        force_tcp
-    }
-}
-`, host, ipList)
-		}
-
-		data[fmt.Sprintf("%s.server", clusterDomain)] = serverBlock(clusterDomain)
-		if cluster.Namespace != "" {
-			data[fmt.Sprintf("%s.svc.%s.server", cluster.Namespace, clusterDomain)] =
-				serverBlock(fmt.Sprintf("%s.svc.%s", cluster.Namespace, clusterDomain))
-			data[fmt.Sprintf("%s.pod.%s.server", cluster.Namespace, clusterDomain)] =
-				serverBlock(fmt.Sprintf("%s.pod.%s", cluster.Namespace, clusterDomain))
-		}
-	}
-
-	return data
-}
-
 func applyAzureCoreDNSService(t *testing.T, kubectlOpts *k8s.KubectlOptions) error {
-	annotations := GetLoadBalancerAnnotations(ProviderAzure)
-	annotationCopy := make(map[string]string, len(annotations))
-	for key, value := range annotations {
-		annotationCopy[key] = value
-	}
-
-	svc := &corev1.Service{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        coreDNSServiceName,
-			Namespace:   coreDNSNamespace,
-			Annotations: annotationCopy,
-		},
-		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeLoadBalancer,
-			Ports: []corev1.ServicePort{
-				{
-					Name:       "dns-tcp",
-					Port:       53,
-					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt(53),
-				},
-			},
-			Selector: detectAzureCoreDNSPodLabel(t, kubectlOpts),
-		},
-	}
+	svc := coredns.CoreDNSService(nil, GetLoadBalancerAnnotations(ProviderAzure))
+	// AKS's managed CoreDNS may use `k8s-app: coredns` (newer AKS) instead of
+	// the shared helper's default `k8s-app: kube-dns`, so probe at runtime.
+	svc.Spec.Selector = detectAzureCoreDNSPodLabel(t, kubectlOpts)
 
 	if err := kubectlApplyAzureManifest(t, kubectlOpts, coredns.ToYAML(t, svc)); err != nil {
 		return fmt.Errorf("kubectl apply %s: %w", coreDNSServiceName, err)
@@ -909,7 +843,9 @@ func applyAzureCoreDNSService(t *testing.T, kubectlOpts *k8s.KubectlOptions) err
 	return nil
 }
 
-func kubectlApplyAzureManifest(t *testing.T, kubectlOpts *k8s.KubectlOptions, manifest string) error {
+func kubectlApplyAzureManifest(
+	t *testing.T, kubectlOpts *k8s.KubectlOptions, manifest string,
+) error {
 	t.Helper()
 
 	manifestFile := filepath.Join(t.TempDir(), "manifest.yaml")
@@ -922,7 +858,9 @@ func kubectlApplyAzureManifest(t *testing.T, kubectlOpts *k8s.KubectlOptions, ma
 	})
 }
 
-func runAzureKubernetesActionWithRetry(t *testing.T, description string, action func() error) error {
+func runAzureKubernetesActionWithRetry(
+	t *testing.T, description string, action func() error,
+) error {
 	t.Helper()
 
 	var err error

--- a/tests/e2e/operator/infra/azure.go
+++ b/tests/e2e/operator/infra/azure.go
@@ -1,0 +1,1242 @@
+package infra
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/coredns"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator/encryption"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+const (
+	azureDefaultResourcePrefix = "helm-charts-e2e"
+	azureDefaultNodeVMSize     = "Standard_D4s_v3"
+	azureDefaultMaxPods        = 30
+	azureCLICommandTimeout     = 10 * time.Minute
+	azureAKSCreateTimeout      = 45 * time.Minute
+	azureAKSCreateAttempts     = 3
+	azureAKSCreatePollAttempts = 30
+	azureAKSCreatePollInterval = 20 * time.Second
+	azureDeleteAttempts        = 5
+	azureDeleteRetrySleep      = 20 * time.Second
+	azureKubernetesAttempts    = 5
+	azureKubernetesRetrySleep  = 10 * time.Second
+	azureMaxNodeRGNameLength   = 80
+)
+
+const (
+	envAzureSubscriptionID     = "AZURE_SUBSCRIPTION_ID"
+	envAzureClientID           = "AZURE_CLIENT_ID"
+	envAzureClientSecret       = "AZURE_CLIENT_SECRET" // #nosec G101 - env var name, not a credential
+	envAzureTenantID           = "AZURE_TENANT_ID"
+	envAzureResourceGroup      = "AZURE_RESOURCE_GROUP"
+	envAzureResourceGroupsFile = "AZURE_RESOURCE_GROUPS_FILE"
+	envAzureResourcePrefix     = "AZURE_RESOURCE_PREFIX"
+	envAzureReuseContexts      = "AZURE_REUSE_CONTEXTS"
+	envAzureNodeVMSize         = "AZURE_NODE_VM_SIZE"
+	envAzureSkipTeardown       = "AZURE_SKIP_TEARDOWN"
+	envAzureTicket             = "AZURE_TICKET"
+)
+
+type azureClusterConfig struct {
+	Region       string
+	ClusterName  string
+	VNetName     string
+	VNetCIDR     string
+	SubnetName   string
+	SubnetCIDR   string
+	ServiceCIDR  string
+	DNSServiceIP string
+}
+
+var azureClusterConfigTemplates = []azureClusterConfig{
+	{
+		Region:       "eastus",
+		VNetCIDR:     "10.10.0.0/16",
+		SubnetCIDR:   "10.10.0.0/24",
+		ServiceCIDR:  "172.28.17.0/24",
+		DNSServiceIP: "172.28.17.10",
+	},
+	{
+		Region:       "westus2",
+		VNetCIDR:     "10.20.0.0/16",
+		SubnetCIDR:   "10.20.0.0/24",
+		ServiceCIDR:  "172.28.49.0/24",
+		DNSServiceIP: "172.28.49.10",
+	},
+}
+
+var azureCLIEnvOverrides = captureAzureCLIEnv()
+
+func captureAzureCLIEnv() map[string]string {
+	env := make(map[string]string)
+	for _, key := range []string{
+		"HTTP_PROXY",
+		"HTTPS_PROXY",
+		"NO_PROXY",
+		"http_proxy",
+		"https_proxy",
+		"no_proxy",
+		"REQUESTS_CA_BUNDLE",
+		"AZURE_CLI_CA_CERTS",
+		"SSL_CERT_FILE",
+	} {
+		if value, ok := os.LookupEnv(key); ok {
+			env[key] = value
+		}
+	}
+	return env
+}
+
+func azureCommand(args ...string) *exec.Cmd {
+	return azureCommandContext(context.Background(), args...)
+}
+
+func azureCommandContext(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "az", args...)
+	cmd.Env = withEnvOverrides(os.Environ(), azureCLIEnvOverrides)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.WaitDelay = 30 * time.Second
+	return cmd
+}
+
+func azureCommandWithTimeout(timeout time.Duration, args ...string) (*exec.Cmd, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	return azureCommandContext(ctx, args...), cancel
+}
+
+func withEnvOverrides(base []string, overrides map[string]string) []string {
+	if len(overrides) == 0 {
+		return base
+	}
+
+	keys := make(map[string]struct{}, len(overrides))
+	for key := range overrides {
+		keys[key] = struct{}{}
+	}
+
+	env := make([]string, 0, len(base)+len(overrides))
+	for _, entry := range base {
+		key, _, found := strings.Cut(entry, "=")
+		if found {
+			if _, overridden := keys[key]; overridden {
+				continue
+			}
+		}
+		env = append(env, entry)
+	}
+	for key, value := range overrides {
+		env = append(env, key+"="+value)
+	}
+	return env
+}
+
+func disableKubernetesProxyEnv(t *testing.T) {
+	t.Helper()
+
+	previous := make(map[string]*string)
+	disabled := false
+	for _, key := range []string{"HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"} {
+		if value, ok := os.LookupEnv(key); ok {
+			valueCopy := value
+			previous[key] = &valueCopy
+			_ = os.Unsetenv(key)
+			disabled = true
+		} else {
+			previous[key] = nil
+		}
+	}
+	if disabled {
+		t.Logf("[%s] Disabled proxy environment for Kubernetes clients; az CLI calls preserve original proxy settings",
+			ProviderAzure)
+	}
+	t.Cleanup(func() {
+		for key, value := range previous {
+			if value == nil {
+				_ = os.Unsetenv(key)
+				continue
+			}
+			_ = os.Setenv(key, *value)
+		}
+	})
+}
+
+// AzureRegion provisions AKS clusters for Helm chart E2E runs.
+type AzureRegion struct {
+	*operator.Region
+
+	resourceGroupName string
+	clusterConfigs    []azureClusterConfig
+	kubeConfigPath    string
+}
+
+func (r *AzureRegion) SetUpInfra(t *testing.T) {
+	if len(r.Clusters) == 0 {
+		t.Fatalf("[%s] no clusters configured", ProviderAzure)
+	}
+	if len(r.Clusters) > len(azureClusterConfigTemplates) {
+		t.Fatalf("[%s] need %d Azure cluster configs, only have %d",
+			ProviderAzure, len(r.Clusters), len(azureClusterConfigTemplates))
+	}
+	if _, err := exec.LookPath("az"); err != nil {
+		t.Fatalf("[%s] az CLI not found in PATH: %v", ProviderAzure, err)
+	}
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		t.Fatalf("[%s] kubectl not found in PATH: %v", ProviderAzure, err)
+	}
+	if len(r.RegionCodes) == 0 {
+		r.RegionCodes = GetRegionCodes(ProviderAzure)
+	}
+
+	r.configureIsolatedKubeconfig(t)
+	disableKubernetesProxyEnv(t)
+
+	if reuseContexts := azureReuseContexts(t, len(r.Clusters)); len(reuseContexts) > 0 {
+		r.Clusters = reuseContexts
+		r.ReusingInfra = true
+	}
+
+	if r.ReusingInfra {
+		r.reuseInfra(t)
+		return
+	}
+
+	subscriptionID := mustAzureEnv(t, envAzureSubscriptionID)
+	require.NoError(t, ensureAzureLogin(t, subscriptionID), "[%s] Azure authentication failed", ProviderAzure)
+
+	uid := strings.ToLower(random.UniqueId())
+	prefix := azureResourcePrefix()
+	r.resourceGroupName = fmt.Sprintf("%s-rg-%s", prefix, uid)
+	r.clusterConfigs = r.buildClusterConfigs(prefix, uid)
+	require.NoError(t, r.validateGeneratedNames(), "[%s] invalid generated Azure resource names", ProviderAzure)
+	require.NoError(t, r.recordResourceGroupForCI(), "[%s] failed to record Azure resource group for CI cleanup",
+		ProviderAzure)
+	r.Clients = make(map[string]client.Client)
+	r.CorednsClusterOptions = make(map[string]coredns.CoreDNSClusterOption)
+
+	rgLocation := r.clusterConfigs[0].Region
+	t.Logf("[%s] Creating resource group %s in %s", ProviderAzure, r.resourceGroupName, rgLocation)
+	require.NoError(t, r.createResourceGroup(rgLocation, uid), "[%s] failed to create resource group", ProviderAzure)
+
+	for i := range r.clusterConfigs {
+		cfg := &r.clusterConfigs[i]
+		t.Logf("[%s] Creating VNet %s in %s", ProviderAzure, cfg.VNetName, cfg.Region)
+		require.NoError(t, r.createVNetAndSubnet(cfg), "[%s] failed to create VNet/subnet for %s",
+			ProviderAzure, cfg.ClusterName)
+	}
+
+	require.NoError(t, r.createAKSClusters(t), "[%s] failed to create AKS clusters", ProviderAzure)
+
+	if len(r.Clusters) > 1 {
+		require.NoError(t, r.setupVNetPeering(t), "[%s] failed to set up VNet peering", ProviderAzure)
+	}
+
+	require.NoError(t, r.deployAndConfigureCoreDNS(t, r.kubeConfigPath), "[%s] failed to configure AKS DNS",
+		ProviderAzure)
+
+	r.ReusingInfra = true
+	t.Logf("[%s] Infrastructure setup complete; cleanup resource group with: az group delete --name %s --subscription %s --yes",
+		ProviderAzure, r.resourceGroupName, subscriptionID)
+}
+
+func (r *AzureRegion) TeardownInfra(t *testing.T) {
+	if parseBoolEnv(envAzureSkipTeardown) {
+		t.Logf("[%s] %s=true; skipping resource group teardown", ProviderAzure, envAzureSkipTeardown)
+		return
+	}
+
+	resourceGroup := r.resourceGroupName
+	if resourceGroup == "" {
+		resourceGroup = strings.TrimSpace(os.Getenv(envAzureResourceGroup))
+	}
+	if resourceGroup == "" {
+		t.Logf("[%s] no resource group recorded; set %s to clean up manually", ProviderAzure, envAzureResourceGroup)
+		return
+	}
+
+	subscriptionID := strings.TrimSpace(os.Getenv(envAzureSubscriptionID))
+	if subscriptionID == "" {
+		t.Logf("[%s] %s is not set; clean up manually with: az group delete --name %s --yes",
+			ProviderAzure, envAzureSubscriptionID, resourceGroup)
+		return
+	}
+
+	if err := ensureAzureLogin(t, subscriptionID); err != nil {
+		t.Logf("[%s] warning: Azure auth failed during teardown: %v", ProviderAzure, err)
+	}
+
+	t.Logf("[%s] Deleting resource group %s", ProviderAzure, resourceGroup)
+	for attempt := 1; attempt <= azureDeleteAttempts; attempt++ {
+		cmd, cancel := azureCommandWithTimeout(azureCLICommandTimeout, "group", "delete",
+			"--name", resourceGroup,
+			"--subscription", subscriptionID,
+			"--yes",
+			"--no-wait",
+			"--output", "none",
+		)
+		out, err := cmd.CombinedOutput()
+		cancel()
+		if err == nil {
+			t.Logf("[%s] Initiated async deletion for resource group %s", ProviderAzure, resourceGroup)
+			return
+		}
+		if isAzureResourceNotFoundError(err) {
+			t.Logf("[%s] resource group %s is already deleted", ProviderAzure, resourceGroup)
+			return
+		}
+		if !isTransientAzureCLIError(err, out) || attempt == azureDeleteAttempts {
+			t.Logf("[%s] warning: failed to initiate resource group deletion for %s: %v\n%s",
+				ProviderAzure, resourceGroup, err, strings.TrimSpace(string(out)))
+			return
+		}
+		t.Logf("[%s] az group delete %s hit a transient Azure CLI transport error on attempt %d/%d: %v\n%s",
+			ProviderAzure, resourceGroup, attempt, azureDeleteAttempts, err, strings.TrimSpace(string(out)))
+		time.Sleep(azureDeleteRetrySleep)
+	}
+}
+
+func (r *AzureRegion) ScaleNodePool(t *testing.T, location string, nodeCount, index int) {
+	t.Logf("[%s] Node scaling delegated to AKS cluster autoscaler for cluster index %d in %s; desired CRDB nodes=%d",
+		ProviderAzure, index, location, nodeCount)
+}
+
+func (r *AzureRegion) CanScale() bool {
+	return true
+}
+
+func (r *AzureRegion) GetEncryptionProvider() encryption.Provider {
+	return r
+}
+
+func (r *AzureRegion) SetupEncryptionInfrastructure(t *testing.T) (func(), error) {
+	t.Logf("[%s] No KMS infrastructure needed for file-based encryption (UNKNOWN_KEY_TYPE)", ProviderAzure)
+	return func() {
+		t.Logf("[%s] No KMS infrastructure to clean up", ProviderAzure)
+	}, nil
+}
+
+func (r *AzureRegion) GetEncryptionPlatformConfig() *encryption.PlatformConfig {
+	return &encryption.PlatformConfig{
+		Platform:                     "UNKNOWN_KEY_TYPE",
+		RequiresCredentialsSecret:    false,
+		DefaultCredentialsSecretName: "",
+	}
+}
+
+func (r *AzureRegion) EncryptKey(plaintextKey []byte, clusterRegion string) (string, error) {
+	return "", fmt.Errorf("EncryptKey not supported for %s (file-based encryption / UNKNOWN_KEY_TYPE)", ProviderAzure)
+}
+
+func (r *AzureRegion) CreateKeySecret(
+	kubectlOptions *k8s.KubectlOptions, secretName string, encryptedKeyData string, clusterRegion string,
+) error {
+	return fmt.Errorf("CreateKeySecret not supported for %s (file-based encryption / UNKNOWN_KEY_TYPE)", ProviderAzure)
+}
+
+func (r *AzureRegion) CreateCredentialsSecret(kubectlOptions *k8s.KubectlOptions) (string, error) {
+	return "", fmt.Errorf("CreateCredentialsSecret not supported for %s (file-based encryption / UNKNOWN_KEY_TYPE)",
+		ProviderAzure)
+}
+
+func (r *AzureRegion) configureIsolatedKubeconfig(t *testing.T) {
+	t.Helper()
+
+	kubeConfigPath := r.kubeConfigPath
+	if kubeConfigPath == "" {
+		kubeConfigPath = fmt.Sprintf("%s/azure-kubeconfig.yaml", t.TempDir())
+	}
+
+	emptyConfig := []byte("apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []\n")
+	require.NoError(t, os.WriteFile(kubeConfigPath, emptyConfig, 0600),
+		"[%s] failed to initialize isolated kubeconfig", ProviderAzure)
+
+	previousKubeconfig := os.Getenv("KUBECONFIG")
+	require.NoError(t, os.Setenv("KUBECONFIG", kubeConfigPath))
+	r.kubeConfigPath = kubeConfigPath
+	t.Cleanup(func() {
+		if previousKubeconfig != "" {
+			_ = os.Setenv("KUBECONFIG", previousKubeconfig)
+			return
+		}
+		_ = os.Unsetenv("KUBECONFIG")
+	})
+
+	t.Logf("[%s] Using isolated kubeconfig %s", ProviderAzure, kubeConfigPath)
+}
+
+func (r *AzureRegion) reuseInfra(t *testing.T) {
+	resourceGroup := strings.TrimSpace(os.Getenv(envAzureResourceGroup))
+	require.NotEmpty(t, resourceGroup, "[%s] %s must be set when reusing Azure infrastructure",
+		ProviderAzure, envAzureResourceGroup)
+
+	r.resourceGroupName = resourceGroup
+	r.Clients = make(map[string]client.Client)
+	r.CorednsClusterOptions = make(map[string]coredns.CoreDNSClusterOption)
+
+	subscriptionID := mustAzureEnv(t, envAzureSubscriptionID)
+	require.NoError(t, ensureAzureLogin(t, subscriptionID), "[%s] Azure authentication failed", ProviderAzure)
+
+	for i, clusterName := range r.Clusters {
+		require.NoError(t, UpdateKubeconfigAzure(t, resourceGroup, clusterName, clusterName),
+			"[%s] failed to get credentials for reused AKS cluster %s", ProviderAzure, clusterName)
+		k8sClient, err := clientForContext(clusterName)
+		require.NoError(t, err, "[%s] failed to initialize Kubernetes client for %s", ProviderAzure, clusterName)
+		r.Clients[clusterName] = k8sClient
+
+		r.CorednsClusterOptions[operator.CustomDomains[i]] = coredns.CoreDNSClusterOption{
+			IPs:       []string{"127.0.0.1"},
+			Namespace: r.Namespace[clusterName],
+			Domain:    operator.CustomDomains[i],
+		}
+	}
+
+	require.NoError(t, r.deployAndConfigureCoreDNS(t, r.kubeConfigPath),
+		"[%s] failed to configure DNS on reused AKS infrastructure", ProviderAzure)
+}
+
+func (r *AzureRegion) buildClusterConfigs(prefix, uid string) []azureClusterConfig {
+	configs := make([]azureClusterConfig, len(r.Clusters))
+	for i, clusterName := range r.Clusters {
+		configs[i] = azureClusterConfigTemplates[i]
+		if len(r.RegionCodes) > i && r.RegionCodes[i] != "" {
+			configs[i].Region = r.RegionCodes[i]
+		}
+		configs[i].ClusterName = clusterName
+		configs[i].VNetName = fmt.Sprintf("%s-vnet-%d-%s", prefix, i, uid)
+		configs[i].SubnetName = fmt.Sprintf("%s-subnet", clusterName)
+	}
+	return configs
+}
+
+func (r *AzureRegion) createResourceGroup(location, testRun string) error {
+	args := []string{
+		"group", "create",
+		"--name", r.resourceGroupName,
+		"--location", location,
+		"--subscription", azureSubscriptionID(),
+		"--tags",
+		"ManagedBy=helm-charts-e2e",
+		"TestRun=" + testRun,
+	}
+	if ticket := strings.TrimSpace(os.Getenv(envAzureTicket)); ticket != "" {
+		args = append(args, "Ticket="+ticket)
+	}
+	for _, tag := range []struct {
+		key string
+		env string
+	}{
+		{key: "GitHubRunID", env: "GITHUB_RUN_ID"},
+		{key: "GitHubRunAttempt", env: "GITHUB_RUN_ATTEMPT"},
+		{key: "GitHubRepository", env: "GITHUB_REPOSITORY"},
+		{key: "GitHubWorkflow", env: "GITHUB_WORKFLOW"},
+		{key: "GitHubJob", env: "GITHUB_JOB"},
+		{key: "GitHubRefName", env: "GITHUB_REF_NAME"},
+	} {
+		if value := strings.TrimSpace(os.Getenv(tag.env)); value != "" {
+			args = append(args, tag.key+"="+value)
+		}
+	}
+	args = append(args, "--output", "none")
+
+	cmd, cancel := azureCommandWithTimeout(azureCLICommandTimeout, args...)
+	defer cancel()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("az group create %s: %w", r.resourceGroupName, err)
+	}
+	return nil
+}
+
+func (r *AzureRegion) recordResourceGroupForCI() error {
+	recordFile := strings.TrimSpace(os.Getenv(envAzureResourceGroupsFile))
+	if recordFile == "" || r.resourceGroupName == "" {
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(recordFile), 0755); err != nil {
+		return fmt.Errorf("create parent directory for %s: %w", recordFile, err)
+	}
+	file, err := os.OpenFile(recordFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", recordFile, err)
+	}
+	defer file.Close()
+
+	if _, err := fmt.Fprintln(file, r.resourceGroupName); err != nil {
+		return fmt.Errorf("write %s: %w", recordFile, err)
+	}
+	return nil
+}
+
+func (r *AzureRegion) validateGeneratedNames() error {
+	for _, cfg := range r.clusterConfigs {
+		nodeResourceGroup := fmt.Sprintf("MC_%s_%s_%s", r.resourceGroupName, cfg.ClusterName, cfg.Region)
+		if len(nodeResourceGroup) > azureMaxNodeRGNameLength {
+			return fmt.Errorf("generated AKS node resource group name %q is %d characters; max is %d; lower %s",
+				nodeResourceGroup, len(nodeResourceGroup), azureMaxNodeRGNameLength, envAzureResourcePrefix)
+		}
+	}
+	return nil
+}
+
+func (r *AzureRegion) createVNetAndSubnet(cfg *azureClusterConfig) error {
+	cmd, cancel := azureCommandWithTimeout(azureCLICommandTimeout, "network", "vnet", "create",
+		"--resource-group", r.resourceGroupName,
+		"--name", cfg.VNetName,
+		"--location", cfg.Region,
+		"--address-prefix", cfg.VNetCIDR,
+		"--subnet-name", cfg.SubnetName,
+		"--subnet-prefix", cfg.SubnetCIDR,
+		"--subscription", azureSubscriptionID(),
+		"--output", "none",
+	)
+	defer cancel()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("az network vnet create %s: %w", cfg.VNetName, err)
+	}
+	return nil
+}
+
+func (r *AzureRegion) createAKSClusters(t *testing.T) error {
+	for i, clusterName := range r.Clusters {
+		cfg := r.clusterConfigs[i]
+		t.Logf("[%s] Creating AKS cluster %s in %s", ProviderAzure, clusterName, cfg.Region)
+		if err := createAKSCluster(t, r.resourceGroupName, cfg, r.NodeCount); err != nil {
+			return err
+		}
+		if err := UpdateKubeconfigAzure(t, r.resourceGroupName, clusterName, clusterName); err != nil {
+			return err
+		}
+		k8sClient, err := clientForContext(clusterName)
+		if err != nil {
+			return err
+		}
+		r.Clients[clusterName] = k8sClient
+		r.CorednsClusterOptions[operator.CustomDomains[i]] = coredns.CoreDNSClusterOption{
+			IPs:       []string{"127.0.0.1"},
+			Namespace: r.Namespace[clusterName],
+			Domain:    operator.CustomDomains[i],
+		}
+	}
+	return nil
+}
+
+func createAKSCluster(t *testing.T, resourceGroup string, cfg azureClusterConfig, nodeCount int) error {
+	subnetID, err := azureSubnetID(resourceGroup, cfg.VNetName, cfg.SubnetName)
+	if err != nil {
+		return fmt.Errorf("get subnet ID for %s: %w", cfg.SubnetName, err)
+	}
+
+	maxCount := nodeCount + 1
+	if maxCount < 2 {
+		maxCount = 2
+	}
+
+	args := []string{
+		"aks", "create",
+		"--resource-group", resourceGroup,
+		"--name", cfg.ClusterName,
+		"--location", cfg.Region,
+		"--subscription", azureSubscriptionID(),
+		"--node-count", fmt.Sprint(nodeCount),
+		"--node-vm-size", azureNodeVMSize(),
+		"--network-plugin", "azure",
+		"--vnet-subnet-id", subnetID,
+		"--service-cidr", cfg.ServiceCIDR,
+		"--dns-service-ip", cfg.DNSServiceIP,
+		"--max-pods", fmt.Sprint(azureDefaultMaxPods),
+		"--enable-cluster-autoscaler",
+		"--min-count", fmt.Sprint(nodeCount),
+		"--max-count", fmt.Sprint(maxCount),
+		"--generate-ssh-keys",
+		"--output", "none",
+	}
+
+	t.Logf("[%s] Running az %s", ProviderAzure, strings.Join(args, " "))
+	var lastErr error
+	for attempt := 1; attempt <= azureAKSCreateAttempts; attempt++ {
+		cmd, cancel := azureCommandWithTimeout(azureAKSCreateTimeout, args...)
+		out, err := cmd.CombinedOutput()
+		cancel()
+		if len(out) > 0 {
+			t.Logf("[%s] az aks create %s output:\n%s", ProviderAzure, cfg.ClusterName, string(out))
+		}
+		if err == nil {
+			return nil
+		}
+
+		lastErr = fmt.Errorf("az aks create %s: %w", cfg.ClusterName, err)
+		if !isTransientAzureCLIError(err, out) {
+			return lastErr
+		}
+
+		t.Logf("[%s] az aks create %s hit a transient Azure CLI transport error on attempt %d/%d: %v",
+			ProviderAzure, cfg.ClusterName, attempt, azureAKSCreateAttempts, err)
+		if waitErr := waitForAKSClusterReadyAfterCreateError(t, resourceGroup, cfg.ClusterName); waitErr == nil {
+			t.Logf("[%s] AKS cluster %s reached Succeeded after transient create error",
+				ProviderAzure, cfg.ClusterName)
+			return nil
+		} else {
+			t.Logf("[%s] AKS cluster %s was not ready after transient create error: %v",
+				ProviderAzure, cfg.ClusterName, waitErr)
+		}
+
+		if attempt < azureAKSCreateAttempts {
+			time.Sleep(30 * time.Second)
+		}
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return nil
+}
+
+func waitForAKSClusterReadyAfterCreateError(t *testing.T, resourceGroup, clusterName string) error {
+	var lastErr error
+	for attempt := 1; attempt <= azureAKSCreatePollAttempts; attempt++ {
+		state, err := azureAKSProvisioningState(resourceGroup, clusterName)
+		if err == nil {
+			switch state {
+			case "Succeeded":
+				return nil
+			case "Failed", "Canceled":
+				return fmt.Errorf("AKS cluster %s provisioning state is %s", clusterName, state)
+			case "":
+				lastErr = fmt.Errorf("AKS cluster %s returned empty provisioning state", clusterName)
+			default:
+				lastErr = fmt.Errorf("AKS cluster %s provisioning state is %s", clusterName, state)
+				t.Logf("[%s] Waiting for AKS cluster %s after transient create error; state=%s",
+					ProviderAzure, clusterName, state)
+			}
+		} else {
+			lastErr = err
+			if isAzureResourceNotFoundError(err) {
+				return err
+			}
+			t.Logf("[%s] Waiting for AKS cluster %s after transient create error; show failed: %v",
+				ProviderAzure, clusterName, err)
+		}
+
+		time.Sleep(azureAKSCreatePollInterval)
+	}
+	if lastErr == nil {
+		return fmt.Errorf("AKS cluster %s did not become visible", clusterName)
+	}
+	return lastErr
+}
+
+func azureAKSProvisioningState(resourceGroup, clusterName string) (string, error) {
+	cmd, cancel := azureCommandWithTimeout(azureCLICommandTimeout, "aks", "show",
+		"--resource-group", resourceGroup,
+		"--name", clusterName,
+		"--subscription", azureSubscriptionID(),
+		"--query", "provisioningState",
+		"--output", "tsv",
+	)
+	out, err := cmd.CombinedOutput()
+	cancel()
+	if err != nil {
+		return "", fmt.Errorf("az aks show %s: %w: %s", clusterName, err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func isTransientAzureCLIError(err error, output []byte) bool {
+	if err == nil {
+		return false
+	}
+	errText := err.Error() + "\n" + string(output)
+	for _, marker := range []string{
+		"UNEXPECTED_EOF_WHILE_READING",
+		"EOF occurred in violation of protocol",
+		"Certificate verification failed",
+		"Connection aborted",
+		"connection reset",
+		"context deadline exceeded",
+		"timed out",
+		"TLS/SSL connection has been closed",
+		"unexpected EOF",
+	} {
+		if strings.Contains(errText, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func isAzureResourceNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errText := err.Error()
+	return strings.Contains(errText, "ResourceNotFound") ||
+		strings.Contains(errText, "could not be found") ||
+		strings.Contains(errText, "was not found")
+}
+
+func (r *AzureRegion) setupVNetPeering(t *testing.T) error {
+	if len(r.clusterConfigs) < 2 {
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, len(r.clusterConfigs)*len(r.clusterConfigs))
+
+	for i := range r.clusterConfigs {
+		for j := range r.clusterConfigs {
+			if i == j {
+				continue
+			}
+			sourceIndex, remoteIndex := i, j
+			source := r.clusterConfigs[i]
+			remote := r.clusterConfigs[j]
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				remoteVNetID, err := azureVNetID(r.resourceGroupName, remote.VNetName)
+				if err != nil {
+					errs <- fmt.Errorf("get remote VNet ID for %s: %w", remote.VNetName, err)
+					return
+				}
+				peeringName := fmt.Sprintf("peer-%d-to-%d", sourceIndex, remoteIndex)
+				if err := createAzureVNetPeering(r.resourceGroupName, source.VNetName, peeringName, remoteVNetID); err != nil {
+					errs <- fmt.Errorf("create VNet peering %s/%s: %w", source.VNetName, peeringName, err)
+				}
+			}()
+		}
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	t.Logf("[%s] VNet peering setup complete", ProviderAzure)
+	return nil
+}
+
+func (r *AzureRegion) deployAndConfigureCoreDNS(t *testing.T, kubeConfigPath string) error {
+	if len(r.Clusters) > 1 {
+		for i, clusterName := range r.Clusters {
+			kubectlOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, coreDNSNamespace)
+			if err := applyAzureCoreDNSService(t, kubectlOpts); err != nil {
+				return fmt.Errorf("apply CoreDNS service for %s: %w", clusterName, err)
+			}
+			actualIPs, err := WaitForCoreDNSServiceIPs(t, kubectlOpts)
+			if err != nil {
+				return fmt.Errorf("get CoreDNS service IPs for %s: %w", clusterName, err)
+			}
+			r.CorednsClusterOptions[operator.CustomDomains[i]] = coredns.CoreDNSClusterOption{
+				IPs:       actualIPs,
+				Namespace: r.Namespace[clusterName],
+				Domain:    operator.CustomDomains[i],
+			}
+		}
+
+		UpdateCoreDNSConfiguration(t, r.Region, kubeConfigPath)
+		return nil
+	}
+
+	for i, clusterName := range r.Clusters {
+		kubectlOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, coreDNSNamespace)
+		if err := applyAzureCoreDNSCustom(t, kubectlOpts, operator.CustomDomains[i], r.CorednsClusterOptions); err != nil {
+			return fmt.Errorf("apply coredns-custom for %s: %w", clusterName, err)
+		}
+		if err := restartAzureCoreDNS(t, kubectlOpts, clusterName); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func restartAzureCoreDNS(t *testing.T, kubectlOpts *k8s.KubectlOptions, clusterName string) error {
+	if err := runAzureKubernetesActionWithRetry(t, fmt.Sprintf("restart AKS CoreDNS for %s", clusterName), func() error {
+		return k8s.RunKubectlE(t, kubectlOpts, "rollout", "restart", "deployment", coreDNSDeploymentName)
+	}); err != nil {
+		return fmt.Errorf("restart AKS CoreDNS for %s: %w", clusterName, err)
+	}
+	if err := runAzureKubernetesActionWithRetry(t, fmt.Sprintf("wait for AKS CoreDNS rollout for %s", clusterName), func() error {
+		return k8s.RunKubectlE(t, kubectlOpts, "rollout", "status", "deployment", coreDNSDeploymentName, "--timeout=3m")
+	}); err != nil {
+		return fmt.Errorf("wait for AKS CoreDNS rollout for %s: %w", clusterName, err)
+	}
+	return nil
+}
+
+func applyAzureCoreDNSCustom(
+	t *testing.T, kubectlOpts *k8s.KubectlOptions, thisDomain string,
+	allClusters map[string]coredns.CoreDNSClusterOption,
+) error {
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "coredns-custom",
+			Namespace: coreDNSNamespace,
+		},
+		Data: buildAzureCoreDNSCustomData(thisDomain, allClusters),
+	}
+	if err := kubectlApplyAzureManifest(t, kubectlOpts, coredns.ToYAML(t, cm)); err != nil {
+		return fmt.Errorf("kubectl apply coredns-custom: %w", err)
+	}
+	return nil
+}
+
+func buildAzureCoreDNSCustomData(
+	thisDomain string, allClusters map[string]coredns.CoreDNSClusterOption,
+) map[string]string {
+	data := map[string]string{}
+
+	quotedDomain := regexp.QuoteMeta(thisDomain)
+	data["rewrite.override"] = fmt.Sprintf(`rewrite continue {
+    name regex ^(.+)\.%s\.?$ {1}.cluster.local
+    answer name ^(.+)\.cluster\.local\.?$ {1}.%s
+    answer value ^(.+)\.cluster\.local\.?$ {1}.%s
+}`, quotedDomain, thisDomain, thisDomain)
+
+	domains := make([]string, 0, len(allClusters))
+	for domain := range allClusters {
+		domains = append(domains, domain)
+	}
+	sort.Strings(domains)
+
+	for _, clusterDomain := range domains {
+		if clusterDomain == thisDomain {
+			continue
+		}
+		cluster := allClusters[clusterDomain]
+		if len(cluster.IPs) == 0 {
+			continue
+		}
+
+		ips := append([]string{}, cluster.IPs...)
+		sort.Strings(ips)
+		ipList := strings.Join(ips, " ")
+		serverBlock := func(host string) string {
+			return fmt.Sprintf(`%s:53 {
+    errors
+    ready
+    cache 30
+    forward . %s {
+        force_tcp
+    }
+}
+`, host, ipList)
+		}
+
+		data[fmt.Sprintf("%s.server", clusterDomain)] = serverBlock(clusterDomain)
+		if cluster.Namespace != "" {
+			data[fmt.Sprintf("%s.svc.%s.server", cluster.Namespace, clusterDomain)] =
+				serverBlock(fmt.Sprintf("%s.svc.%s", cluster.Namespace, clusterDomain))
+			data[fmt.Sprintf("%s.pod.%s.server", cluster.Namespace, clusterDomain)] =
+				serverBlock(fmt.Sprintf("%s.pod.%s", cluster.Namespace, clusterDomain))
+		}
+	}
+
+	return data
+}
+
+func applyAzureCoreDNSService(t *testing.T, kubectlOpts *k8s.KubectlOptions) error {
+	annotations := GetLoadBalancerAnnotations(ProviderAzure)
+	annotationCopy := make(map[string]string, len(annotations))
+	for key, value := range annotations {
+		annotationCopy[key] = value
+	}
+
+	svc := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        coreDNSServiceName,
+			Namespace:   coreDNSNamespace,
+			Annotations: annotationCopy,
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "dns-tcp",
+					Port:       53,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(53),
+				},
+			},
+			Selector: detectAzureCoreDNSPodLabel(t, kubectlOpts),
+		},
+	}
+
+	if err := kubectlApplyAzureManifest(t, kubectlOpts, coredns.ToYAML(t, svc)); err != nil {
+		return fmt.Errorf("kubectl apply %s: %w", coreDNSServiceName, err)
+	}
+	return nil
+}
+
+func kubectlApplyAzureManifest(t *testing.T, kubectlOpts *k8s.KubectlOptions, manifest string) error {
+	t.Helper()
+
+	manifestFile := filepath.Join(t.TempDir(), "manifest.yaml")
+	if err := os.WriteFile(manifestFile, []byte(manifest), 0600); err != nil {
+		return err
+	}
+
+	return runAzureKubernetesActionWithRetry(t, "kubectl apply Azure manifest", func() error {
+		return k8s.RunKubectlE(t, kubectlOpts, "apply", "--validate=false", "-f", manifestFile)
+	})
+}
+
+func runAzureKubernetesActionWithRetry(t *testing.T, description string, action func() error) error {
+	t.Helper()
+
+	var err error
+	for attempt := 1; attempt <= azureKubernetesAttempts; attempt++ {
+		err = action()
+		if err == nil {
+			return nil
+		}
+		if !isTransientAzureKubernetesError(err) || attempt == azureKubernetesAttempts {
+			return err
+		}
+		t.Logf("[%s] %s hit a transient Kubernetes API error on attempt %d/%d: %v",
+			ProviderAzure, description, attempt, azureKubernetesAttempts, err)
+		time.Sleep(azureKubernetesRetrySleep)
+	}
+	return err
+}
+
+func isTransientAzureKubernetesError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errText := err.Error()
+	for _, marker := range []string{
+		"Bad Gateway",
+		"Client.Timeout",
+		"EOF",
+		"failed to download openapi",
+		"http2: client connection lost",
+		"IncompleteCertChain",
+		"net/http: request canceled",
+		"request canceled",
+		"SSL_INCOMPLETE_CHAIN",
+		"TLS handshake timeout",
+		"connection reset",
+		"context deadline exceeded",
+		"i/o timeout",
+		"server was unable to return a response",
+		"unexpected EOF",
+	} {
+		if strings.Contains(errText, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func detectAzureCoreDNSPodLabel(t *testing.T, kubectlOpts *k8s.KubectlOptions) map[string]string {
+	for _, label := range []string{"kube-dns", "coredns"} {
+		output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOpts,
+			"get", "pods", "-l", fmt.Sprintf("k8s-app=%s", label), "--no-headers", "-o", "name")
+		if err != nil {
+			t.Logf("[%s] warning: failed to detect AKS CoreDNS pods with k8s-app=%s: %v",
+				ProviderAzure, label, err)
+			continue
+		}
+		if strings.TrimSpace(output) != "" {
+			t.Logf("[%s] Detected AKS CoreDNS pod label k8s-app=%s", ProviderAzure, label)
+			return map[string]string{"k8s-app": label}
+		}
+	}
+	t.Logf("[%s] warning: defaulting AKS CoreDNS selector to k8s-app=kube-dns", ProviderAzure)
+	return map[string]string{"k8s-app": "kube-dns"}
+}
+
+func UpdateKubeconfigAzure(t *testing.T, resourceGroup, clusterName, alias string) error {
+	args := []string{
+		"aks", "get-credentials",
+		"--resource-group", resourceGroup,
+		"--name", clusterName,
+		"--subscription", azureSubscriptionID(),
+		"--context", alias,
+		"--overwrite-existing",
+	}
+	if kubeconfig := os.Getenv("KUBECONFIG"); kubeconfig != "" {
+		args = append(args, "--file", kubeconfig)
+	}
+
+	cmd, cancel := azureCommandWithTimeout(azureCLICommandTimeout, args...)
+	defer cancel()
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("[%s] az aks get-credentials output:\n%s", ProviderAzure, string(output))
+		return fmt.Errorf("get credentials for AKS cluster %s: %w", clusterName, err)
+	}
+
+	if err := EnsureKubeconfigTLSVerificationDisabled(t, []string{alias, clusterName}); err != nil {
+		return fmt.Errorf("disable kubeconfig TLS verification for %s: %w", clusterName, err)
+	}
+	if err := addKubeAPIServerToNoProxy(t, alias, clusterName); err != nil {
+		return fmt.Errorf("add AKS API server to NO_PROXY for %s: %w", clusterName, err)
+	}
+	return nil
+}
+
+func addKubeAPIServerToNoProxy(t *testing.T, contextName, clusterName string) error {
+	t.Helper()
+
+	kubeConfigPath := strings.TrimSpace(os.Getenv("KUBECONFIG"))
+	if kubeConfigPath == "" {
+		var err error
+		kubeConfigPath, err = k8s.KubeConfigPathFromHomeDirE()
+		if err != nil {
+			return fmt.Errorf("resolve kubeconfig path: %w", err)
+		}
+	}
+	rawConfig, err := clientcmd.LoadFromFile(kubeConfigPath)
+	if err != nil {
+		return fmt.Errorf("load kubeconfig %s: %w", kubeConfigPath, err)
+	}
+
+	clusterRef := clusterName
+	if context, ok := rawConfig.Contexts[contextName]; ok && context.Cluster != "" {
+		clusterRef = context.Cluster
+	}
+	cluster, ok := rawConfig.Clusters[clusterRef]
+	if !ok {
+		cluster, ok = rawConfig.Clusters[contextName]
+	}
+	if !ok {
+		cluster, ok = rawConfig.Clusters[clusterName]
+	}
+	if !ok {
+		return fmt.Errorf("cluster entry not found for context %s", contextName)
+	}
+
+	serverURL, err := url.Parse(strings.TrimSpace(cluster.Server))
+	if err != nil {
+		return fmt.Errorf("parse AKS API server URL %q: %w", cluster.Server, err)
+	}
+	host := serverURL.Hostname()
+	if host == "" {
+		return fmt.Errorf("AKS API server URL %q has no host", cluster.Server)
+	}
+
+	addHostToNoProxy(host)
+	t.Logf("[%s] Added AKS API server %s to NO_PROXY", ProviderAzure, host)
+	return nil
+}
+
+func addHostToNoProxy(host string) {
+	for _, envName := range []string{"NO_PROXY", "no_proxy"} {
+		current := strings.TrimSpace(os.Getenv(envName))
+		if current == "*" {
+			continue
+		}
+
+		entries := make([]string, 0)
+		found := false
+		for _, entry := range strings.Split(current, ",") {
+			entry = strings.TrimSpace(entry)
+			if entry == "" {
+				continue
+			}
+			if entry == host {
+				found = true
+			}
+			entries = append(entries, entry)
+		}
+		if !found {
+			entries = append(entries, host)
+		}
+		_ = os.Setenv(envName, strings.Join(entries, ","))
+	}
+}
+
+func azureSubnetID(resourceGroup, vnetName, subnetName string) (string, error) {
+	cmd, cancel := azureCommandWithTimeout(azureCLICommandTimeout, "network", "vnet", "subnet", "show",
+		"--resource-group", resourceGroup,
+		"--vnet-name", vnetName,
+		"--name", subnetName,
+		"--subscription", azureSubscriptionID(),
+		"--query", "id",
+		"--output", "tsv",
+	)
+	defer cancel()
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("az network vnet subnet show %s/%s: %w", vnetName, subnetName, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func azureVNetID(resourceGroup, vnetName string) (string, error) {
+	cmd, cancel := azureCommandWithTimeout(azureCLICommandTimeout, "network", "vnet", "show",
+		"--resource-group", resourceGroup,
+		"--name", vnetName,
+		"--subscription", azureSubscriptionID(),
+		"--query", "id",
+		"--output", "tsv",
+	)
+	defer cancel()
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("az network vnet show %s: %w", vnetName, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func createAzureVNetPeering(resourceGroup, vnetName, peeringName, remoteVNetID string) error {
+	cmd, cancel := azureCommandWithTimeout(azureCLICommandTimeout, "network", "vnet", "peering", "create",
+		"--resource-group", resourceGroup,
+		"--name", peeringName,
+		"--vnet-name", vnetName,
+		"--remote-vnet", remoteVNetID,
+		"--subscription", azureSubscriptionID(),
+		"--allow-vnet-access",
+		"--allow-forwarded-traffic",
+		"--output", "none",
+	)
+	defer cancel()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func clientForContext(contextName string) (client.Client, error) {
+	cfg, err := config.GetConfigWithContext(contextName)
+	if err != nil {
+		return nil, fmt.Errorf("get REST config for %s: %w", contextName, err)
+	}
+	k8sClient, err := client.New(cfg, client.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("create Kubernetes client for %s: %w", contextName, err)
+	}
+	return k8sClient, nil
+}
+
+func ensureAzureLogin(t *testing.T, subscriptionID string) error {
+	clientID := strings.TrimSpace(os.Getenv(envAzureClientID))
+	clientSecret := strings.TrimSpace(os.Getenv(envAzureClientSecret))
+	tenantID := strings.TrimSpace(os.Getenv(envAzureTenantID))
+
+	if clientID != "" || clientSecret != "" || tenantID != "" {
+		if clientID == "" || clientSecret == "" || tenantID == "" {
+			return fmt.Errorf("%s, %s, and %s must be set together for service principal auth",
+				envAzureClientID, envAzureClientSecret, envAzureTenantID)
+		}
+		t.Logf("[%s] Authenticating az CLI with service principal in tenant %s", ProviderAzure, tenantID)
+		cmd, cancel := azureCommandWithTimeout(azureCLICommandTimeout, "login",
+			"--service-principal",
+			"--username", clientID,
+			"--password", clientSecret,
+			"--tenant", tenantID,
+		)
+		output, err := cmd.CombinedOutput()
+		cancel()
+		if err != nil {
+			t.Logf("[%s] az login output:\n%s", ProviderAzure, string(output))
+			return fmt.Errorf("az login failed: %w", err)
+		}
+	} else {
+		t.Logf("[%s] Using existing az CLI login session", ProviderAzure)
+	}
+
+	cmd, cancel := azureCommandWithTimeout(azureCLICommandTimeout, "account", "set",
+		"--subscription", subscriptionID)
+	out, err := cmd.CombinedOutput()
+	cancel()
+	if err != nil {
+		t.Logf("[%s] az account set output:\n%s", ProviderAzure, string(out))
+		return fmt.Errorf("az account set %s: %w", subscriptionID, err)
+	}
+	cmd, cancel = azureCommandWithTimeout(azureCLICommandTimeout, "account", "show",
+		"--subscription", subscriptionID, "--output", "none")
+	out, err = cmd.CombinedOutput()
+	cancel()
+	if err != nil {
+		t.Logf("[%s] az account show output:\n%s", ProviderAzure, string(out))
+		return fmt.Errorf("az account show %s: %w", subscriptionID, err)
+	}
+	return nil
+}
+
+func mustAzureEnv(t *testing.T, envName string) string {
+	t.Helper()
+	value := strings.TrimSpace(os.Getenv(envName))
+	if value == "" {
+		t.Fatalf("[%s] required environment variable %s is not set", ProviderAzure, envName)
+	}
+	return value
+}
+
+func azureSubscriptionID() string {
+	return strings.TrimSpace(os.Getenv(envAzureSubscriptionID))
+}
+
+func azureResourcePrefix() string {
+	if prefix := strings.TrimSpace(os.Getenv(envAzureResourcePrefix)); prefix != "" {
+		return prefix
+	}
+	return azureDefaultResourcePrefix
+}
+
+func azureNodeVMSize() string {
+	if size := strings.TrimSpace(os.Getenv(envAzureNodeVMSize)); size != "" {
+		return size
+	}
+	return azureDefaultNodeVMSize
+}
+
+func azureReuseContexts(t *testing.T, clusterCount int) []string {
+	t.Helper()
+	reuseContexts := strings.TrimSpace(os.Getenv(envAzureReuseContexts))
+	if reuseContexts == "" {
+		return nil
+	}
+	contexts := filepath.SplitList(reuseContexts)
+	if len(contexts) != clusterCount {
+		t.Fatalf("[%s] %s must contain %d context names, got %d",
+			ProviderAzure, envAzureReuseContexts, clusterCount, len(contexts))
+	}
+	return contexts
+}
+
+var _ CloudProvider = (*AzureRegion)(nil)
+var _ encryption.Provider = (*AzureRegion)(nil)

--- a/tests/e2e/operator/infra/azure_runtime.go
+++ b/tests/e2e/operator/infra/azure_runtime.go
@@ -1,0 +1,43 @@
+package infra
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+)
+
+const azureDefaultClusterDomain = "cluster.local"
+
+type azureRuntime struct{}
+
+func (azureRuntime) ChartCloudProvider(provider string) string {
+	return provider
+}
+
+func (azureRuntime) ClusterDomain(_ *operator.Region, index int) string {
+	if domain, ok := operator.CustomDomains[index]; ok {
+		return domain
+	}
+	return azureDefaultClusterDomain
+}
+
+func (azureRuntime) PatchHelmValues(values map[string]string) map[string]string {
+	if values == nil {
+		values = make(map[string]string)
+	}
+	values["cockroachdb.crdbCluster.podTemplate.spec.terminationGracePeriodSeconds"] = "30"
+	return values
+}
+
+func (azureRuntime) ConfigureNamespace(_ *testing.T, _ *k8s.KubectlOptions, _ string) {
+}
+
+func (azureRuntime) HelmDeleteArgs(args []string) []string {
+	return args
+}
+
+func (azureRuntime) CleanupNamespace(_ *testing.T, _ *k8s.KubectlOptions, _ string) {
+}
+
+var _ operator.ProviderRuntime = azureRuntime{}

--- a/tests/e2e/operator/infra/common.go
+++ b/tests/e2e/operator/infra/common.go
@@ -23,6 +23,7 @@ const (
 	ProviderGCP       = "gcp"
 	ProviderAWS       = "aws"
 	ProviderOpenShift = "openshift"
+	ProviderAzure     = "azure"
 )
 
 // Common constants.
@@ -57,6 +58,7 @@ var RegionCodes = map[string][]string{
 	ProviderGCP:       {"us-central1", "us-east1"},
 	ProviderAWS:       {"us-east-1", "us-east-2"},
 	ProviderOpenShift: {"us-central1", "us-east1"},
+	ProviderAzure:     {"eastus", "westus2"},
 }
 
 // LoadBalancerAnnotations contains provider-specific service annotations.
@@ -70,6 +72,9 @@ var LoadBalancerAnnotations = map[string]map[string]string{
 		"service.beta.kubernetes.io/aws-load-balancer-type":     "nlb",
 		"service.beta.kubernetes.io/aws-load-balancer-internal": "true",
 	},
+	ProviderAzure: {
+		"service.beta.kubernetes.io/azure-load-balancer-internal": "true",
+	},
 	ProviderK3D:       {},
 	ProviderKind:      {},
 	ProviderOpenShift: {},
@@ -77,6 +82,20 @@ var LoadBalancerAnnotations = map[string]map[string]string{
 
 // NetworkConfigs defines standard network configurations for each provider and region.
 var NetworkConfigs = map[string]map[string]interface{}{
+	ProviderAzure: {
+		"eastus": map[string]string{
+			"VNetCIDR":     "10.10.0.0/16",
+			"SubnetCIDR":   "10.10.0.0/24",
+			"ServiceCIDR":  "172.28.17.0/24",
+			"DNSServiceIP": "172.28.17.10",
+		},
+		"westus2": map[string]string{
+			"VNetCIDR":     "10.20.0.0/16",
+			"SubnetCIDR":   "10.20.0.0/24",
+			"ServiceCIDR":  "172.28.49.0/24",
+			"DNSServiceIP": "172.28.49.10",
+		},
+	},
 	ProviderGCP: {
 		"us-central1": map[string]string{
 			"ClusterCIDR": "172.28.0.0/20",
@@ -344,19 +363,31 @@ func UpdateCoreDNSConfiguration(t *testing.T, r *operator.Region, kubeConfigPath
 	for i, clusterName := range r.Clusters {
 		kubectlOpts := k8s.NewKubectlOptions(clusterName, kubeConfigPath, coreDNSNamespace)
 
-		// Create and apply the updated CoreDNS ConfigMap with complete cluster information
-		cm := coredns.CoreDNSConfigMap(operator.CustomDomains[i], r.CorednsClusterOptions)
-		cmYAML := coredns.ToYAML(t, cm)
-		if err := k8s.KubectlApplyFromStringE(t, kubectlOpts, cmYAML); err != nil {
-			require.NoError(t, err, "failed to update CoreDNS ConfigMap for cluster %s", clusterName)
+		if r.Provider == ProviderAzure {
+			if err := applyAzureCoreDNSCustom(t, kubectlOpts, operator.CustomDomains[i], r.CorednsClusterOptions); err != nil {
+				require.NoError(t, err, "failed to update AKS coredns-custom ConfigMap for cluster %s", clusterName)
+			}
+		} else {
+			// Create and apply the updated CoreDNS ConfigMap with complete cluster information
+			cm := coredns.CoreDNSConfigMap(operator.CustomDomains[i], r.CorednsClusterOptions)
+			cmYAML := coredns.ToYAML(t, cm)
+			if err := k8s.KubectlApplyFromStringE(t, kubectlOpts, cmYAML); err != nil {
+				require.NoError(t, err, "failed to update CoreDNS ConfigMap for cluster %s", clusterName)
+			}
 		}
 
-		// Restart CoreDNS to pick up the updated configuration
-		if err := k8s.RunKubectlE(t, kubectlOpts, "rollout", "restart", "deployment", coreDNSDeploymentName); err != nil {
-			require.NoError(t, err, "failed to restart CoreDNS deployment for cluster %s", clusterName)
-		}
-		if err := k8s.RunKubectlE(t, kubectlOpts, "rollout", "status", "deployment", coreDNSDeploymentName, "--timeout=3m"); err != nil {
-			require.NoError(t, err, "CoreDNS deployment did not finish rolling out for cluster %s", clusterName)
+		// Restart CoreDNS to pick up the updated configuration.
+		if r.Provider == ProviderAzure {
+			if err := restartAzureCoreDNS(t, kubectlOpts, clusterName); err != nil {
+				require.NoError(t, err, "failed to restart or wait for CoreDNS deployment for cluster %s", clusterName)
+			}
+		} else {
+			if err := k8s.RunKubectlE(t, kubectlOpts, "rollout", "restart", "deployment", coreDNSDeploymentName); err != nil {
+				require.NoError(t, err, "failed to restart CoreDNS deployment for cluster %s", clusterName)
+			}
+			if err := k8s.RunKubectlE(t, kubectlOpts, "rollout", "status", "deployment", coreDNSDeploymentName, "--timeout=3m"); err != nil {
+				require.NoError(t, err, "CoreDNS deployment did not finish rolling out for cluster %s", clusterName)
+			}
 		}
 
 		t.Logf("[%s] Updated CoreDNS configuration for cluster %s with namespace %s", r.Provider, clusterName, r.Namespace[clusterName])

--- a/tests/e2e/operator/infra/provider.go
+++ b/tests/e2e/operator/infra/provider.go
@@ -34,7 +34,7 @@ type CloudProvider interface {
 func ResolveProvider(t *testing.T) string {
 	if p := strings.TrimSpace(strings.ToLower(os.Getenv("PROVIDER"))); p != "" {
 		switch p {
-		case ProviderK3D, ProviderKind, ProviderGCP, ProviderAWS, ProviderOpenShift:
+		case ProviderK3D, ProviderKind, ProviderGCP, ProviderAWS, ProviderOpenShift, ProviderAzure:
 			return p
 		default:
 			t.Fatalf("Unsupported provider override: %s", p)
@@ -70,6 +70,11 @@ func ProviderFactory(providerType string, region *operator.Region) CloudProvider
 		p := OpenShiftRegion{Region: region}
 		p.RegionCodes = GetRegionCodes(providerType)
 		region.SetProviderRuntime(openShiftRuntime{})
+		cp = &p
+	case ProviderAzure:
+		p := AzureRegion{Region: region}
+		p.RegionCodes = GetRegionCodes(providerType)
+		region.SetProviderRuntime(azureRuntime{})
 		cp = &p
 	default:
 		return nil

--- a/tests/e2e/operator/multiRegion/cockroachdb_multi_region_advanced_features_test.go
+++ b/tests/e2e/operator/multiRegion/cockroachdb_multi_region_advanced_features_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/testutil"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
@@ -61,7 +62,7 @@ func (r *multiRegion) TestWALFailoverMultiRegion(t *testing.T) {
 	kubeConfig, _ := r.GetCurrentContext(t)
 	kubectlOptions1 := k8s.NewKubectlOptions(cluster1, kubeConfig, r.Namespace[cluster1])
 
-	pods := k8s.ListPods(t, kubectlOptions1, metav1.ListOptions{
+	pods := testutil.ListPodsWithRetry(t, kubectlOptions1, metav1.ListOptions{
 		LabelSelector: operator.LabelSelector,
 	})
 	require.True(t, len(pods) > 0, "No CockroachDB pods found in region 1")
@@ -111,7 +112,7 @@ func (r *multiRegion) TestEncryptionAtRestMultiRegion(t *testing.T) {
 	kubeConfig, _ := r.GetCurrentContext(t)
 	kubectlOptions1 := k8s.NewKubectlOptions(cluster1, kubeConfig, r.Namespace[cluster1])
 
-	pods := k8s.ListPods(t, kubectlOptions1, metav1.ListOptions{
+	pods := testutil.ListPodsWithRetry(t, kubectlOptions1, metav1.ListOptions{
 		LabelSelector: operator.LabelSelector,
 	})
 	require.True(t, len(pods) > 0, "No CockroachDB pods found in region 1")

--- a/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
+++ b/tests/e2e/operator/multiRegion/cockroachdb_multi_region_e2e_test.go
@@ -188,7 +188,7 @@ func (r *multiRegion) TestHelmUpgrade(t *testing.T) {
 			},
 		}
 		// Apply Helm upgrade with updated values.
-		helm.Upgrade(t, options, helmChartPath, operator.ReleaseName)
+		operator.HelmUpgradeWithRetry(t, options, helmChartPath, operator.ReleaseName)
 
 		crdbCluster := testutil.CockroachCluster{
 			DesiredNodes: r.NodeCount,
@@ -251,10 +251,10 @@ func (r *multiRegion) TestClusterRollingRestart(t *testing.T) {
 				"upgrade": {"--reuse-values", "--set", fmt.Sprintf("cockroachdb.crdbCluster.timestamp=%s", upgradeTime.Format(time.RFC3339))},
 			},
 		}
-		helm.Upgrade(t, options, helmChartPath, operator.ReleaseName)
+		operator.HelmUpgradeWithRetry(t, options, helmChartPath, operator.ReleaseName)
 
 		// Get the initial timestamp of the pods before the upgrade.
-		pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		pods := testutil.ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{
 			LabelSelector: operator.LabelSelector,
 		})
 		require.True(t, len(pods) >= 3, "Expected at least 3 pods but found %d", len(pods))
@@ -268,7 +268,7 @@ func (r *multiRegion) TestClusterRollingRestart(t *testing.T) {
 			DesiredNodes: r.NodeCount,
 		}
 		testutil.RequireCRDBClusterToBeReadyEventuallyTimeout(t, kubectlOptions, crdbCluster, 600*time.Second)
-		pods = k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		pods = testutil.ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{
 			LabelSelector: operator.LabelSelector,
 		})
 		// Verify that each pod's creation timestamp is after the upgradeTime.
@@ -317,7 +317,7 @@ func (r *multiRegion) TestKillingCockroachNode(t *testing.T) {
 	// Kill a pod in each cluster and verify the reconciliation.
 	for _, cluster := range r.Clusters {
 		kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
-		pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+		pods := testutil.ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{
 			LabelSelector: operator.LabelSelector,
 		})
 
@@ -400,7 +400,7 @@ func (r *multiRegion) TestClusterScaleUp(t *testing.T, cloudProvider infra.Cloud
 			},
 		}
 		// Apply Helm upgrade with updated values.
-		helm.Upgrade(t, options, helmChartPath, operator.ReleaseName)
+		operator.HelmUpgradeWithRetry(t, options, helmChartPath, operator.ReleaseName)
 
 		crdbCluster := testutil.CockroachCluster{
 			DesiredNodes: r.NodeCount,

--- a/tests/e2e/operator/provider_runtime.go
+++ b/tests/e2e/operator/provider_runtime.go
@@ -1,9 +1,15 @@
 package operator
 
 import (
+	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const defaultClusterDomain = "cluster.local"
@@ -62,8 +68,31 @@ func (r *Region) clusterDomain(index int) string {
 }
 
 func (r *Region) prepareNamespace(t *testing.T, kubectlOptions *k8s.KubectlOptions, namespace string) {
-	k8s.CreateNamespace(t, kubectlOptions, namespace)
+	if !r.shouldRetryKubernetesAction(kubectlOptions) {
+		k8s.CreateNamespace(t, kubectlOptions, namespace)
+		r.runtime().ConfigureNamespace(t, kubectlOptions, namespace)
+		return
+	}
+
+	_, err := retry.DoWithRetryE(t, "create namespace "+namespace, 12, 5*time.Second, func() (string, error) {
+		err := k8s.CreateNamespaceE(t, kubectlOptions, namespace)
+		if apierrors.IsAlreadyExists(err) {
+			return "", nil
+		}
+		return "", err
+	})
+	require.NoError(t, err)
 	r.runtime().ConfigureNamespace(t, kubectlOptions, namespace)
+}
+
+func (r *Region) shouldRetryKubernetesAction(opts *k8s.KubectlOptions) bool {
+	if strings.EqualFold(strings.TrimSpace(r.Provider), "azure") {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("PROVIDER")), "azure") {
+		return true
+	}
+	return opts != nil && strings.HasPrefix(opts.ContextName, "azure-")
 }
 
 func (r *Region) CockroachDBHelmValues(index int, values map[string]string) map[string]string {

--- a/tests/e2e/operator/region.go
+++ b/tests/e2e/operator/region.go
@@ -56,6 +56,22 @@ var (
 			"--debug",
 		},
 	}
+
+	transientHelmErrorMarkers = []string{
+		"Bad Gateway",
+		"Client.Timeout",
+		"EOF",
+		"retry helm install after cleaning up existing release",
+		"IncompleteCertChain",
+		"SSL_INCOMPLETE_CHAIN",
+		"TLS handshake timeout",
+		"connection reset",
+		"context deadline exceeded",
+		"could not get apiVersions",
+		"i/o timeout",
+		"server was unable to return a response",
+		"unexpected EOF",
+	}
 )
 
 type Region struct {
@@ -190,7 +206,7 @@ func (r *Region) InstallCharts(t *testing.T, cluster string, index int) {
 		ExtraArgs:      helmExtraArgs,
 	}
 
-	helm.Install(t, crdbOptions, helmChartPath, ReleaseName)
+	HelmInstallWithRetry(t, crdbOptions, helmChartPath, ReleaseName)
 
 	serviceName := "cockroachdb-public"
 	k8s.WaitUntilServiceAvailable(t, kubectlOptions, serviceName, 30, 5*time.Second)
@@ -230,7 +246,7 @@ func (r *Region) ValidateCRDB(t *testing.T, cluster string) {
 	}
 	testutil.RequireCRDBClusterToBeReadyEventuallyTimeout(t, kubectlOptions, crdbCluster, 900*time.Second)
 
-	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+	pods := testutil.ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{
 		LabelSelector: LabelSelector,
 	})
 	require.True(t, len(pods) > 0)
@@ -255,9 +271,20 @@ func (r *Region) VerifyHelmUpgrade(
 		60, 10*time.Second,
 		func() (string, error) {
 			// List the pods for the deployment.
-			pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
-				LabelSelector: LabelSelector,
-			})
+			var pods []corev1.Pod
+			if r.shouldRetryKubernetesAction(kubectlOptions) {
+				var err error
+				pods, err = k8s.ListPodsE(t, kubectlOptions, metav1.ListOptions{
+					LabelSelector: LabelSelector,
+				})
+				if err != nil {
+					return "", err
+				}
+			} else {
+				pods = k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+					LabelSelector: LabelSelector,
+				})
+			}
 
 			// Check if any pods exist.
 			if len(pods) == 0 {
@@ -381,9 +408,20 @@ func (r *Region) ValidateCRDBContainerResources(t *testing.T, kubectlOptions *k8
 	_, err := retry.DoWithRetryE(t, "waiting for container resources to be updated",
 		30, 5*time.Second,
 		func() (string, error) {
-			pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
-				LabelSelector: LabelSelector,
-			})
+			var pods []corev1.Pod
+			if r.shouldRetryKubernetesAction(kubectlOptions) {
+				var err error
+				pods, err = k8s.ListPodsE(t, kubectlOptions, metav1.ListOptions{
+					LabelSelector: LabelSelector,
+				})
+				if err != nil {
+					return "", err
+				}
+			} else {
+				pods = k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+					LabelSelector: LabelSelector,
+				})
+			}
 
 			for _, pod := range pods {
 				containers := pod.Spec.Containers
@@ -447,16 +485,33 @@ func (r *Region) GetCurrentContext(t *testing.T) (string, api.Config) {
 
 // EnsureKubeConfigPath ensures that the kubeconfig file exists and returns its path.
 func (r *Region) EnsureKubeConfigPath() (string, error) {
+	if kubeConfigPath := strings.TrimSpace(os.Getenv("KUBECONFIG")); kubeConfigPath != "" {
+		if strings.ContainsRune(kubeConfigPath, os.PathListSeparator) {
+			return kubeConfigPath, nil
+		}
+		if err := ensureKubeConfigFile(kubeConfigPath); err != nil {
+			return "", err
+		}
+		return kubeConfigPath, nil
+	}
+
 	kubeConfigPath, err := k8s.KubeConfigPathFromHomeDirE()
-	kubeConfigDir := filepath.Dir(kubeConfigPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to get kubeconfig path: %w", err)
 	}
+	if err := ensureKubeConfigFile(kubeConfigPath); err != nil {
+		return "", err
+	}
+	return kubeConfigPath, nil
+}
+
+func ensureKubeConfigFile(kubeConfigPath string) error {
+	kubeConfigDir := filepath.Dir(kubeConfigPath)
 
 	// Check if a directory exists, create if not.
 	if _, err := os.Stat(kubeConfigDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(kubeConfigDir, 0755); err != nil {
-			return "", fmt.Errorf("failed to create .kube directory: %w", err)
+			return fmt.Errorf("failed to create .kube directory: %w", err)
 		}
 	}
 
@@ -465,11 +520,10 @@ func (r *Region) EnsureKubeConfigPath() (string, error) {
 		// Create an empty kubeconfig file.
 		emptyConfig := []byte("apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []\n")
 		if err := os.WriteFile(kubeConfigPath, emptyConfig, 0644); err != nil {
-			return "", fmt.Errorf("failed to create empty kubeconfig file: %w", err)
+			return fmt.Errorf("failed to create empty kubeconfig file: %w", err)
 		}
 	}
-
-	return kubeConfigPath, nil
+	return nil
 }
 
 // CleanupResources will clean the resources installed by Operator, CockroachDB charts and deletes the namespace.
@@ -493,10 +547,10 @@ func (r *Region) CleanupResources(t *testing.T) {
 			KubectlOptions: kubectlOptions,
 			ExtraArgs:      extraArgs,
 		}
-		if err := helm.DeleteE(t, helmOptions, ReleaseName, true); err != nil {
+		if err := HelmDeleteWithRetryE(t, helmOptions, ReleaseName, true); err != nil {
 			t.Logf("Warning: helm delete %s failed (may not exist): %v", ReleaseName, err)
 		}
-		if err := helm.DeleteE(t, helmOptions, operatorReleaseName, true); err != nil {
+		if err := HelmDeleteWithRetryE(t, helmOptions, operatorReleaseName, true); err != nil {
 			t.Logf("Warning: helm delete %s failed (may not exist): %v", operatorReleaseName, err)
 		}
 		r.cleanupNamespace(t, clusterOptions, namespace)
@@ -531,6 +585,118 @@ func HelmChartPaths() (helmChartPath string, operatorChartPath string) {
 	operatorChartPath = filepath.Join(rootPath, "cockroachdb-parent/charts/operator")
 
 	return helmChartPath, operatorChartPath
+}
+
+func HelmInstallWithRetry(t *testing.T, options *helm.Options, chart, releaseName string) {
+	t.Helper()
+	if !shouldRetryHelmAction(options) {
+		helm.Install(t, options, chart, releaseName)
+		return
+	}
+
+	err := runHelmActionWithRetry(t, fmt.Sprintf("helm install %s", releaseName), func() error {
+		err := helm.InstallE(t, options, chart, releaseName)
+		if isHelmInstallAlreadyExists(err) {
+			t.Logf("helm install %s found an existing release; deleting it before retrying install", releaseName)
+			if deleteErr := HelmDeleteWithRetryE(t, options, releaseName, true); deleteErr != nil {
+				return fmt.Errorf("delete existing helm release %s before retrying install: %w", releaseName, deleteErr)
+			}
+			return fmt.Errorf("retry helm install after cleaning up existing release: %w", err)
+		}
+		return err
+	})
+	require.NoError(t, err)
+}
+
+func HelmUpgradeWithRetry(t *testing.T, options *helm.Options, chart, releaseName string) {
+	t.Helper()
+	if !shouldRetryHelmAction(options) {
+		helm.Upgrade(t, options, chart, releaseName)
+		return
+	}
+
+	err := runHelmActionWithRetry(t, fmt.Sprintf("helm upgrade %s", releaseName), func() error {
+		return helm.UpgradeE(t, options, chart, releaseName)
+	})
+	require.NoError(t, err)
+}
+
+func HelmDeleteWithRetryE(t *testing.T, options *helm.Options, releaseName string, purge bool) error {
+	t.Helper()
+	if !shouldRetryHelmAction(options) {
+		return helm.DeleteE(t, options, releaseName, purge)
+	}
+
+	return runHelmActionWithRetry(t, fmt.Sprintf("helm delete %s", releaseName), func() error {
+		err := helm.DeleteE(t, options, releaseName, purge)
+		if isHelmReleaseNotFound(err) {
+			return nil
+		}
+		return err
+	})
+}
+
+func shouldRetryHelmAction(options *helm.Options) bool {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("PROVIDER")), "azure") {
+		return true
+	}
+	if options == nil || options.KubectlOptions == nil {
+		return false
+	}
+	return strings.HasPrefix(options.KubectlOptions.ContextName, "azure-")
+}
+
+func runHelmActionWithRetry(t *testing.T, description string, action func() error) error {
+	t.Helper()
+
+	const attempts = 5
+	var err error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		err = action()
+		if err == nil {
+			return nil
+		}
+		if !isTransientHelmError(err) {
+			return err
+		}
+		if attempt == attempts {
+			break
+		}
+		t.Logf("%s failed with a transient Kubernetes API error on attempt %d/%d: %v", description, attempt, attempts, err)
+		time.Sleep(20 * time.Second)
+	}
+	return err
+}
+
+func isHelmInstallAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+	errText := err.Error()
+	return strings.Contains(errText, "cannot re-use a name that is still in use") ||
+		strings.Contains(errText, "release: already exists")
+}
+
+func isHelmReleaseNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	errText := err.Error()
+	return strings.Contains(errText, "Release not loaded") ||
+		strings.Contains(errText, "release: not found")
+}
+
+func isTransientHelmError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errText := err.Error()
+	for _, marker := range transientHelmErrorMarkers {
+		if strings.Contains(errText, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // createOperatorRegions returns the appropriate regions config
@@ -573,7 +739,7 @@ func VerifyInitCommandInOperatorLogs(
 	t *testing.T, kubectlOptions *k8s.KubectlOptions, expected string,
 ) {
 	// Get operator pods
-	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+	pods := testutil.ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{
 		LabelSelector: OperatorLabelSelector,
 	})
 	require.NotEmpty(t, pods, "no operator pods found")
@@ -647,7 +813,7 @@ func InstallCockroachDBOperatorChart(
 	setValues map[string]string,
 ) {
 	operatorOpts := operatorHelmOptions(kubectlOptions, version, setValues)
-	helm.Install(t, operatorOpts, chart, operatorReleaseName)
+	HelmInstallWithRetry(t, operatorOpts, chart, operatorReleaseName)
 	waitForCockroachDBOperator(t, operatorOpts, kubectlOptions)
 }
 
@@ -662,7 +828,7 @@ func UpgradeCockroachDBOperatorChart(
 			"--debug",
 		},
 	}
-	helm.Upgrade(t, operatorOpts, chart, operatorReleaseName)
+	HelmUpgradeWithRetry(t, operatorOpts, chart, operatorReleaseName)
 	waitForCockroachDBOperator(t, operatorOpts, kubectlOptions)
 }
 
@@ -698,7 +864,7 @@ func waitForCockroachDBOperator(
 	k8s.WaitUntilServiceAvailable(t, kubectlOptions, "cockroach-webhook-service", 30, 5*time.Second)
 	testutil.RequireServiceEndpointsAvailable(t, kubectlOptions, "cockroach-webhook-service", 2*time.Minute)
 
-	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+	pods := testutil.ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{
 		LabelSelector: OperatorLabelSelector,
 	})
 	for i := range pods {
@@ -722,7 +888,7 @@ func (r *Region) ExtendOperatorWatchNamespace(
 		"--timeout=120s")
 
 	// Wait for the operator pod to be ready after rollout.
-	pods := k8s.ListPods(t, operatorKubectlOptions, metav1.ListOptions{
+	pods := testutil.ListPodsWithRetry(t, operatorKubectlOptions, metav1.ListOptions{
 		LabelSelector: OperatorLabelSelector,
 	})
 	for i := range pods {
@@ -734,7 +900,7 @@ func UninstallCockroachDBOperator(t *testing.T, kubectlOptions *k8s.KubectlOptio
 	operatorOpts := &helm.Options{
 		KubectlOptions: kubectlOptions,
 	}
-	helm.Delete(t, operatorOpts, operatorReleaseName, true)
+	require.NoError(t, HelmDeleteWithRetryE(t, operatorOpts, operatorReleaseName, true))
 	// Delete the operator's PriorityClass (cluster-scoped resource)
 	k8s.RunKubectl(t, kubectlOptions, "delete", "priorityclass", "cockroach-operator", "--ignore-not-found=true")
 	k8s.DeleteNamespace(t, kubectlOptions, kubectlOptions.Namespace)
@@ -1100,7 +1266,7 @@ func (r *Region) InstallChartsWithAdvancedConfig(
 		ExtraArgs:      helmExtraArgs,
 	}
 
-	helm.Install(t, crdbOptions, helmChartPath, ReleaseName)
+	HelmInstallWithRetry(t, crdbOptions, helmChartPath, ReleaseName)
 
 	serviceName := "cockroachdb-public"
 	k8s.WaitUntilServiceAvailable(t, kubectlOptions, serviceName, 30, 5*time.Second)
@@ -1119,7 +1285,7 @@ func (r *Region) ValidateWALFailover(t *testing.T, cluster string, cfg *Advanced
 	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
 
 	// Get CockroachDB pods
-	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+	pods := testutil.ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{
 		LabelSelector: LabelSelector,
 	})
 	require.True(t, len(pods) > 0, "No CockroachDB pods found")
@@ -1181,7 +1347,7 @@ func (r *Region) ValidateEncryptionAtRest(
 	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
 
 	// Get CockroachDB pods
-	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+	pods := testutil.ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{
 		LabelSelector: LabelSelector,
 	})
 	require.True(t, len(pods) > 0, "No CockroachDB pods found")
@@ -1364,12 +1530,12 @@ func (r *Region) ValidatePCR(t *testing.T, cfg *AdvancedValidationConfig) {
 	primaryKubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, primaryNamespace)
 	standbyKubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, standbyNamespace)
 
-	primaryPods := k8s.ListPods(t, primaryKubectlOptions, metav1.ListOptions{
+	primaryPods := testutil.ListPodsWithRetry(t, primaryKubectlOptions, metav1.ListOptions{
 		LabelSelector: LabelSelector,
 	})
 	require.True(t, len(primaryPods) > 0, "No primary pods found")
 
-	standbyPods := k8s.ListPods(t, standbyKubectlOptions, metav1.ListOptions{
+	standbyPods := testutil.ListPodsWithRetry(t, standbyKubectlOptions, metav1.ListOptions{
 		LabelSelector: LabelSelector,
 	})
 	require.True(t, len(standbyPods) > 0, "No standby pods found")

--- a/tests/e2e/operator/singleRegion/cockroachdb_single_region_advanced_features_test.go
+++ b/tests/e2e/operator/singleRegion/cockroachdb_single_region_advanced_features_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/helm-charts/tests/e2e/operator"
+	"github.com/cockroachdb/helm-charts/tests/testutil"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
@@ -68,7 +69,7 @@ func (r *singleRegion) TestWALFailoverDisable(t *testing.T) {
 	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
 
 	// Get initial pod timestamps before upgrade
-	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+	pods := testutil.ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{
 		LabelSelector: operator.LabelSelector,
 	})
 	require.True(t, len(pods) > 0, "No CockroachDB pods found")
@@ -97,7 +98,7 @@ func (r *singleRegion) TestWALFailoverDisable(t *testing.T) {
 		},
 	}
 
-	helm.Upgrade(t, upgradeOptions, helmChartPath, operator.ReleaseName)
+	operator.HelmUpgradeWithRetry(t, upgradeOptions, helmChartPath, operator.ReleaseName)
 
 	// Wait for upgrade to complete using VerifyHelmUpgrade helper
 	err := r.VerifyHelmUpgrade(t, initialTimestamp, kubectlOptions)
@@ -105,7 +106,7 @@ func (r *singleRegion) TestWALFailoverDisable(t *testing.T) {
 
 	// Step 3: Verify WAL failover is disabled
 	t.Log("Verifying WAL failover is disabled after upgrade")
-	pods = k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+	pods = testutil.ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{
 		LabelSelector: operator.LabelSelector,
 	})
 	require.True(t, len(pods) > 0, "No CockroachDB pods found")
@@ -185,7 +186,7 @@ func (r *singleRegion) TestEncryptionAtRestDisable(t *testing.T) {
 	helmChartPath, _ := operator.HelmChartPaths()
 
 	// Get initial pod timestamps before upgrade
-	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+	pods := testutil.ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{
 		LabelSelector: operator.LabelSelector,
 	})
 	require.True(t, len(pods) > 0, "No CockroachDB pods found")
@@ -212,7 +213,7 @@ func (r *singleRegion) TestEncryptionAtRestDisable(t *testing.T) {
 		},
 	}
 
-	helm.Upgrade(t, upgradeOptions, helmChartPath, operator.ReleaseName)
+	operator.HelmUpgradeWithRetry(t, upgradeOptions, helmChartPath, operator.ReleaseName)
 
 	err := r.VerifyHelmUpgrade(t, initialTimestamp, kubectlOptions)
 	require.NoError(t, err)
@@ -235,7 +236,7 @@ func (r *singleRegion) TestEncryptionAtRestDisable(t *testing.T) {
 
 	// Step 4: Verify pod command reflects plaintext transition.
 	t.Log("Verifying transition to plaintext after upgrade")
-	pods = k8s.ListPods(t, kubectlOptions, metav1.ListOptions{LabelSelector: operator.LabelSelector})
+	pods = testutil.ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{LabelSelector: operator.LabelSelector})
 	require.True(t, len(pods) > 0, "No CockroachDB pods found")
 	podName := pods[0].Name
 
@@ -289,7 +290,7 @@ func (r *singleRegion) TestEncryptionAtRestModifySecret(t *testing.T) {
 	t.Logf("Created new encryption key secret: %s", operator.DefaultRotatedEncryptionSecret)
 
 	// Get initial pod timestamps before upgrade
-	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+	pods := testutil.ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{
 		LabelSelector: operator.LabelSelector,
 	})
 	require.True(t, len(pods) > 0, "No CockroachDB pods found")
@@ -317,7 +318,7 @@ func (r *singleRegion) TestEncryptionAtRestModifySecret(t *testing.T) {
 		},
 	}
 
-	helm.Upgrade(t, upgradeOptions, helmChartPath, operator.ReleaseName)
+	operator.HelmUpgradeWithRetry(t, upgradeOptions, helmChartPath, operator.ReleaseName)
 
 	// Wait for pods to restart and key rotation to complete using VerifyHelmUpgrade helper
 	err = r.VerifyHelmUpgrade(t, initialTimestamp, kubectlOptions)
@@ -377,7 +378,7 @@ func (r *singleRegion) TestWALFailoverWithEncryption(t *testing.T) {
 	// Unique to WAL+encryption: verify the WAL path is also covered by the encryption flag
 	kubeConfig, _ := r.GetCurrentContext(t)
 	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
-	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+	pods := testutil.ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{
 		LabelSelector: operator.LabelSelector,
 	})
 	require.True(t, len(pods) > 0, "No CockroachDB pods found")

--- a/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
+++ b/tests/e2e/operator/singleRegion/cockroachdb_single_region_e2e_test.go
@@ -250,7 +250,7 @@ func (r *singleRegion) TestHelmUpgrade(t *testing.T) {
 		},
 	}
 	// Apply Helm upgrade with updated values.
-	helm.Upgrade(t, options, helmChartPath, operator.ReleaseName)
+	operator.HelmUpgradeWithRetry(t, options, helmChartPath, operator.ReleaseName)
 
 	crdbCluster := testutil.CockroachCluster{
 		DesiredNodes: r.NodeCount,
@@ -301,10 +301,10 @@ func (r *singleRegion) TestClusterRollingRestart(t *testing.T) {
 			"upgrade": {"--reuse-values", "--set", fmt.Sprintf("cockroachdb.crdbCluster.timestamp=%s", upgradeTime.Format(time.RFC3339))},
 		},
 	}
-	helm.Upgrade(t, options, helmChartPath, operator.ReleaseName)
+	operator.HelmUpgradeWithRetry(t, options, helmChartPath, operator.ReleaseName)
 
 	// Get the initial timestamp of the pods before the upgrade.
-	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+	pods := testutil.ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{
 		LabelSelector: operator.LabelSelector,
 	})
 	require.True(t, len(pods) >= 3, "Expected at least 3 pods but found %d", len(pods))
@@ -318,7 +318,7 @@ func (r *singleRegion) TestClusterRollingRestart(t *testing.T) {
 		DesiredNodes: r.NodeCount,
 	}
 	testutil.RequireCRDBClusterToBeReadyEventuallyTimeout(t, kubectlOptions, crdbCluster, 600*time.Second)
-	pods = k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+	pods = testutil.ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{
 		LabelSelector: operator.LabelSelector,
 	})
 	// Verify that each pod's creation timestamp is after the upgradeTime.
@@ -357,7 +357,7 @@ func (r *singleRegion) TestKillingCockroachNode(t *testing.T) {
 
 	// List the pods.
 	kubectlOptions := k8s.NewKubectlOptions(cluster, kubeConfig, r.Namespace[cluster])
-	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{
+	pods := testutil.ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{
 		LabelSelector: operator.LabelSelector,
 	})
 
@@ -426,7 +426,7 @@ func (r *singleRegion) TestClusterScaleUp(t *testing.T, cloudProvider infra.Clou
 			"upgrade": {"--reuse-values", "--wait"},
 		},
 	}
-	helm.Upgrade(t, options, helmChartPath, operator.ReleaseName)
+	operator.HelmUpgradeWithRetry(t, options, helmChartPath, operator.ReleaseName)
 
 	crdbCluster := testutil.CockroachCluster{
 		DesiredNodes: r.NodeCount,

--- a/tests/testutil/cert-manager.go
+++ b/tests/testutil/cert-manager.go
@@ -41,7 +41,7 @@ func InstallCertManager(t *testing.T, kubectlOptions *k8s.KubectlOptions) {
 	t.Log(output)
 
 	// Wait for the cert-manager to be ready.
-	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{LabelSelector: "app=cert-manager"})
+	pods := ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{LabelSelector: "app=cert-manager"})
 	require.NoError(t, err)
 	for _, pod := range pods {
 		k8s.IsPodAvailable(&pod)
@@ -60,7 +60,7 @@ func InstallTrustManager(t *testing.T, kubectlOptions *k8s.KubectlOptions, trust
 	t.Log(output)
 
 	// Wait for the trust-manager to be ready.
-	pods := k8s.ListPods(t, kubectlOptions, metav1.ListOptions{LabelSelector: "app=trust-manager"})
+	pods := ListPodsWithRetry(t, kubectlOptions, metav1.ListOptions{LabelSelector: "app=trust-manager"})
 	require.NoError(t, err)
 	for _, pod := range pods {
 		k8s.IsPodAvailable(&pod)

--- a/tests/testutil/require.go
+++ b/tests/testutil/require.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -109,6 +110,26 @@ func RequireCRDBClusterToBeReadyEventuallyTimeout(t *testing.T, opts *k8s.Kubect
 	require.NoError(t, err)
 }
 
+func ListPodsWithRetry(t *testing.T, opts *k8s.KubectlOptions, options metav1.ListOptions) []corev1.Pod {
+	t.Helper()
+
+	if !shouldRetryKubernetesContext(kubectlContext(opts)) {
+		pods, err := k8s.ListPodsE(t, opts, options)
+		require.NoError(t, err)
+		return pods
+	}
+
+	var pods []corev1.Pod
+	_, err := retry.DoWithRetryE(t, "list pods", 12, 5*time.Second, func() (string, error) {
+		var listErr error
+		pods, listErr = k8s.ListPodsE(t, opts, options)
+		return "", listErr
+	})
+	require.NoError(t, err)
+
+	return pods
+}
+
 func RequirePodToBeCreatedAndReady(t *testing.T, opts *k8s.KubectlOptions, podName string, timeout time.Duration) {
 	ctx := context.Background()
 	require.NoError(t, wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true,
@@ -151,6 +172,20 @@ func RequireServiceEndpointsAvailable(t *testing.T, opts *k8s.KubectlOptions, se
 			return false, nil
 		},
 	))
+}
+
+func shouldRetryKubernetesContext(contextName string) bool {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("PROVIDER")), "azure") {
+		return true
+	}
+	return strings.HasPrefix(contextName, "azure-")
+}
+
+func kubectlContext(opts *k8s.KubectlOptions) string {
+	if opts == nil {
+		return ""
+	}
+	return opts.ContextName
 }
 
 func logPods(ctx context.Context, sts *appsv1.StatefulSet, cfg *rest.Config, t *testing.T) {
@@ -228,7 +263,17 @@ func getDBConn(t *testing.T, crdbCluster CockroachCluster, dbName string, podNam
 	}
 
 	// Create a new database connection for the update.
-	db, err := database.NewDbConnection(conn)
+	var db *sql.DB
+	var err error
+	if shouldRetryKubernetesContext(crdbCluster.Context) {
+		_, err = retry.DoWithRetryE(t, "open database connection", 12, 5*time.Second, func() (string, error) {
+			var connErr error
+			db, connErr = database.NewDbConnection(conn)
+			return "", connErr
+		})
+	} else {
+		db, err = database.NewDbConnection(conn)
+	}
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		db.Close()
@@ -404,7 +449,7 @@ func RequireCertificatesToBeValid(t *testing.T, crdbCluster CockroachCluster) {
 	kubectlOptions := k8s.NewKubectlOptions(crdbCluster.Context, kubeConfig, crdbCluster.Namespace)
 
 	// Get the node certificate secret and load the node cert
-	nodeSecret := k8s.GetSecret(t, kubectlOptions, crdbCluster.NodeSecret)
+	nodeSecret := getSecretWithRetry(t, kubectlOptions, crdbCluster.NodeSecret)
 	nodeCert := LoadCertificate(t, nodeSecret, "tls.crt")
 
 	t.Log("Verifying the node certificate validity with its secret")
@@ -414,7 +459,7 @@ func RequireCertificatesToBeValid(t *testing.T, crdbCluster CockroachCluster) {
 	t.Log("Verifying node certs are signed by CA certificates")
 	verifyCertificate(t, nodeSecret.Data["ca.crt"], nodeCert)
 
-	clientSecret := k8s.GetSecret(t, kubectlOptions, crdbCluster.ClientSecret)
+	clientSecret := getSecretWithRetry(t, kubectlOptions, crdbCluster.ClientSecret)
 	clientCert := LoadCertificate(t, clientSecret, "tls.crt")
 
 	t.Log("Verifying the client certificate validity with its secret")
@@ -423,7 +468,7 @@ func RequireCertificatesToBeValid(t *testing.T, crdbCluster CockroachCluster) {
 
 	// Get the CA certificate secret and load the ca cert
 	var caCert *x509.Certificate
-	caSecret := k8s.GetSecret(t, kubectlOptions, crdbCluster.CaSecret)
+	caSecret := getSecretWithRetry(t, kubectlOptions, crdbCluster.CaSecret)
 	if _, ok := caSecret.Data["ca.crt"]; !ok {
 		caCert = LoadCertificate(t, nodeSecret, "ca.crt")
 	} else {
@@ -437,6 +482,28 @@ func RequireCertificatesToBeValid(t *testing.T, crdbCluster CockroachCluster) {
 	}
 
 	t.Log("Certificates validated successfully")
+}
+
+func getSecretWithRetry(t *testing.T, kubectlOptions *k8s.KubectlOptions, secretName string) *corev1.Secret {
+	if !shouldRetryKubernetesContext(kubectlContext(kubectlOptions)) {
+		return k8s.GetSecret(t, kubectlOptions, secretName)
+	}
+
+	var secret *corev1.Secret
+	_, err := retry.DoWithRetryE(t, fmt.Sprintf("get secret %s", secretName),
+		12, 5*time.Second,
+		func() (string, error) {
+			fetchedSecret, err := k8s.GetSecretE(t, kubectlOptions, secretName)
+			if err != nil {
+				return "", err
+			}
+
+			secret = fetchedSecret
+			return "", nil
+		})
+	require.NoError(t, err)
+
+	return secret
 }
 
 func LoadCertificate(t *testing.T, certSecret *corev1.Secret, key string) *x509.Certificate {


### PR DESCRIPTION
## Summary

Adds Azure-backed E2E infrastructure and CI wiring for the Helm chart operator test suites.

This PR is for [CC-35912](https://cockroachlabs.atlassian.net/browse/CC-35912).

## Changes

- Adds an AKS-backed Azure provider for the operator E2E harness.
- Provisions tagged Azure resource groups, VNets/subnets, AKS clusters, VNet peerings, CoreDNS service/configuration, and Azure-specific provider runtime behavior.
- Wires Azure into the integration and advanced-features workflows for single-region, multi-region, and advanced E2E runs.
- Adds Azure workflow authentication with `azure/login`, Azure-specific timeouts, and branch-scoped concurrency groups so Azure jobs do not overlap for the same branch/test class.
- Records created Azure resource groups through `AZURE_RESOURCE_GROUPS_FILE` so cleanup can run independently from Go test teardown.
- Tags Azure resource groups with `ManagedBy`, `Ticket`, `TestRun`, GitHub run metadata, workflow, job, and ref name for ownership and stale-resource detection.

## Azure CI Features

- Supports `PROVIDER=azure` for operator single-region and multi-region E2E suites.
- Runs the Azure matrix entries in both scheduled and manually triggered CI workflows.
- Uses generated per-run resource names, isolated kubeconfigs, and Azure-aware Kubernetes retry behavior.
- Configures CoreDNS for Azure cluster domains and multi-region DNS forwarding.
- Uses async final Azure resource-group cleanup to keep successful CI runs fast.
- Performs a pre-run stale-resource check before provisioning new Azure infrastructure. If stale groups from previous runs exist, the job submits async cleanup for them and fails before creating new resources.

## Debugging And O11y

`build/azure-ci-debug.sh` captures Azure CI snapshots before stale cleanup, before/after tests, periodically during long-running tests, and before/after cleanup.

Each snapshot includes:

- Azure CLI account/subscription context.
- Recorded resource groups for the current run.
- Known `helm-charts` Azure resource groups by prefix/tag.
- Resource group details and resource inventory.
- AKS clusters, provisioning states, power states, Kubernetes versions, and AKS node resource groups.
- VNets, VNet peerings, public IPs, load balancers, disks, and recent failed Azure activity-log events.

To access the debug output:

1. Open the GitHub Actions run.
2. Open the Azure job, such as `advanced-features-single-region (azure)` or `advanced-features-multi-region (azure)`.
3. Download the uploaded job artifact, for example `advanced-single-region-results-azure` or `advanced-multi-region-results-azure`.
4. Inspect `_temp/azure-debug/azure-*.log` and `_temp/azure-resource-groups.txt` inside the artifact.

A validation run used while developing this CI is [GitHub Actions run 32354470589](https://github.com/cockroachdb/helm-charts/actions/runs/32354470589).

## Cleanup Model

Cleanup is intentionally split into two paths:

- End-of-run cleanup submits async `az group delete --no-wait` for the resource groups recorded during the test run.
- Start-of-run preflight checks for stale tagged resource groups from prior runs. If any are found, the workflow submits async cleanup and fails immediately before provisioning anything new.

This keeps normal successful runs fast while making leftover Azure resources visible and actionable instead of silently carrying them into a new run.

## Validation

- `bash -n build/azure-ci-debug.sh`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/workflows/advanced-features-tests.yaml .github/workflows/integration-tests.yaml`
- `git diff --check HEAD`
- `go test ./tests/e2e/operator/infra`
- `go test ./tests/e2e/operator/... -run '^$'`
- Live Azure query confirmed no matching `hc-e2e`, `helm-charts-e2e`, `MC_hc-e2e`, or `ManagedBy=helm-charts-e2e` resource groups/resources remained after [GitHub Actions run 32354470589](https://github.com/cockroachdb/helm-charts/actions/runs/32354470589).

`actionlint` was not available in the local environment, so workflow validation was limited to YAML parsing and the checks above.
