### PR TITLE
charts: remove deprecated CrdbCluster template fields

### DIFF
--- a/build/templates/cockroachdb-parent/charts/cockroachdb/README.md
+++ b/build/templates/cockroachdb-parent/charts/cockroachdb/README.md
@@ -112,7 +112,7 @@ $ helm install $CRDBOPERATOR ./cockroachdb-parent/charts/operator -n $NAMESPACE
           namespace: cockroach-ns
 ```
 - If the `cloudProvider` is `azure`, create an application in your Azure tenant and create a secret named `azure-cluster-identity-credentials-secret` which contains `azure_client_id` and  `azure_client_secret` to hold the application credentials.[2]
-- Modify the other relevant configuration like `topologySpreadConstraints`, `localityLabels`,  `service.ports`, as required.
+- Modify the other relevant configuration like `topologySpreadConstraints`, `localityMappings`,  `service.ports`, as required.
 
 Install the cockroachdb chart:
 

--- a/build/templates/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/build/templates/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -393,26 +393,6 @@ cockroachdb:
           annotations: {}
           host: ""
       #
-    # sideCars captures the configuration for sidecar containers.
-    sideCars:
-      # initContainers captures init containers for CockroachDB pods.
-      initContainers: []
-      # containers captures additional containers for CockroachDB pods.
-      containers: []
-      # volumes captures additional volumes for CockroachDB pods.
-      volumes: []
-    # localityLabels captures labels used to determine node locality.
-    # It is an ordered, comma-separated list of keys that which must be present as labels on the nodes.
-    # For region and zone to be part of the locality, the labels (topology.kubernetes.io/region, topology.kubernetes.io/region) must be set on the nodes.
-    # For other labels, they must be set on the nodes and will be presented as key/value pairs to the node locality.
-    # Example:
-    # If localityLabels are provided as ["topology.kubernetes.io/region", "topology.kubernetes.io/zone", "example.datacenter.locality"], and the node labels are:
-    #   topology.kubernetes.io/region: us-central1
-    #   topology.kubernetes.io/zone: us-central1-c
-    #   example.datacenter.locality: dc2
-    # the resulting locality flag will be: locality=region=us-central1,zone=us-central1-c,example.datacenter.locality=dc2.
-    # It is recommended to configure `localityMappings` over `localityLabels` for locality flag computation that is passed to the CockroachDB start command.
-    localityLabels: []
     # localityMappings captures labels used to determine node locality.
     # It is an ordered, comma-separated list of key/value pairs that which must be present as labels on the nodes.
     # Each locality mapping captures the relationship between a node label and a locality label.
@@ -495,14 +475,17 @@ cockroachdb:
         #     storageClassName defines the StorageClass for the PVC.
         #     If not set, the default provisioner will be chosen (gp2 on AWS, standard on GKE).
         #     storageClassName: ""
-    # godebug captures Go runtime debug settings for CockroachDB pods.
+    # godebug sets the GODEBUG environment variable on the cockroachdb container.
+    # Each key/value pair becomes one clause. Changing it triggers a rolling restart.
     godebug:
-      # disablethp determines whether Transparent Huge Pages are disabled.
-      # By default, disables THP, which can cause memory inefficiency for CockroachDB.
+      # Disable Transparent Huge Pages, which can cause memory inefficiency for CockroachDB.
       disablethp: "1"
     # podTemplate defines the pod specification to override default pod specification configured by the operator.
     # If specified, podTemplate is merged with the default pod specification, with settings in podTemplate taking precedence.
     # This can be used to add or update containers, volumes, and other settings of the CockroachDB pod.
+    # Containers, init containers and volumes are merged by name. A name that matches one the operator
+    # already creates (cockroachdb, cert-reloader, cockroachdb-init, datadir, logsdir, cockroach-env)
+    # updates that entry, as the examples below do. Any other name is added alongside them.
     podTemplate:
       # metadata captures the pod metadata for CockroachDB pods.
       metadata:
@@ -550,6 +533,8 @@ cockroachdb:
         # # nodeSelector captures the node selector labels for scheduling pods.
         # nodeSelector: {}
         # # affinity captures scheduling affinity rules for CockroachDB pods.
+        # # Unlike the rest of podTemplate, this replaces the operator's affinity instead of merging with
+        # # it. The rule it drops keeps one CockroachDB pod per node, so repeat it here if you still want it.
         # affinity:
         #   nodeAffinity:
         #     requiredDuringSchedulingIgnoredDuringExecution:

--- a/build/templates/cockroachdb-parent/values.yaml
+++ b/build/templates/cockroachdb-parent/values.yaml
@@ -119,14 +119,18 @@
 #        verbs: ["get"]
 #    serviceAccountName: ~
 #
-#  # PodLabels are the labels that should be applied to the underlying CRDB pod
-#  podLabels:
-#    app.kubernetes.io/component: cockroachdb
+#  # Labels that should be applied to the underlying CRDB pod.
+#  podTemplate:
+#    metadata:
+#      labels:
+#        app.kubernetes.io/component: cockroachdb
 #
 #  extras:
 #    # Add a container with dnsutils (nslookup, dig, ping, etc.) installed.
 #    dnsutils: false
 #
-#  localityLabels:
-#    - topology.kubernetes.io/region
-#    - topology.kubernetes.io/zone
+#  localityMappings:
+#    - nodeLabel: topology.kubernetes.io/region
+#      localityLabel: region
+#    - nodeLabel: topology.kubernetes.io/zone
+#      localityLabel: zone

--- a/cockroachdb-parent/Chart.lock
+++ b/cockroachdb-parent/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.0
 - name: cockroachdb-chart
   repository: file://charts/cockroachdb
-  version: 26.3.1
-digest: sha256:0e8ed4b274886f38d338dbf74713be4bdb89680df4db241f482de6d266dfaf33
-generated: "2026-08-28T17:29:33.24954+05:30"
+  version: 26.3.2
+digest: sha256:107a3e098461dac663b975e194713ea4e153eb065f2849a76264862c0a85fd85
+generated: "2026-09-03T20:52:21.5519+05:30"

--- a/cockroachdb-parent/Chart.yaml
+++ b/cockroachdb-parent/Chart.yaml
@@ -13,6 +13,6 @@ dependencies:
     repository: "file://charts/operator"
   - name: cockroachdb-chart
     alias: cockroachdb
-    version: 26.3.1
+    version: 26.3.2
     condition: cockroachdb.enabled
     repository: "file://charts/cockroachdb"

--- a/cockroachdb-parent/charts/cockroachdb/CHANGELOG.md
+++ b/cockroachdb-parent/charts/cockroachdb/CHANGELOG.md
@@ -1,5 +1,23 @@
 # CockroachDB Chart — CHANGELOG
 
+## [26.3.2] — 2026-09-03
+### Fixed
+- `cockroachdb.crdbCluster.godebug` now reaches the cockroachdb container. It was parsed but
+  never rendered, so the `disablethp: "1"` default had no effect. Set `godebug: null` to opt out.
+
+### Removed
+- Removed `cockroachdb.crdbCluster.localityLabels` and `cockroachdb.crdbCluster.sideCars`.
+  Use `cockroachdb.crdbCluster.localityMappings` and `cockroachdb.crdbCluster.podTemplate.spec`
+  instead.
+- The chart now fails with an upgrade message if any value the CrdbCluster template no longer
+  applies is still set, so an upgrade cannot silently drop a sidecar or a scheduling constraint.
+
+### Upgrade Notes
+- Upgrading may roll CockroachDB pods to apply the default `GODEBUG` setting.
+- `podTemplate` containers and init containers are appended after the operator's default ones,
+  where `sideCars` used to go first. Init containers run in order, so an init container that has
+  to run before the operator's `cockroachdb-init` needs rework before you move it.
+
 ## [26.3.1] — 2026-08-26
 ### Changed
 - Updated the default CockroachDB image version from `v26.3.0` to `v26.3.1`.

--- a/cockroachdb-parent/charts/cockroachdb/Chart.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 name: cockroachdb-chart
 home: https://www.cockroachlabs.com
-version: 26.3.1
+version: 26.3.2
 appVersion: 26.3.1
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb-parent/charts/cockroachdb/README.md
+++ b/cockroachdb-parent/charts/cockroachdb/README.md
@@ -113,7 +113,7 @@ $ helm install $CRDBOPERATOR ./cockroachdb-parent/charts/operator -n $NAMESPACE
           namespace: cockroach-ns
 ```
 - If the `cloudProvider` is `azure`, create an application in your Azure tenant and create a secret named `azure-cluster-identity-credentials-secret` which contains `azure_client_id` and  `azure_client_secret` to hold the application credentials.[2]
-- Modify the other relevant configuration like `topologySpreadConstraints`, `localityLabels`,  `service.ports`, as required.
+- Modify the other relevant configuration like `topologySpreadConstraints`, `localityMappings`,  `service.ports`, as required.
 
 Install the cockroachdb chart:
 

--- a/cockroachdb-parent/charts/cockroachdb/templates/_helpers.tpl
+++ b/cockroachdb-parent/charts/cockroachdb/templates/_helpers.tpl
@@ -265,6 +265,41 @@ and none when TLS is off.
 {{- end -}}
 
 
+{{/*
+Fail when a removed value is still set, so an upgrade cannot silently drop it.
+*/}}
+{{- define "cockroachdb.removedFields.validation" -}}
+{{- $crdbCluster := .Values.cockroachdb.crdbCluster -}}
+{{- $replacements := dict
+  "affinity" "cockroachdb.crdbCluster.podTemplate.spec.affinity"
+  "env" "the cockroachdb container under cockroachdb.crdbCluster.podTemplate.spec.containers"
+  "flags" "cockroachdb.crdbCluster.startFlags"
+  "localityLabels" "cockroachdb.crdbCluster.localityMappings"
+  "nodeSelector" "cockroachdb.crdbCluster.podTemplate.spec.nodeSelector"
+  "podAnnotations" "cockroachdb.crdbCluster.podTemplate.metadata.annotations"
+  "podLabels" "cockroachdb.crdbCluster.podTemplate.metadata.labels"
+  "readinessProbe" "the cockroachdb container under cockroachdb.crdbCluster.podTemplate.spec.containers"
+  "resources" "the cockroachdb container under cockroachdb.crdbCluster.podTemplate.spec.containers"
+  "terminationGracePeriod" "cockroachdb.crdbCluster.podTemplate.spec.terminationGracePeriodSeconds"
+  "tolerations" "cockroachdb.crdbCluster.podTemplate.spec.tolerations"
+  "topologySpreadConstraints" "cockroachdb.crdbCluster.podTemplate.spec.topologySpreadConstraints"
+-}}
+{{- $found := list -}}
+{{- range $field, $replacement := $replacements -}}
+{{- if index $crdbCluster $field -}}
+{{- $found = append $found (printf "cockroachdb.crdbCluster.%s, use %s" $field $replacement) -}}
+{{- end -}}
+{{- end -}}
+{{- with $crdbCluster.sideCars -}}
+{{- if or .initContainers .containers .volumes -}}
+{{- $found = append $found "cockroachdb.crdbCluster.sideCars, use cockroachdb.crdbCluster.podTemplate.spec.initContainers, .containers and .volumes" -}}
+{{- end -}}
+{{- end -}}
+{{- if $found -}}
+{{- fail (printf "The following values were removed from the CockroachDB Helm chart and are no longer applied:\n  %s\nMigrate them and remove them from your values before upgrading." (join "\n  " (sortAlpha $found))) -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "cockroachdb.tls.certs.selfSigner.validation" -}}
 {{ include "cockroachdb.tls.certs.selfSigner.caProvidedValidation" . }}
 {{ include "cockroachdb.tls.certs.selfSigner.caCertValidation" . }}
@@ -316,14 +351,51 @@ Validate the WAL failover configuration.
 {{- end -}}
 
 {{/*
-Construct the GODEBUG env var value (looks like: GODEBUG="foo=bar,baz=quux"; default: "disablethp=1")
+Construct the GODEBUG env var value (looks like: GODEBUG="foo=bar,baz=quux"). Empty when
+cockroachdb.crdbCluster.godebug is unset.
 */}}
 {{- define "godebugList" -}}
 {{- $godebugList := list -}}
 {{- range $key, $value := .Values.cockroachdb.crdbCluster.godebug }}
-  {{- $godebugList = append $godebugList (printf "%s=%s" $key $value) -}}
+  {{- $godebugList = append $godebugList (printf "%s=%v" $key $value) -}}
 {{- end }}
 {{- join "," $godebugList -}}
+{{- end }}
+
+{{/*
+Render podTemplate.spec with the chart-owned service account and GODEBUG merged in.
+A GODEBUG already set on the cockroachdb container wins, so an exported value from a migrated
+cluster is not replaced by the chart default.
+*/}}
+{{- define "cockroachdb.podTemplate.spec" -}}
+{{- $spec := deepCopy (.Values.cockroachdb.crdbCluster.podTemplate.spec | default dict) -}}
+{{- $_ := set $spec "serviceAccountName" (include "cockroachdb.serviceAccount.name" .) -}}
+{{- $godebug := include "godebugList" . -}}
+{{- if $godebug -}}
+{{- $containers := list -}}
+{{- $patched := false -}}
+{{- range $container := ($spec.containers | default list) -}}
+{{- if eq ($container.name | toString) "cockroachdb" -}}
+{{- $patched = true -}}
+{{- $env := $container.env | default list -}}
+{{- $hasGodebug := false -}}
+{{- range $var := $env -}}
+{{- if eq ($var.name | toString) "GODEBUG" -}}
+{{- $hasGodebug = true -}}
+{{- end -}}
+{{- end -}}
+{{- if not $hasGodebug -}}
+{{- $_ := set $container "env" (append $env (dict "name" "GODEBUG" "value" $godebug)) -}}
+{{- end -}}
+{{- end -}}
+{{- $containers = append $containers $container -}}
+{{- end -}}
+{{- if not $patched -}}
+{{- $containers = append $containers (dict "name" "cockroachdb" "env" (list (dict "name" "GODEBUG" "value" $godebug))) -}}
+{{- end -}}
+{{- $_ := set $spec "containers" $containers -}}
+{{- end -}}
+{{- toYaml $spec -}}
 {{- end }}
 
 {{/* Common labels that are applied to all managed objects. */}}

--- a/cockroachdb-parent/charts/cockroachdb/templates/crdb.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/templates/crdb.yaml
@@ -1,6 +1,7 @@
 {{ template "cockroachdb.tlsValidation" . }}
 {{ template "cockroachdb.log.validation" . }}
 {{ template "cockroachdb.postInitSQL.validation" . }}
+{{ template "cockroachdb.removedFields.validation" . }}
 {{- if .Release.IsUpgrade -}}
 {{ template "cockroachdb.isUpgradeAllowed" . }}
 {{- end -}}
@@ -65,9 +66,6 @@ spec:
       {{- with .Values.cockroachdb.crdbCluster.walFailoverSpec }}
       walFailoverSpec: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cockroachdb.crdbCluster.localityLabels }}
-      localityLabels: {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- with .Values.cockroachdb.crdbCluster.localityMappings }}
       localityMappings: {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -79,9 +77,6 @@ spec:
       {{- end }}
       {{- with .Values.cockroachdb.crdbCluster.log.logsStore }}
       logsStore: {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.cockroachdb.crdbCluster.sideCars }}
-      sideCars: {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.cockroachdb.crdbCluster.service.ports.grpc.port }}
       grpcPort: {{ .Values.cockroachdb.crdbCluster.service.ports.grpc.port }}
@@ -95,25 +90,21 @@ spec:
       {{- with .Values.cockroachdb.crdbCluster.startFlags }}
       startFlags: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cockroachdb.crdbCluster.podTemplate }}
       podTemplate:
         metadata:
           labels:
-            app.kubernetes.io/name: {{ template "cockroachdb.name" $ }}
-            app.kubernetes.io/instance: {{ $.Release.Name | quote }}
-            {{- with .metadata.labels }}
+            app.kubernetes.io/name: {{ template "cockroachdb.name" . }}
+            app.kubernetes.io/instance: {{ .Release.Name | quote }}
+            {{- with .Values.cockroachdb.crdbCluster.podTemplate.metadata.labels }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           annotations:
-            helm.sh/restartedAt: {{ $.Values.cockroachdb.crdbCluster.timestamp | quote }}
-            {{- with .metadata.annotations }}
+            helm.sh/restartedAt: {{ .Values.cockroachdb.crdbCluster.timestamp | quote }}
+            {{- with .Values.cockroachdb.crdbCluster.podTemplate.metadata.annotations }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-        spec:        
-            {{- $spec := deepCopy .spec }}
-            {{- $_ := set $spec "serviceAccountName" (include "cockroachdb.serviceAccount.name" $) }}
-            {{- toYaml $spec | nindent 12 }}
-      {{- end }}
+        spec:
+            {{- include "cockroachdb.podTemplate.spec" . | nindent 12 }}
       {{- with .Values.cockroachdb.crdbCluster.persistentVolumeClaimRetentionPolicy }}
       persistentVolumeClaimRetentionPolicy: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/cockroachdb-parent/charts/cockroachdb/values.yaml
+++ b/cockroachdb-parent/charts/cockroachdb/values.yaml
@@ -394,26 +394,6 @@ cockroachdb:
           annotations: {}
           host: ""
       #
-    # sideCars captures the configuration for sidecar containers.
-    sideCars:
-      # initContainers captures init containers for CockroachDB pods.
-      initContainers: []
-      # containers captures additional containers for CockroachDB pods.
-      containers: []
-      # volumes captures additional volumes for CockroachDB pods.
-      volumes: []
-    # localityLabels captures labels used to determine node locality.
-    # It is an ordered, comma-separated list of keys that which must be present as labels on the nodes.
-    # For region and zone to be part of the locality, the labels (topology.kubernetes.io/region, topology.kubernetes.io/region) must be set on the nodes.
-    # For other labels, they must be set on the nodes and will be presented as key/value pairs to the node locality.
-    # Example:
-    # If localityLabels are provided as ["topology.kubernetes.io/region", "topology.kubernetes.io/zone", "example.datacenter.locality"], and the node labels are:
-    #   topology.kubernetes.io/region: us-central1
-    #   topology.kubernetes.io/zone: us-central1-c
-    #   example.datacenter.locality: dc2
-    # the resulting locality flag will be: locality=region=us-central1,zone=us-central1-c,example.datacenter.locality=dc2.
-    # It is recommended to configure `localityMappings` over `localityLabels` for locality flag computation that is passed to the CockroachDB start command.
-    localityLabels: []
     # localityMappings captures labels used to determine node locality.
     # It is an ordered, comma-separated list of key/value pairs that which must be present as labels on the nodes.
     # Each locality mapping captures the relationship between a node label and a locality label.
@@ -496,14 +476,17 @@ cockroachdb:
         #     storageClassName defines the StorageClass for the PVC.
         #     If not set, the default provisioner will be chosen (gp2 on AWS, standard on GKE).
         #     storageClassName: ""
-    # godebug captures Go runtime debug settings for CockroachDB pods.
+    # godebug sets the GODEBUG environment variable on the cockroachdb container.
+    # Each key/value pair becomes one clause. Changing it triggers a rolling restart.
     godebug:
-      # disablethp determines whether Transparent Huge Pages are disabled.
-      # By default, disables THP, which can cause memory inefficiency for CockroachDB.
+      # Disable Transparent Huge Pages, which can cause memory inefficiency for CockroachDB.
       disablethp: "1"
     # podTemplate defines the pod specification to override default pod specification configured by the operator.
     # If specified, podTemplate is merged with the default pod specification, with settings in podTemplate taking precedence.
     # This can be used to add or update containers, volumes, and other settings of the CockroachDB pod.
+    # Containers, init containers and volumes are merged by name. A name that matches one the operator
+    # already creates (cockroachdb, cert-reloader, cockroachdb-init, datadir, logsdir, cockroach-env)
+    # updates that entry, as the examples below do. Any other name is added alongside them.
     podTemplate:
       # metadata captures the pod metadata for CockroachDB pods.
       metadata:
@@ -551,6 +534,8 @@ cockroachdb:
         # # nodeSelector captures the node selector labels for scheduling pods.
         # nodeSelector: {}
         # # affinity captures scheduling affinity rules for CockroachDB pods.
+        # # Unlike the rest of podTemplate, this replaces the operator's affinity instead of merging with
+        # # it. The rule it drops keeps one CockroachDB pod per node, so repeat it here if you still want it.
         # affinity:
         #   nodeAffinity:
         #     requiredDuringSchedulingIgnoredDuringExecution:

--- a/cockroachdb-parent/values.yaml
+++ b/cockroachdb-parent/values.yaml
@@ -120,14 +120,18 @@
 #        verbs: ["get"]
 #    serviceAccountName: ~
 #
-#  # PodLabels are the labels that should be applied to the underlying CRDB pod
-#  podLabels:
-#    app.kubernetes.io/component: cockroachdb
+#  # Labels that should be applied to the underlying CRDB pod.
+#  podTemplate:
+#    metadata:
+#      labels:
+#        app.kubernetes.io/component: cockroachdb
 #
 #  extras:
 #    # Add a container with dnsutils (nslookup, dig, ping, etc.) installed.
 #    dnsutils: false
 #
-#  localityLabels:
-#    - topology.kubernetes.io/region
-#    - topology.kubernetes.io/zone
+#  localityMappings:
+#    - nodeLabel: topology.kubernetes.io/region
+#      localityLabel: region
+#    - nodeLabel: topology.kubernetes.io/zone
+#      localityLabel: zone

--- a/docs/migration/helm/controller_migration.md
+++ b/docs/migration/helm/controller_migration.md
@@ -469,7 +469,7 @@ carry those forward into the new values.yaml as well.
 | Dedicated `logsdir` PVC | `spec.template.spec.logsStore` | `cockroachdb.crdbCluster.log.logsStore` |
 | Helm log Secret | Converted to ConfigMap. `spec.template.spec.loggingConfigMapName` | `cockroachdb.crdbCluster.loggingConfigMapName` |
 | Service account | `spec.template.spec.podTemplate.spec.serviceAccountName` | `cockroachdb.crdbCluster.rbac.serviceAccount.name` with `create=false` |
-| `--locality` tier keys | `spec.template.spec.localityLabels` | Exported into values. Patch `localityMappings` for custom labels |
+| `--locality` tier keys | `spec.template.spec.localityLabels` | Not exported. Set `cockroachdb.crdbCluster.localityMappings` for custom labels |
 | Ingress intent | Preserved as annotation on CrdbCluster | `cockroachdb.crdbCluster.service.ingress` |
 | PCR config | `spec.template.spec.virtualCluster` | `cockroachdb.crdbCluster.virtualCluster` |
 
@@ -540,11 +540,14 @@ kubectl delete pdb ${STS_NAME}-budget -n ${NAMESPACE} --ignore-not-found
 
 ## Step 12: Configure LocalityMappings
 
-The migration controller preserves the `--locality` flag tier keys (e.g. `region`, `zone`)
-as `localityLabels` on the CrdbNodeSpec. `localityLabels` is deprecated in favor of
-`localityMappings`, which maps K8s node labels to CockroachDB locality tiers. The default
-mapping covers standard K8s topology labels (`topology.kubernetes.io/region` → `region`,
-`topology.kubernetes.io/zone` → `zone`).
+The migration controller records the `--locality` flag tier keys (e.g. `region`, `zone`)
+as `localityLabels` on each migrated CrdbNode. `localityLabels` is deprecated and does not
+determine node locality. Locality comes from `localityMappings`, which maps K8s node labels
+to CockroachDB locality tiers and defaults to the standard K8s topology labels
+(`topology.kubernetes.io/region` → `region`, `topology.kubernetes.io/zone` → `zone`).
+
+The CockroachDB Helm chart no longer renders `localityLabels`. This is a no-op for the
+migrated cluster.
 
 If your cluster uses custom K8s node labels for locality, update `localityMappings` to
 match. Each entry maps a K8s node label key to a CockroachDB locality tier name.

--- a/docs/migration/helm/manual_migration.md
+++ b/docs/migration/helm/manual_migration.md
@@ -72,6 +72,14 @@ bin/migration-helper build-manifest helm \
   --output-dir ./manifests
 ```
 
+If the StatefulSet passes `--locality`, the generated manifests carry the same flag in
+`spec.startFlags.upsert`, so each node keeps the locality it has today. The CockroachDB
+Operator uses a supplied locality flag as is and does not compute one from Kubernetes node
+labels. To switch to node labels after the migration, set
+`cockroachdb.crdbCluster.localityMappings` and remove `--locality` from
+`cockroachdb.crdbCluster.startFlags.upsert`. Changing locality restarts the pods, so plan it
+as a separate change once the cluster is healthy.
+
 Create the PriorityClass required by the generated resources before replacing any pods:
 
 ```

--- a/docs/migration/operator/controller_migration.md
+++ b/docs/migration/operator/controller_migration.md
@@ -521,11 +521,14 @@ Key fields converted during migration:
 
 ## Step 10: Configure LocalityMappings
 
-The migration controller preserves the `--locality` flag tier keys (e.g. `region`, `zone`)
-as `localityLabels` on the CrdbNodeSpec. `localityLabels` is deprecated in favor of
-`localityMappings`, which maps K8s node labels to CockroachDB locality tiers. The default
-mapping covers standard K8s topology labels (`topology.kubernetes.io/region` → `region`,
-`topology.kubernetes.io/zone` → `zone`).
+The migration controller records the `--locality` flag tier keys (e.g. `region`, `zone`)
+as `localityLabels` on each migrated CrdbNode. `localityLabels` is deprecated and does not
+determine node locality. Locality comes from `localityMappings`, which maps K8s node labels
+to CockroachDB locality tiers and defaults to the standard K8s topology labels
+(`topology.kubernetes.io/region` → `region`, `topology.kubernetes.io/zone` → `zone`).
+
+The CockroachDB Helm chart no longer renders `localityLabels`. This is a no-op for the
+migrated cluster.
 
 If your cluster uses custom K8s node labels for locality, update `localityMappings` to
 match. Each entry maps a K8s node label key to a CockroachDB locality tier name.

--- a/docs/migration/operator/manual_migration.md
+++ b/docs/migration/operator/manual_migration.md
@@ -72,6 +72,14 @@ The migration helper reads the public operator's `v1alpha1` CrdbCluster and Stat
 generating these manifests. Do not delete the target `CrdbCluster` or the CRDs; the converted
 `v1beta1` view is served from the same Kubernetes object during migration.
 
+If the StatefulSet passes `--locality`, the generated manifests carry the same flag in
+`spec.startFlags.upsert`, so each node keeps the locality it has today. The CockroachDB
+Operator uses a supplied locality flag as is and does not compute one from Kubernetes node
+labels. To switch to node labels after the migration, set
+`cockroachdb.crdbCluster.localityMappings` and remove `--locality` from
+`cockroachdb.crdbCluster.startFlags.upsert`. Changing locality restarts the pods, so plan it
+as a separate change once the cluster is healthy.
+
 ## Prepare for CockroachDB Operator installation
 
 The manual migration can be run while the public operator continues managing other clusters.

--- a/pkg/migrate/build-manifests.go
+++ b/pkg/migrate/build-manifests.go
@@ -313,12 +313,11 @@ func (m *Manifest) FromHelmChart() error {
 		return errors.Wrap(err, "writing helm values to disk")
 	}
 
-	if len(input.localityLabels) > 0 {
-		fmt.Println("⚠️  Locality labels detected on CockroachDB cluster.")
-		fmt.Println("CockroachDB uses locality labels to distribute pods across failure domains (e.g., zones or regions).")
-		fmt.Println("These labels must be present on the Kubernetes nodes before upgrading to new operator.")
-		fmt.Printf("Following locality label keys are supplied to cockroachdb nodes: %v\n", input.localityLabels)
-		fmt.Println("\n❗ If the required locality labels are missing from kubernetes nodes, the CockroachDB pods will not start.")
+	if len(input.localityTiers) > 0 {
+		fmt.Println("ℹ️  Locality detected on the CockroachDB cluster.")
+		fmt.Printf("Locality tiers carried over unchanged: %v\n", input.localityTiers)
+		fmt.Println("The --locality flag is preserved in spec.startFlags.upsert, so each node keeps the exact locality it has today.")
+		fmt.Println("To have the CockroachDB Operator derive locality from Kubernetes node labels instead, set localityMappings and drop the --locality flag from startFlags.upsert after the migration completes.")
 	}
 
 	return nil

--- a/pkg/migrate/build-manifests_test.go
+++ b/pkg/migrate/build-manifests_test.go
@@ -264,7 +264,12 @@ func TestExportValuesFromV1beta1(t *testing.T) {
 					},
 					LoggingConfigMapName: "logging-config",
 					LocalityLabels:       []string{"topology.kubernetes.io/region"},
-					GRPCPort:             new(int32(26258)),
+					SideCars: v1beta1.CrdbNodeSideCars{
+						InitContainers: []corev1.Container{{Name: "fluentbit-init", Image: "fluent/fluent-bit:3.1"}},
+						Containers:     []corev1.Container{{Name: "fluentbit", Image: "fluent/fluent-bit:3.1"}},
+						Volumes:        []corev1.Volume{{Name: "fluentbit-config"}},
+					},
+					GRPCPort: new(int32(26258)),
 					HTTPPort:             new(int32(8080)),
 					SQLPort:              new(int32(26257)),
 					PodTemplate: &v1beta1.PodTemplateSpec{
@@ -385,6 +390,15 @@ func TestExportValuesFromV1beta1(t *testing.T) {
 	_, templateScopeAnnotationExists := podTemplateAnnotations["template-scope"]
 	assert.False(t, templateScopeAnnotationExists)
 
+	assert.NotContains(t, crdbClusterValues, "localityLabels")
+	assert.NotContains(t, crdbClusterValues, "sideCars")
+
+	podTemplateSpec, ok := podTemplateValues["spec"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, []interface{}{"cockroachdb", "fluentbit"}, containerNames(t, podTemplateSpec["containers"]))
+	assert.Equal(t, []interface{}{"fluentbit-init"}, containerNames(t, podTemplateSpec["initContainers"]))
+	assert.Equal(t, []interface{}{"fluentbit-config"}, containerNames(t, podTemplateSpec["volumes"]))
+
 	walFailoverSpec, ok := crdbClusterValues["walFailoverSpec"].(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "/cockroach/wal-failover", walFailoverSpec["path"])
@@ -397,6 +411,19 @@ func TestExportValuesFromV1beta1(t *testing.T) {
 	uiValues, ok := ingressValues["ui"].(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, "ui.local.com", uiValues["host"])
+}
+
+func containerNames(t *testing.T, entries interface{}) []interface{} {
+	t.Helper()
+	list, ok := entries.([]interface{})
+	require.True(t, ok)
+	names := make([]interface{}, 0, len(list))
+	for _, entry := range list {
+		item, ok := entry.(map[string]interface{})
+		require.True(t, ok)
+		names = append(names, item["name"])
+	}
+	return names
 }
 
 // validateGoldenFile compares the generated file with the golden file

--- a/pkg/migrate/helpers.go
+++ b/pkg/migrate/helpers.go
@@ -71,7 +71,7 @@ type parsedMigrationInput struct {
 	grpcPort          int32
 	httpPort          int32
 	tlsEnabled        bool
-	localityLabels    []string
+	localityTiers     []string
 	loggingConfigMap  string
 	startFlags        *v1beta1.Flags
 	certManagerInput  *certManagerInput
@@ -137,21 +137,38 @@ func yamlToDisk(path string, data []any) (retErr error) {
 	return nil
 }
 
+// appendOperatorRequiredEnv adds the env vars the CockroachDB Operator expects on a
+// CrdbNode. Anything the source cluster already set wins, so a custom GODEBUG is not
+// silently overridden by the default.
 func appendOperatorRequiredEnv(env []corev1.EnvVar) []corev1.EnvVar {
-	result := make([]corev1.EnvVar, 0, len(env)+2)
-	result = append(result, env...)
-	result = append(result, corev1.EnvVar{
-		Name: "HOST_IP",
-		ValueFrom: &corev1.EnvVarSource{
-			FieldRef: &corev1.ObjectFieldSelector{
-				APIVersion: "v1",
-				FieldPath:  "status.hostIP",
+	required := []corev1.EnvVar{
+		{
+			Name: "HOST_IP",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "status.hostIP",
+				},
 			},
 		},
-	}, corev1.EnvVar{
-		Name:  "GODEBUG",
-		Value: "disablethp=1",
-	})
+		{
+			Name:  "GODEBUG",
+			Value: "disablethp=1",
+		},
+	}
+
+	existing := make(map[string]struct{}, len(env))
+	for _, e := range env {
+		existing[e.Name] = struct{}{}
+	}
+
+	result := make([]corev1.EnvVar, 0, len(env)+len(required))
+	result = append(result, env...)
+	for _, e := range required {
+		if _, ok := existing[e.Name]; !ok {
+			result = append(result, e)
+		}
+	}
 	return result
 }
 
@@ -415,6 +432,16 @@ func buildHelmValuesFromV1beta1(
 		podTemplateSpec = cluster.Spec.Template.Spec.PodTemplate.Spec
 	}
 
+	// sideCars is no longer rendered by the chart, so fold it into the pod
+	// template. Without this the exported values would silently drop the
+	// containers and volumes the migrated cluster is running with.
+	if sideCars := cluster.Spec.Template.Spec.SideCars; len(sideCars.InitContainers) > 0 ||
+		len(sideCars.Containers) > 0 || len(sideCars.Volumes) > 0 {
+		podTemplateSpec.InitContainers = slices.Concat(podTemplateSpec.InitContainers, sideCars.InitContainers)
+		podTemplateSpec.Containers = slices.Concat(podTemplateSpec.Containers, sideCars.Containers)
+		podTemplateSpec.Volumes = slices.Concat(podTemplateSpec.Volumes, sideCars.Volumes)
+	}
+
 	podTemplateValue := map[string]interface{}{}
 	if len(podTemplateLabels) > 0 || len(podTemplateAnnotations) > 0 {
 		metadata := map[string]interface{}{}
@@ -468,9 +495,6 @@ func buildHelmValuesFromV1beta1(
 	if cluster.Spec.Template.Spec.WALFailoverSpec != nil {
 		crdbCluster["walFailoverSpec"] = cluster.Spec.Template.Spec.WALFailoverSpec
 	}
-	if len(cluster.Spec.Template.Spec.LocalityLabels) > 0 {
-		crdbCluster["localityLabels"] = cluster.Spec.Template.Spec.LocalityLabels
-	}
 	if len(cluster.Spec.Template.Spec.LocalityMappings) > 0 {
 		crdbCluster["localityMappings"] = cluster.Spec.Template.Spec.LocalityMappings
 	}
@@ -484,9 +508,6 @@ func buildHelmValuesFromV1beta1(
 		crdbCluster["log"] = map[string]interface{}{
 			"logsStore": cluster.Spec.Template.Spec.LogsStore,
 		}
-	}
-	if len(cluster.Spec.Template.Spec.SideCars.InitContainers) > 0 || len(cluster.Spec.Template.Spec.SideCars.Containers) > 0 || len(cluster.Spec.Template.Spec.SideCars.Volumes) > 0 {
-		crdbCluster["sideCars"] = cluster.Spec.Template.Spec.SideCars
 	}
 	if cluster.Spec.Template.Spec.StartFlags != nil {
 		crdbCluster["startFlags"] = cluster.Spec.Template.Spec.StartFlags
@@ -768,7 +789,6 @@ func buildNodeSpecFromHelm(
 			},
 		},
 		Domain:               "",
-		LocalityLabels:       input.localityLabels,
 		LoggingConfigMapName: input.loggingConfigMap,
 		Image:                sts.Spec.Template.Spec.Containers[0].Image,
 		GRPCPort:             &input.grpcPort,
@@ -869,8 +889,7 @@ func buildHelmValuesFromHelm(
 		"image": map[string]interface{}{
 			"name": sts.Spec.Template.Spec.Containers[0].Image,
 		},
-		"localityLabels": input.localityLabels,
-		"startFlags":     input.startFlags,
+		"startFlags": input.startFlags,
 		"regions": []map[string]interface{}{
 			{
 				"namespace":     namespace,
@@ -1144,11 +1163,13 @@ func extractJoinStringAndFlags(parsedInput *parsedMigrationInput, args []string)
 		case strings.HasPrefix(arg, insecureFlag):
 			parsedInput.tlsEnabled = false
 
-		case strings.HasPrefix(arg, localityFlag):
-			value := strings.TrimPrefix(arg, localityFlag+"=")
-			labels := strings.Split(value, ",")
-			for i := range labels {
-				parsedInput.localityLabels = append(parsedInput.localityLabels, strings.Split(labels[i], "=")[0])
+		// Carry --locality over untouched. The CockroachDB Operator prefers a locality flag
+		// in startFlags over localityMappings, so upserting it pins the migrated nodes to
+		// the locality they have today.
+		case strings.HasPrefix(arg, localityFlag+"="):
+			flags.Upsert = append(flags.Upsert, arg)
+			for _, tier := range strings.Split(strings.TrimPrefix(arg, localityFlag+"="), ",") {
+				parsedInput.localityTiers = append(parsedInput.localityTiers, strings.Split(tier, "=")[0])
 			}
 
 		// CockroachDB Operator automatically adds "--logs" flag if it is not present.

--- a/pkg/migrate/helpers_test.go
+++ b/pkg/migrate/helpers_test.go
@@ -210,7 +210,7 @@ func TestGenerateParsedMigrationInput(t *testing.T) {
 		assert.Equal(t, "myregistrykey", input.imagePullSecrets[0].Name)
 	}
 
-	assert.Equal(t, []string{"country", "region"}, input.localityLabels)
+	assert.Equal(t, []string{"country", "region"}, input.localityTiers)
 	assert.Equal(t, "crdb-critical", input.priorityClassName)
 	expectedJoinString := "${STATEFULSET_NAME}-0.${STATEFULSET_FQDN}:26257,${STATEFULSET_NAME}-1.${STATEFULSET_FQDN}:26257,${STATEFULSET_NAME}-2.${STATEFULSET_FQDN}:26257"
 	expectedFlags := []string{
@@ -219,6 +219,7 @@ func TestGenerateParsedMigrationInput(t *testing.T) {
 		"--certs-dir=/cockroach/cockroach-certs/",
 		"--cache=25%",
 		"--max-sql-memory=25%",
+		"--locality=country=us,region=us-central1",
 		"--wal-failover=path=/cockroach/wal-failover",
 	}
 	assert.Equal(t, expectedFlags, input.startFlags.Upsert)
@@ -500,7 +501,7 @@ func TestBuildHelmValuesFromHelm_WALFailover(t *testing.T) {
 				sqlPort:        26257,
 				grpcPort:       26258,
 				httpPort:       8080,
-				localityLabels: []string{"region", "zone"},
+				localityTiers:   []string{"region", "zone"},
 				startFlags: &v1beta1.Flags{
 					Upsert: []string{
 						"--join=cockroachdb-0.cockroachdb:26257",
@@ -1319,7 +1320,7 @@ func TestBuildNodeSpecFromHelm_WithWalFailover(t *testing.T) {
 				sqlPort:          26257,
 				grpcPort:         26258,
 				httpPort:         8080,
-				localityLabels:   []string{"region", "zone"},
+				localityTiers:    []string{"region", "zone"},
 				walFailoverSpec:  tc.walFailoverSpec,
 				caConfigMap:      "ca-config",
 				nodeSecretName:   "node-secret",

--- a/pkg/migrate/testdata/helm/allInput/crdbnode-0.yaml.golden
+++ b/pkg/migrate/testdata/helm/allInput/crdbnode-0.yaml.golden
@@ -33,9 +33,6 @@ spec:
   grpcPort: 26258
   httpPort: 8080
   image: cockroachdb/cockroach:v25.1.5
-  localityLabels:
-  - country
-  - region
   loggingConfigMapName: cockroachdb-log-config
   nodeName: node0
   persistentVolumeClaimRetentionPolicy:
@@ -75,8 +72,6 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        - name: GODEBUG
-          value: disablethp=1
         image: cockroachdb/cockroach:v25.1.5
         name: cockroachdb
         resources:
@@ -135,6 +130,7 @@ spec:
     - --certs-dir=/cockroach/cockroach-certs/
     - --cache=25%
     - --max-sql-memory=25%
+    - --locality=country=us,region=us-central1
   tlsEnabled: true
   virtualCluster:
     mode: primary

--- a/pkg/migrate/testdata/helm/allInput/crdbnode-1.yaml.golden
+++ b/pkg/migrate/testdata/helm/allInput/crdbnode-1.yaml.golden
@@ -33,9 +33,6 @@ spec:
   grpcPort: 26258
   httpPort: 8080
   image: cockroachdb/cockroach:v25.1.5
-  localityLabels:
-  - country
-  - region
   loggingConfigMapName: cockroachdb-log-config
   nodeName: node1
   persistentVolumeClaimRetentionPolicy:
@@ -75,8 +72,6 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        - name: GODEBUG
-          value: disablethp=1
         image: cockroachdb/cockroach:v25.1.5
         name: cockroachdb
         resources:
@@ -135,6 +130,7 @@ spec:
     - --certs-dir=/cockroach/cockroach-certs/
     - --cache=25%
     - --max-sql-memory=25%
+    - --locality=country=us,region=us-central1
   tlsEnabled: true
   virtualCluster:
     mode: primary

--- a/pkg/migrate/testdata/helm/allInput/crdbnode-2.yaml.golden
+++ b/pkg/migrate/testdata/helm/allInput/crdbnode-2.yaml.golden
@@ -33,9 +33,6 @@ spec:
   grpcPort: 26258
   httpPort: 8080
   image: cockroachdb/cockroach:v25.1.5
-  localityLabels:
-  - country
-  - region
   loggingConfigMapName: cockroachdb-log-config
   nodeName: node2
   persistentVolumeClaimRetentionPolicy:
@@ -75,8 +72,6 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        - name: GODEBUG
-          value: disablethp=1
         image: cockroachdb/cockroach:v25.1.5
         name: cockroachdb
         resources:
@@ -135,6 +130,7 @@ spec:
     - --certs-dir=/cockroach/cockroach-certs/
     - --cache=25%
     - --max-sql-memory=25%
+    - --locality=country=us,region=us-central1
   tlsEnabled: true
   virtualCluster:
     mode: primary

--- a/pkg/migrate/testdata/helm/allInput/values.yaml.golden
+++ b/pkg/migrate/testdata/helm/allInput/values.yaml.golden
@@ -13,9 +13,6 @@ cockroachdb:
           volumeMode: Filesystem
     image:
       name: cockroachdb/cockroach:v25.1.5
-    localityLabels:
-    - country
-    - region
     loggingConfigMapName: cockroachdb-log-config
     mode: MutableOnly
     podTemplate:
@@ -53,8 +50,6 @@ cockroachdb:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.hostIP
-          - name: GODEBUG
-            value: disablethp=1
           image: cockroachdb/cockroach:v25.1.5
           name: cockroachdb
           resources:
@@ -123,6 +118,7 @@ cockroachdb:
       - --certs-dir=/cockroach/cockroach-certs/
       - --cache=25%
       - --max-sql-memory=25%
+      - --locality=country=us,region=us-central1
     virtualCluster:
       mode: primary
   tls:

--- a/tests/e2e/migrate/controller_migration_test.go
+++ b/tests/e2e/migrate/controller_migration_test.go
@@ -1425,8 +1425,8 @@ func requireHelmSourceFieldsPreserved(
 		"{.spec.template.spec.logsStore.volumeClaimTemplate.spec.resources.requests.storage}", "1Gi")
 	requireJSONPathEquals(t, kubectlOptions, v1beta1CrdbClusterResource, clusterName,
 		"{.spec.template.spec.loggingConfigMapName}", fmt.Sprintf("%s-log-config", clusterName))
-	requireJSONPathContains(t, kubectlOptions, v1beta1CrdbClusterResource, clusterName,
-		"{.spec.template.spec.localityLabels}", "topology.kubernetes.io/region")
+	requireJSONPathContains(t, kubectlOptions, "crdbnode", fmt.Sprintf("%s-0", clusterName),
+		"{.spec.localityMappings}", "topology.kubernetes.io/region")
 	requireJSONPathEquals(t, kubectlOptions, "crdbnode", fmt.Sprintf("%s-0", clusterName),
 		"{.spec.logsStore.mountPath}", "/cockroach/test-logs/")
 	requireJSONPathEquals(t, kubectlOptions, "crdbnode", fmt.Sprintf("%s-0", clusterName),

--- a/tests/e2e/operator/compatibility/chart_compatibility_e2e_test.go
+++ b/tests/e2e/operator/compatibility/chart_compatibility_e2e_test.go
@@ -30,6 +30,11 @@ const (
 
 	defaultCompatHelmRepoName = "cockroachdb-v2-compat"
 	defaultCompatHelmRepoURL  = "https://charts.cockroachdb.com/v2"
+
+	compatSidecarContainers = `[{"name":"compat-sidecar","image":"registry.k8s.io/pause:3.9","resources":{}}]`
+	compatLocalityLabels    = `["topology.kubernetes.io/region","topology.kubernetes.io/zone"]`
+	compatLocalityMappings  = `[{"nodeLabel":"topology.kubernetes.io/region","localityLabel":"region"},` +
+		`{"nodeLabel":"topology.kubernetes.io/zone","localityLabel":"zone"}]`
 )
 
 type compatibilityRegion struct {
@@ -96,17 +101,45 @@ func TestChartCompatibilityUpgrade(t *testing.T) {
 	)
 	r.ValidateCRDB(t, cluster)
 
+	t.Log("Setting values on the published chart that the local chart removed")
+	require.NoError(t, upgradeCockroachDBChartE(t, kubectlOptions,
+		fmt.Sprintf("%s/cockroachdb-chart", repoName), cockroachDBVersion, nil,
+		map[string]string{
+			"cockroachdb.crdbCluster.sideCars.containers": compatSidecarContainers,
+			"cockroachdb.crdbCluster.localityLabels":      compatLocalityLabels,
+		},
+	))
+	testutil.RequireCRDBClusterToBeReadyEventuallyTimeout(t, kubectlOptions, testutil.CockroachCluster{
+		DesiredNodes: r.NodeCount,
+	}, 600*time.Second)
+	r.ValidateCRDB(t, cluster)
+
 	helmChartPath, operatorChartPath := operator.HelmChartPaths()
 
 	t.Log("Upgrading operator chart from the local checkout")
 	operator.UpgradeCockroachDBOperatorChart(t, kubectlOptions, operatorChartPath, compatibilityOperatorUpgradeValues(t, operatorChartPath))
 	requireOperatorMigrationFlag(t, kubectlOptions, false)
 
+	t.Log("Upgrading the CockroachDB chart with removed values still set should fail")
+	err = upgradeCockroachDBChartE(t, kubectlOptions, helmChartPath, "", nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "were removed from the CockroachDB Helm chart")
+	require.Contains(t, err.Error(), "cockroachdb.crdbCluster.localityLabels")
+	require.Contains(t, err.Error(), "cockroachdb.crdbCluster.sideCars")
+
 	t.Log("Upgrading CockroachDB chart from the local checkout")
 	postInitSQLDatabase := "compat_post_init"
-	upgradeCockroachDBChart(t, kubectlOptions, helmChartPath, map[string]string{
-		"cockroachdb.crdbCluster.postInitSQL.inline[0]": fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", postInitSQLDatabase),
-	})
+	require.NoError(t, upgradeCockroachDBChartE(t, kubectlOptions, helmChartPath, "",
+		map[string]string{
+			"cockroachdb.crdbCluster.postInitSQL.inline[0]": fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", postInitSQLDatabase),
+		},
+		map[string]string{
+			"cockroachdb.crdbCluster.sideCars":                    "null",
+			"cockroachdb.crdbCluster.localityLabels":              "null",
+			"cockroachdb.crdbCluster.podTemplate.spec.containers": compatSidecarContainers,
+			"cockroachdb.crdbCluster.localityMappings":            compatLocalityMappings,
+		},
+	))
 
 	testutil.RequireCRDBClusterToBeReadyEventuallyTimeout(t, kubectlOptions, testutil.CockroachCluster{
 		DesiredNodes: r.NodeCount,
@@ -264,16 +297,31 @@ func installCockroachDBChart(
 func upgradeCockroachDBChart(
 	t *testing.T, kubectlOptions *k8s.KubectlOptions, chart string, overrides ...map[string]string,
 ) {
-	values := cockroachDBCompatibilityValues()
+	values := map[string]string{}
 	for _, override := range overrides {
 		for key, value := range override {
 			values[key] = value
 		}
 	}
+	require.NoError(t, upgradeCockroachDBChartE(t, kubectlOptions, chart, "", values, nil))
+}
+
+// upgradeCockroachDBChartE returns the helm error instead of failing the test, so callers can
+// assert on upgrades that are meant to be rejected.
+func upgradeCockroachDBChartE(
+	t *testing.T, kubectlOptions *k8s.KubectlOptions, chart, version string,
+	overrides, jsonOverrides map[string]string,
+) error {
+	values := cockroachDBCompatibilityValues()
+	for key, value := range overrides {
+		values[key] = value
+	}
 
 	options := &helm.Options{
 		KubectlOptions: kubectlOptions,
+		Version:        version,
 		SetValues:      values,
+		SetJsonValues:  jsonOverrides,
 		ExtraArgs: map[string][]string{
 			"upgrade": {
 				"--reuse-values",
@@ -283,8 +331,11 @@ func upgradeCockroachDBChart(
 		},
 	}
 
-	helm.Upgrade(t, options, chart, operator.ReleaseName)
+	if err := helm.UpgradeE(t, options, chart, operator.ReleaseName); err != nil {
+		return err
+	}
 	k8s.WaitUntilServiceAvailable(t, kubectlOptions, "cockroachdb-public", 30, 5*time.Second)
+	return nil
 }
 
 func requireOperatorMigrationFlag(t *testing.T, kubectlOptions *k8s.KubectlOptions, expected bool) {

--- a/tests/e2e/operator/region.go
+++ b/tests/e2e/operator/region.go
@@ -758,7 +758,7 @@ func PatchHelmValues(inputValues map[string]string) map[string]string {
 		"cockroachdb.tls.selfSigner.image.registry":   testutil.TestSelfSignerImageRegistry,
 		"cockroachdb.tls.selfSigner.image.repository": testutil.TestSelfSignerImageRepository,
 		// Override the terminationGracePeriodSeconds from 300s to 30 as it makes pod delete take longer.
-		"cockroachdb.crdbCluster.terminationGracePeriod": "30s",
+		"cockroachdb.crdbCluster.podTemplate.spec.terminationGracePeriodSeconds": "30",
 		// Override the rolling restart delay 30s as few times cockroachdb takes few seconds to come up.
 		"cockroachdb.crdbCluster.rollingRestartDelay": "30s",
 	}

--- a/tests/template/cockroachdb_helm_template_test.go
+++ b/tests/template/cockroachdb_helm_template_test.go
@@ -2210,10 +2210,19 @@ func (v *podTemplateValidators) validateInitContainer(expectedName string) {
 	require.Equal(v.subT, expectedName, initContainer.Name)
 }
 
-func (v *podTemplateValidators) validateContainer(expectedName string) {
+func (v *podTemplateValidators) validateContainer(expected PodTemplateExpected) {
 	require.NotEmpty(v.subT, v.spec.Spec.Containers, "Expected at least one container")
 	container := v.spec.Spec.Containers[0]
-	require.Equal(v.subT, expectedName, container.Name)
+	require.Equal(v.subT, expected.containerName, container.Name)
+
+	for name, quantity := range expected.containerRequests {
+		actual := container.Resources.Requests[name]
+		require.Equal(v.subT, quantity, actual.String())
+	}
+	for name, quantity := range expected.containerLimits {
+		actual := container.Resources.Limits[name]
+		require.Equal(v.subT, quantity, actual.String())
+	}
 }
 
 func (v *podTemplateValidators) validateVolume(expectedName string) {
@@ -2242,6 +2251,8 @@ type PodTemplateExpected struct {
 	annotations         map[string]string
 	initContainerName   string
 	containerName       string
+	containerRequests   map[corev1.ResourceName]string
+	containerLimits     map[corev1.ResourceName]string
 	volumeName          string
 	imagePullSecretName string
 }
@@ -2269,7 +2280,7 @@ func validatePodTemplateConfiguration(
 				validator.validateInitContainer(expected.initContainerName)
 			}
 			if expected.hasContainer {
-				validator.validateContainer(expected.containerName)
+				validator.validateContainer(expected)
 			}
 			if expected.hasVolume {
 				validator.validateVolume(expected.volumeName)
@@ -2338,6 +2349,24 @@ func TestHelmOperatorPodTemplate(t *testing.T) {
 				hasSpec:       true,
 				hasContainer:  true,
 				containerName: "logging-sidecar",
+			},
+		},
+		{
+			"Pod template with cockroachdb container resources",
+			map[string]string{
+				"operator.enabled": "true",
+				"cockroachdb.crdbCluster.podTemplate.spec.containers[0].name":                      "cockroachdb",
+				"cockroachdb.crdbCluster.podTemplate.spec.containers[0].resources.requests.cpu":    "2",
+				"cockroachdb.crdbCluster.podTemplate.spec.containers[0].resources.requests.memory": "8Gi",
+				"cockroachdb.crdbCluster.podTemplate.spec.containers[0].resources.limits.cpu":      "4",
+				"cockroachdb.crdbCluster.podTemplate.spec.containers[0].resources.limits.memory":   "16Gi",
+			},
+			PodTemplateExpected{
+				hasSpec:           true,
+				hasContainer:      true,
+				containerName:     "cockroachdb",
+				containerRequests: map[corev1.ResourceName]string{corev1.ResourceCPU: "2", corev1.ResourceMemory: "8Gi"},
+				containerLimits:   map[corev1.ResourceName]string{corev1.ResourceCPU: "4", corev1.ResourceMemory: "16Gi"},
 			},
 		},
 		{
@@ -3279,6 +3308,264 @@ func TestHelmSelfSignerAdditionalSANs(t *testing.T) {
 			} else {
 				require.Nil(t, additionalSANsEnvCron, "ADDITIONAL_SANS env var should not be present when not configured")
 			}
+		})
+	}
+}
+
+// TestHelmOperatorRemovedFieldsValidation verifies that values which used to map to
+// CrdbNodeSpec fields deprecated by the CockroachDB Operator now fail the render with
+// a message naming the replacement, rather than being dropped silently.
+func TestHelmOperatorRemovedFieldsValidation(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		values map[string]string
+		expect string
+	}{
+		{
+			"localityLabels",
+			map[string]string{"cockroachdb.crdbCluster.localityLabels[0]": "topology.kubernetes.io/region"},
+			"cockroachdb.crdbCluster.localityLabels, use cockroachdb.crdbCluster.localityMappings",
+		},
+		{
+			"sideCars containers",
+			map[string]string{"cockroachdb.crdbCluster.sideCars.containers[0].name": "fluentbit"},
+			"cockroachdb.crdbCluster.sideCars, use cockroachdb.crdbCluster.podTemplate.spec.initContainers, .containers and .volumes",
+		},
+		{
+			"sideCars volumes",
+			map[string]string{"cockroachdb.crdbCluster.sideCars.volumes[0].name": "fluentbit-config"},
+			"cockroachdb.crdbCluster.sideCars, use cockroachdb.crdbCluster.podTemplate.spec.initContainers, .containers and .volumes",
+		},
+		{
+			"podLabels",
+			map[string]string{"cockroachdb.crdbCluster.podLabels.team": "platform"},
+			"cockroachdb.crdbCluster.podLabels, use cockroachdb.crdbCluster.podTemplate.metadata.labels",
+		},
+		{
+			"terminationGracePeriod",
+			map[string]string{"cockroachdb.crdbCluster.terminationGracePeriod": "30s"},
+			"cockroachdb.crdbCluster.terminationGracePeriod, use cockroachdb.crdbCluster.podTemplate.spec.terminationGracePeriodSeconds",
+		},
+		{
+			"flags",
+			map[string]string{"cockroachdb.crdbCluster.flags.--max-offset": "500ms"},
+			"cockroachdb.crdbCluster.flags, use cockroachdb.crdbCluster.startFlags",
+		},
+	}
+
+	chartPath := filepath.Join("../../cockroachdb-parent/charts/cockroachdb")
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(subT *testing.T) {
+			subT.Parallel()
+
+			options := &helm.Options{
+				KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+				SetValues:      testCase.values,
+			}
+			_, err := helm.RenderTemplateE(subT, options, chartPath, releaseName, []string{"templates/crdb.yaml"})
+
+			require.Error(subT, err)
+			require.Contains(subT, err.Error(), testCase.expect)
+		})
+	}
+}
+
+// TestHelmOperatorEmptyRemovedFieldsRender verifies that leaving the removed keys empty,
+// as they appear in older copies of values.yaml, still renders.
+func TestHelmOperatorEmptyRemovedFieldsRender(t *testing.T) {
+	t.Parallel()
+
+	options := &helm.Options{
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+		SetJsonValues: map[string]string{
+			"cockroachdb.crdbCluster.localityLabels": "[]",
+			"cockroachdb.crdbCluster.sideCars":       `{"initContainers":[],"containers":[],"volumes":[]}`,
+		},
+	}
+
+	chartPath := filepath.Join("../../cockroachdb-parent/charts/cockroachdb")
+	output, err := helm.RenderTemplateE(t, options, chartPath, releaseName, []string{"templates/crdb.yaml"})
+	require.NoError(t, err)
+
+	require.NotContains(t, output, "localityLabels")
+	require.NotContains(t, output, "sideCars")
+}
+
+// TestHelmOperatorGodebug verifies the godebug values reach the cockroachdb container as a
+// GODEBUG env var, and that the chart-owned serviceAccountName survives the same merge.
+func TestHelmOperatorGodebug(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		values           map[string]string
+		jsonValues       map[string]string
+		expectEnv        []string
+		expectContainers []string
+	}{
+		{
+			name:             "default disables THP",
+			expectEnv:        []string{"GODEBUG=disablethp=1"},
+			expectContainers: []string{"cockroachdb"},
+		},
+		{
+			name:             "multiple clauses are joined and sorted",
+			values:           map[string]string{"cockroachdb.crdbCluster.godebug.madvdontneed": "1"},
+			expectEnv:        []string{"GODEBUG=disablethp=1,madvdontneed=1"},
+			expectContainers: []string{"cockroachdb"},
+		},
+		{
+			name:             "godebug is appended after the container's own env",
+			jsonValues:       map[string]string{"cockroachdb.crdbCluster.podTemplate.spec.containers": `[{"name":"cockroachdb","env":[{"name":"COCKROACH_CHANNEL","value":"kubernetes-helm"}]}]`},
+			expectEnv:        []string{"COCKROACH_CHANNEL=kubernetes-helm", "GODEBUG=disablethp=1"},
+			expectContainers: []string{"cockroachdb"},
+		},
+		{
+			name:             "user supplied GODEBUG wins and its siblings are kept",
+			jsonValues:       map[string]string{"cockroachdb.crdbCluster.podTemplate.spec.containers": `[{"name":"cockroachdb","env":[{"name":"COCKROACH_CHANNEL","value":"kubernetes-helm"},{"name":"GODEBUG","value":"disablethp=0"}]}]`},
+			expectEnv:        []string{"COCKROACH_CHANNEL=kubernetes-helm", "GODEBUG=disablethp=0"},
+			expectContainers: []string{"cockroachdb"},
+		},
+		{
+			name:             "container is added when podTemplate omits cockroachdb",
+			jsonValues:       map[string]string{"cockroachdb.crdbCluster.podTemplate.spec.containers": `[{"name":"fluentbit","image":"fluent/fluent-bit:3.1"}]`},
+			expectEnv:        []string{"GODEBUG=disablethp=1"},
+			expectContainers: []string{"fluentbit", "cockroachdb"},
+		},
+	}
+
+	chartPath := filepath.Join("../../cockroachdb-parent/charts/cockroachdb")
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(subT *testing.T) {
+			subT.Parallel()
+
+			options := &helm.Options{
+				KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+				SetValues:      testCase.values,
+				SetJsonValues:  testCase.jsonValues,
+			}
+			output := helm.RenderTemplate(subT, options, chartPath, releaseName, []string{"templates/crdb.yaml"})
+
+			var cluster struct {
+				Spec struct {
+					Template struct {
+						Spec struct {
+							PodTemplate struct {
+								Spec corev1.PodSpec `yaml:"spec"`
+							} `yaml:"podTemplate"`
+						} `yaml:"spec"`
+					} `yaml:"template"`
+				} `yaml:"spec"`
+			}
+			helm.UnmarshalK8SYaml(subT, output, &cluster)
+
+			podSpec := cluster.Spec.Template.Spec.PodTemplate.Spec
+			require.Equal(subT, releaseName+"-cockroachdb", podSpec.ServiceAccountName)
+
+			var containers []string
+			var crdbContainer *corev1.Container
+			for i := range podSpec.Containers {
+				containers = append(containers, podSpec.Containers[i].Name)
+				if podSpec.Containers[i].Name == "cockroachdb" {
+					crdbContainer = &podSpec.Containers[i]
+				}
+			}
+			require.Equal(subT, testCase.expectContainers, containers)
+			require.NotNil(subT, crdbContainer)
+
+			var env []string
+			for _, variable := range crdbContainer.Env {
+				env = append(env, fmt.Sprintf("%s=%s", variable.Name, variable.Value))
+			}
+			require.Equal(subT, testCase.expectEnv, env)
+		})
+	}
+}
+
+// TestHelmOperatorGodebugDisabled verifies clearing godebug drops the env var entirely.
+func TestHelmOperatorGodebugDisabled(t *testing.T) {
+	t.Parallel()
+
+	options := &helm.Options{
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+		SetJsonValues:  map[string]string{"cockroachdb.crdbCluster.godebug": "null"},
+	}
+
+	chartPath := filepath.Join("../../cockroachdb-parent/charts/cockroachdb")
+	output := helm.RenderTemplate(t, options, chartPath, releaseName, []string{"templates/crdb.yaml"})
+
+	require.NotContains(t, output, "GODEBUG")
+	require.Contains(t, output, "serviceAccountName: "+releaseName+"-cockroachdb")
+}
+
+// TestHelmOperatorServiceAccount verifies the pod runs as the ServiceAccount the chart owns,
+// whether the chart creates it or the operator brings their own.
+func TestHelmOperatorServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		values    map[string]string
+		expectSA  string
+		expectSet bool
+	}{
+		{
+			name:      "chart creates a ServiceAccount named after the release",
+			expectSA:  releaseName + "-cockroachdb",
+			expectSet: true,
+		},
+		{
+			name:      "chart creates a ServiceAccount with a custom name",
+			values:    map[string]string{"cockroachdb.crdbCluster.rbac.serviceAccount.name": "custom-sa"},
+			expectSA:  "custom-sa",
+			expectSet: true,
+		},
+		{
+			name: "an existing ServiceAccount is used without creating one",
+			values: map[string]string{
+				"cockroachdb.crdbCluster.rbac.serviceAccount.create": "false",
+				"cockroachdb.crdbCluster.rbac.serviceAccount.name":   "existing-sa",
+			},
+			expectSA: "existing-sa",
+		},
+		{
+			name:     "falls back to the default ServiceAccount when none is named",
+			values:   map[string]string{"cockroachdb.crdbCluster.rbac.serviceAccount.create": "false"},
+			expectSA: "default",
+		},
+	}
+
+	chartPath := filepath.Join("../../cockroachdb-parent/charts/cockroachdb")
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(subT *testing.T) {
+			subT.Parallel()
+
+			options := &helm.Options{
+				KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+				SetValues:      testCase.values,
+			}
+
+			output := helm.RenderTemplate(subT, options, chartPath, releaseName, []string{"templates/crdb.yaml"})
+			require.Contains(subT, output, "serviceAccountName: "+testCase.expectSA)
+
+			saOutput, err := helm.RenderTemplateE(subT, options, chartPath, releaseName, []string{"templates/serviceaccount.yaml"})
+			if !testCase.expectSet {
+				require.Error(subT, err, "no ServiceAccount should be rendered")
+				return
+			}
+			require.NoError(subT, err)
+
+			var serviceAccount corev1.ServiceAccount
+			helm.UnmarshalK8SYaml(subT, saOutput, &serviceAccount)
+			require.Equal(subT, testCase.expectSA, serviceAccount.Name)
 		})
 	}
 }


### PR DESCRIPTION
This change completely removes support for deprecated fields under `cockroachdb.crdbCluster` and rejects upgrades when they are still configured.

Users must migrate to the supported CrdbCluster template fields, including startFlags and podTemplate.

Changes also include updates to manual Helm and public-operator migrations to lift and shift --locality into startFlags, instead of deriving deprecated localityLabels.Existing GODEBUG values are preserved, while the chart applies its default when none is configured.